### PR TITLE
Add list_projects MCP tool and consolidate language display names

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,7 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
 | Tool | Description |
 |------|-------------|
 | `status` | Verify MCP connection and local filesystem access |
+| `list_projects` | Discover projects in a parent directory (with optional filter) |
 | `get_structure` | Project tree view with file sizes and language detection |
 | `get_dependencies` | Dependency flow with imports, functions, and hub files |
 | `get_diff` | Changed files with line counts and impact analysis |
@@ -325,7 +326,7 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
 - [x] **Skyline Mode** (`codemap --skyline`) — ASCII cityscape visualization
 - [x] **Dependency Flow** (`codemap --deps`) — function/import analysis with 16 language support
 - [x] **Claude Code Skill** — automatic invocation based on user questions
-- [x] **MCP Server** — deep integration with 6 tools for codebase analysis
+- [x] **MCP Server** — deep integration with 7 tools for codebase analysis
 
 ## Contributing
 

--- a/render/depgraph.go
+++ b/render/depgraph.go
@@ -45,12 +45,6 @@ var stdlibNames = map[string]bool{
 	"react": true, "filepath": true, "embed": true,
 }
 
-// Language labels for display
-var langLabels = map[string]string{
-	"go": "Go", "javascript": "JS", "python": "Py", "rust": "Rs", "ruby": "Rb",
-	"swift": "Swift", "bash": "Sh", "kotlin": "Kt", "c_sharp": "C#", "php": "PHP",
-	"dart": "Dart", "r": "R",
-}
 
 // normalizeImport normalizes an import string
 func normalizeImport(imp, lang string) string {
@@ -247,7 +241,7 @@ func Depgraph(project scanner.DepsProject) {
 
 	for _, lang := range langOrder {
 		if names, ok := extByLang[lang]; ok {
-			label := langLabels[lang]
+			label := scanner.LangDisplay[lang].Short
 			if label == "" {
 				label = strings.Title(lang)
 			}

--- a/scanner/grammar.go
+++ b/scanner/grammar.go
@@ -26,6 +26,32 @@ type GrammarLoader struct {
 	grammarDir string
 }
 
+// LangInfo holds display names for a language
+type LangInfo struct {
+	Short string // Compact label: "JS", "Py"
+	Full  string // Full name: "JavaScript", "Python"
+}
+
+// LangDisplay maps internal language names to display names
+var LangDisplay = map[string]LangInfo{
+	"go":         {"Go", "Go"},
+	"python":     {"Py", "Python"},
+	"javascript": {"JS", "JavaScript"},
+	"typescript": {"TS", "TypeScript"},
+	"rust":       {"Rs", "Rust"},
+	"ruby":       {"Rb", "Ruby"},
+	"c":          {"C", "C"},
+	"cpp":        {"C++", "C++"},
+	"java":       {"Java", "Java"},
+	"swift":      {"Swift", "Swift"},
+	"bash":       {"Sh", "Bash"},
+	"kotlin":     {"Kt", "Kotlin"},
+	"c_sharp":    {"C#", "C#"},
+	"php":        {"PHP", "PHP"},
+	"dart":       {"Dart", "Dart"},
+	"r":          {"R", "R"},
+}
+
 // Extension to language mapping
 var extToLang = map[string]string{
 	".go":    "go",


### PR DESCRIPTION
## Summary

- **New MCP tool**: `list_projects` - discovers projects in a parent directory when you don't know the exact folder name
- **DRY cleanup**: Consolidated language display names into single source of truth in `scanner/grammar.go`

## The Problem

When Claude Desktop user says "Review the BMBC iOS app under my Code directory", the MCP had no good way to discover the exact folder name (`BMBC-iOS`). The only option was `find_file` which returned 372 files.

## The Solution

New `list_projects` tool:
```
list_projects /Users/jordan/Code
→ Projects in /Users/jordan/Code:

BMBC-iOS/                      (287 files, Swift [git])
codemap/                       (50 files, Go [git])
DMVProxy/                      (45 files, TypeScript [git])
...
```

With optional filter:
```
list_projects /Users/jordan/Code BMBC
→ Projects matching 'BMBC' in /Users/jordan/Code:

BMBC-iOS/                      (287 files, Swift [git])
```

## DRY Cleanup

Language display names were duplicated in 3 places. Now consolidated:

```go
// scanner/grammar.go
type LangInfo struct {
    Short string  // "JS", "Py" - for compact depgraph output
    Full  string  // "JavaScript", "Python" - for MCP output
}

var LangDisplay = map[string]LangInfo{...}
```

- `render/depgraph.go` uses `scanner.LangDisplay[lang].Short`
- `mcp/main.go` uses `scanner.LangDisplay[lang].Full`

## Test plan

- [x] `codemap .` works
- [x] `codemap --deps` works  
- [x] `codemap --diff` works
- [x] MCP builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)