### PR TITLE
Add size limits to prevent context overflow in large repos

### DIFF
--- a/cmd/hooks.go
+++ b/cmd/hooks.go
@@ -9,9 +9,11 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
+	"codemap/limits"
 	"codemap/scanner"
 	"codemap/watch"
 )
@@ -23,10 +25,15 @@ type hubInfo struct {
 	Imports   map[string][]string
 }
 
-// getHubInfo returns hub info from daemon state (fast) or fresh scan (slow)
+// getHubInfo returns hub info from daemon state.
+// If daemon isn't running, falls back to a fresh scan.
 func getHubInfo(root string) *hubInfo {
-	// Try daemon state first (instant)
 	if state := watch.ReadState(root); state != nil {
+		// State may contain file/event info only (no dependency graph) on very
+		// large repos. Avoid expensive fallback scans in that case.
+		if len(state.Importers) == 0 && len(state.Imports) == 0 && len(state.Hubs) == 0 {
+			return nil
+		}
 		return &hubInfo{
 			Hubs:      state.Hubs,
 			Importers: state.Importers,
@@ -34,7 +41,12 @@ func getHubInfo(root string) *hubInfo {
 		}
 	}
 
-	// Fall back to fresh scan (slower)
+	// If daemon is running but state is unavailable, skip expensive fallback.
+	if watch.IsRunning(root) {
+		return nil
+	}
+
+	// Fall back to fresh scan only when daemon is not running.
 	fg, err := scanner.BuildFileGraph(root)
 	if err != nil {
 		return nil
@@ -45,6 +57,17 @@ func getHubInfo(root string) *hubInfo {
 		Importers: fg.Importers,
 		Imports:   fg.Imports,
 	}
+}
+
+func waitForDaemonState(root string, timeout time.Duration) *watch.State {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if state := watch.ReadState(root); state != nil {
+			return state
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	return nil
 }
 
 // RunHook executes the named hook with the given project root
@@ -103,23 +126,21 @@ func hookSessionStart(root string) error {
 	// 2. Hard cap: 60KB max output (~15k tokens, <10% of context window)
 	//
 	// Future: Consider structured output that Claude Code can format/truncate intelligently.
+	fileCount := 0
+	fileCountKnown := false
+	state := watch.ReadState(root)
+	if state == nil && watch.IsRunning(root) {
+		state = waitForDaemonState(root, 2*time.Second)
+	}
+	if state != nil {
+		fileCount = state.FileCount
+		fileCountKnown = true
+	}
+
 	exe, err := os.Executable()
 	if err == nil {
-		// Count files to determine appropriate depth
-		fileCount := 0
-		if state := watch.ReadState(root); state != nil {
-			fileCount = state.FileCount
-		}
-
-		// Adaptive depth: large repos get shallower trees
-		depth := "4"
-		if fileCount > 5000 {
-			depth = "2"
-		} else if fileCount > 2000 {
-			depth = "3"
-		}
-
-		cmd := exec.Command(exe, "--depth", depth, root)
+		depth := limits.AdaptiveDepth(fileCount)
+		cmd := exec.Command(exe, "--depth", strconv.Itoa(depth), root)
 
 		// Capture output to enforce size limit
 		var buf strings.Builder
@@ -128,7 +149,7 @@ func hookSessionStart(root string) error {
 		cmd.Run()
 
 		output := buf.String()
-		const maxBytes = 60000 // ~15k tokens, <10% of 200k context
+		const maxBytes = limits.MaxContextOutputBytes
 
 		if len(output) > maxBytes {
 			// Truncate and add warning
@@ -137,7 +158,11 @@ func hookSessionStart(root string) error {
 			if idx := strings.LastIndex(output, "\n"); idx > maxBytes-1000 {
 				output = output[:idx]
 			}
-			output += "\n\n... (truncated - repo has " + fmt.Sprintf("%d", fileCount) + " files, use `codemap .` for full tree)\n"
+			repoSummary := "repo size unknown"
+			if fileCountKnown {
+				repoSummary = fmt.Sprintf("repo has %d files", fileCount)
+			}
+			output += "\n\n... (truncated - " + repoSummary + ", use `codemap .` for full tree)\n"
 		}
 
 		fmt.Print(output)
@@ -156,10 +181,12 @@ func hookSessionStart(root string) error {
 			importers := len(info.Importers[hub])
 			fmt.Printf("   ⚠️  HUB FILE: %s (imported by %d files)\n", hub, importers)
 		}
+	} else if fileCountKnown && fileCount > limits.LargeRepoFileCount {
+		fmt.Printf("ℹ️  Hub analysis skipped for large repo (%d files)\n", fileCount)
 	}
 
 	// Show diff vs main if on a feature branch
-	showDiffVsMain(root)
+	showDiffVsMain(root, fileCount, fileCountKnown)
 
 	// Show last session context if resuming work
 	if len(lastSessionEvents) > 0 {
@@ -169,8 +196,9 @@ func hookSessionStart(root string) error {
 	return nil
 }
 
-// showDiffVsMain shows files changed on this branch vs main
-func showDiffVsMain(root string) {
+// showDiffVsMain shows files changed on this branch vs main.
+// For large/unknown repos, uses lightweight git output to avoid expensive scans.
+func showDiffVsMain(root string, fileCount int, fileCountKnown bool) {
 	// Check if we're on a branch other than main
 	branchCmd := exec.Command("git", "rev-parse", "--abbrev-ref", "HEAD")
 	branchCmd.Dir = root
@@ -191,10 +219,44 @@ func showDiffVsMain(root string) {
 
 	fmt.Println()
 	fmt.Printf("📝 Changes on branch '%s' vs main:\n", branch)
+
+	// Unknown file count typically means daemon state is not ready.
+	// Use cheap git-based output in that case to avoid startup blowups.
+	if !fileCountKnown || fileCount > limits.LargeRepoFileCount {
+		showLightweightDiffVsMain(root)
+		return
+	}
+
+	// Run codemap --diff to show richer impact analysis on manageable repos.
 	cmd := exec.Command(exe, "--diff", root)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.Run()
+}
+
+func showLightweightDiffVsMain(root string) {
+	cmd := exec.Command("git", "diff", "--name-only", "main...HEAD")
+	cmd.Dir = root
+	out, err := cmd.Output()
+	if err != nil {
+		fmt.Println("   (unable to read git diff)")
+		return
+	}
+
+	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
+	if len(lines) == 1 && lines[0] == "" {
+		fmt.Println("   No files changed")
+		return
+	}
+
+	const maxShown = 20
+	for i, line := range lines {
+		if i >= maxShown {
+			fmt.Printf("   ... and %d more files\n", len(lines)-maxShown)
+			break
+		}
+		fmt.Printf("   • %s\n", line)
+	}
 }
 
 // getLastSessionEvents reads events.log for previous session context

--- a/limits/limits.go
+++ b/limits/limits.go
@@ -1,0 +1,27 @@
+package limits
+
+// Context output budgets for hook and MCP text responses.
+const (
+	MaxContextOutputBytes = 60000 // ~15k tokens, <10% of a 200k context window
+)
+
+// Repo-size thresholds used to scale expensive analysis work.
+const (
+	MediumRepoFileCount = 2000
+	LargeRepoFileCount  = 5000
+)
+
+// AdaptiveDepth returns a safe tree depth based on repository size.
+// Unknown file count (<=0) defaults to a conservative depth.
+func AdaptiveDepth(fileCount int) int {
+	if fileCount <= 0 {
+		return 2
+	}
+	if fileCount > LargeRepoFileCount {
+		return 2
+	}
+	if fileCount > MediumRepoFileCount {
+		return 3
+	}
+	return 4
+}

--- a/watch/events.go
+++ b/watch/events.go
@@ -288,10 +288,6 @@ func (d *Daemon) writeState() {
 	d.graph.mu.RLock()
 	defer d.graph.mu.RUnlock()
 
-	if d.graph.FileGraph == nil {
-		return
-	}
-
 	// Get last 50 events for timeline
 	events := d.graph.Events
 	if len(events) > 50 {
@@ -301,10 +297,15 @@ func (d *Daemon) writeState() {
 	state := State{
 		UpdatedAt:    time.Now(),
 		FileCount:    len(d.graph.Files),
-		Hubs:         d.graph.FileGraph.HubFiles(),
-		Importers:    d.graph.FileGraph.Importers,
-		Imports:      d.graph.FileGraph.Imports,
+		Hubs:         []string{},
+		Importers:    map[string][]string{},
+		Imports:      map[string][]string{},
 		RecentEvents: events,
+	}
+	if d.graph.FileGraph != nil {
+		state.Hubs = d.graph.FileGraph.HubFiles()
+		state.Importers = d.graph.FileGraph.Importers
+		state.Imports = d.graph.FileGraph.Imports
 	}
 
 	data, err := json.MarshalIndent(state, "", "  ")

--- a/watch/state_test.go
+++ b/watch/state_test.go
@@ -1,0 +1,114 @@
+package watch
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"codemap/scanner"
+)
+
+func TestReadStateStaleButRunning(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "codemap-state-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	codemapDir := filepath.Join(tmpDir, ".codemap")
+	if err := os.MkdirAll(codemapDir, 0755); err != nil {
+		t.Fatalf("Failed to create .codemap dir: %v", err)
+	}
+
+	state := State{
+		UpdatedAt: time.Now().Add(-2 * time.Minute),
+		FileCount: 42,
+	}
+	data, err := json.Marshal(state)
+	if err != nil {
+		t.Fatalf("Failed to marshal state: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(codemapDir, "state.json"), data, 0644); err != nil {
+		t.Fatalf("Failed to write state file: %v", err)
+	}
+
+	// Simulate running daemon by pointing pid file to current process.
+	if err := WritePID(tmpDir); err != nil {
+		t.Fatalf("Failed to write pid file: %v", err)
+	}
+	defer RemovePID(tmpDir)
+
+	got := ReadState(tmpDir)
+	if got == nil {
+		t.Fatal("Expected stale state to be returned when daemon is running")
+	}
+	if got.FileCount != 42 {
+		t.Fatalf("Expected file_count 42, got %d", got.FileCount)
+	}
+}
+
+func TestReadStateStaleAndNotRunning(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "codemap-state-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	codemapDir := filepath.Join(tmpDir, ".codemap")
+	if err := os.MkdirAll(codemapDir, 0755); err != nil {
+		t.Fatalf("Failed to create .codemap dir: %v", err)
+	}
+
+	state := State{
+		UpdatedAt: time.Now().Add(-2 * time.Minute),
+		FileCount: 10,
+	}
+	data, err := json.Marshal(state)
+	if err != nil {
+		t.Fatalf("Failed to marshal state: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(codemapDir, "state.json"), data, 0644); err != nil {
+		t.Fatalf("Failed to write state file: %v", err)
+	}
+
+	if got := ReadState(tmpDir); got != nil {
+		t.Fatal("Expected nil for stale state when daemon is not running")
+	}
+}
+
+func TestWriteStateWithoutFileGraph(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "codemap-state-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	if err := os.MkdirAll(filepath.Join(tmpDir, ".codemap"), 0755); err != nil {
+		t.Fatalf("Failed to create .codemap dir: %v", err)
+	}
+
+	d := &Daemon{
+		root: tmpDir,
+		graph: &Graph{
+			Files: map[string]*scanner.FileInfo{
+				"main.go": {Path: "main.go", Ext: ".go"},
+			},
+			Events: []Event{},
+		},
+	}
+
+	d.writeState()
+
+	state := ReadState(tmpDir)
+	if state == nil {
+		t.Fatal("Expected state file to be written without file graph")
+	}
+	if state.FileCount != 1 {
+		t.Fatalf("Expected file_count 1, got %d", state.FileCount)
+	}
+	if len(state.Hubs) != 0 {
+		t.Fatalf("Expected 0 hubs without file graph, got %d", len(state.Hubs))
+	}
+}


### PR DESCRIPTION
## Summary

This PR keeps codemap hooks/MCP useful while making them safe on large repos.

### Existing fix (kept)
- Session-start hook uses adaptive depth based on repo size:
  - `>5000 files -> depth 2`
  - `>2000 files -> depth 3`
  - otherwise `depth 4`
- Hook + MCP `get_structure` enforce `60KB` max output (~15k tokens, <10% of context)
- Truncation is clean at line boundaries with a helpful message

### Additional hardening in this PR
- Added shared limits package (`limits/`) so hook + MCP use one source of truth for:
  - output budget (`60KB`)
  - adaptive depth thresholds
- Daemon now **skips dependency graph build** on very large repos (`>5000 files`) to avoid startup CPU/memory spikes
- Daemon now **always writes `.codemap/state.json`** (even when dep graph is unavailable), so hooks still get `file_count` + session event context
- `ReadState` now accepts stale state if daemon PID is still alive (avoids unnecessary expensive rescans after idle periods)
- Hook hub lookup no longer falls back to heavy fresh graph builds when daemon is already running but dep data is unavailable
- Session-start now:
  - waits briefly for daemon state (small warmup window)
  - uses conservative depth when file count is unknown
  - uses lightweight git diff output for large/unknown repos instead of full `codemap --diff`
- MCP `get_structure` now:
  - accepts optional `depth`
  - defaults to adaptive depth when omitted
  - reuses daemon hub data when available
  - skips expensive hub analysis on very large repos and prints a note

## Problem

Large repos (10k+ files) could produce massive startup output and expensive repeated analysis:
- Hook output goes into Claude “Messages” context (competes directly with conversation history)
- Large tree output could consume context immediately
- Repeated fallback graph scans could be expensive when daemon state was missing/stale

## Why this matters

Hooks need to be context-aware and resource-aware:
- bounded output
- graceful degradation on large repos
- avoid repeated heavy computation in background hook flows

## Test results

- `go test ./...` passes
- Stress-tested on synthetic ~10k-file repo:
  - session-start output remained small (no runaway output)
  - daemon state remained usable after idle
  - pre-edit hook significantly faster with daemon vs no daemon

## Behavioral note

On very large repos, hub/dependency analysis is intentionally deferred in hook/session-start flows unless explicitly requested via dedicated tooling (`get_hubs`, etc.).