### PR TITLE
Harden hooks/watch against context bloat and blocking scans

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,19 @@ jobs:
       - name: Run tests
         run: go test -v -race -coverprofile=coverage.out ./...
 
+      - name: Enforce coverage floor
+        if: matrix.os == 'ubuntu-latest' && matrix.go-version == '1.23'
+        run: |
+          total=$(go tool cover -func=coverage.out | awk '/^total:/ {gsub("%","",$3); print $3}')
+          min=30.0
+          awk -v t="$total" -v m="$min" 'BEGIN {
+            if (t+0 < m+0) {
+              printf "Coverage %.1f%% is below floor %.1f%%\n", t, m
+              exit 1
+            }
+            printf "Coverage %.1f%% meets floor %.1f%%\n", t, m
+          }'
+
       - name: Upload coverage
         if: matrix.os == 'ubuntu-latest' && matrix.go-version == '1.23'
         uses: codecov/codecov-action@v4

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build build-mcp run deps grammars clean
+.PHONY: all build build-mcp run deps grammars coverage clean
 
 all: build
 
@@ -24,6 +24,10 @@ grammars:
 # Dependency graph mode - shows functions and imports per file
 deps: build grammars
 	./codemap --deps "$(ABS_DIR)"
+
+coverage:
+	go test -coverprofile=coverage.out ./...
+	go tool cover -func=coverage.out | tail -n 1
 
 clean:
 	rm -f codemap codemap-mcp

--- a/cmd/hooks.go
+++ b/cmd/hooks.go
@@ -32,7 +32,10 @@ type hubInfo struct {
 const (
 	DefaultHookTimeout      = 8 * time.Second
 	daemonRestartStaleAfter = 2 * time.Hour
+	diffCaptureSlackBytes   = 4 * 1024
 )
+
+var isOwnedDaemonProcess = watch.IsOwnedDaemon
 
 type HookTimeoutError struct {
 	Hook    string
@@ -41,6 +44,47 @@ type HookTimeoutError struct {
 
 func (e *HookTimeoutError) Error() string {
 	return fmt.Sprintf("hook %q timed out after %s", e.Hook, e.Timeout)
+}
+
+// cappedStringWriter captures at most maxBytes while still reporting full
+// progress to avoid blocking subprocess writers on large output.
+type cappedStringWriter struct {
+	maxBytes  int
+	buf       strings.Builder
+	truncated bool
+}
+
+func newCappedStringWriter(maxBytes int) *cappedStringWriter {
+	return &cappedStringWriter{maxBytes: maxBytes}
+}
+
+func (w *cappedStringWriter) Write(p []byte) (int, error) {
+	if w.maxBytes <= 0 {
+		w.truncated = true
+		return len(p), nil
+	}
+
+	remaining := w.maxBytes - w.buf.Len()
+	if remaining <= 0 {
+		w.truncated = true
+		return len(p), nil
+	}
+	if len(p) <= remaining {
+		_, _ = w.buf.Write(p)
+		return len(p), nil
+	}
+
+	_, _ = w.buf.Write(p[:remaining])
+	w.truncated = true
+	return len(p), nil
+}
+
+func (w *cappedStringWriter) String() string {
+	return w.buf.String()
+}
+
+func (w *cappedStringWriter) Truncated() bool {
+	return w.truncated
 }
 
 // getHubInfo returns hub info from daemon state.
@@ -148,6 +192,9 @@ func IsHookTimeoutError(err error) bool {
 
 func shouldRestartDaemon(root string, now time.Time) bool {
 	if !watch.IsRunning(root) {
+		return false
+	}
+	if !isOwnedDaemonProcess(root) {
 		return false
 	}
 
@@ -362,13 +409,17 @@ func showDiffVsMain(root string, fileCount int, fileCountKnown bool) {
 	}
 	args = append(args, root)
 	cmd := exec.Command(exe, args...)
-	var buf strings.Builder
-	cmd.Stdout = &buf
+	captureLimit := limits.MaxDiffOutputBytes + diffCaptureSlackBytes
+	if captureLimit < limits.MaxDiffOutputBytes {
+		captureLimit = limits.MaxDiffOutputBytes
+	}
+	buf := newCappedStringWriter(captureLimit)
+	cmd.Stdout = buf
 	cmd.Stderr = os.Stderr
 	cmd.Run()
 
 	output := buf.String()
-	if len(output) > limits.MaxDiffOutputBytes {
+	if len(output) > limits.MaxDiffOutputBytes || buf.Truncated() {
 		output = limits.TruncateAtLineBoundary(
 			output,
 			limits.MaxDiffOutputBytes,
@@ -422,9 +473,12 @@ func getLastSessionEvents(root string) []string {
 	if maxTail > 0 && readBytes > maxTail {
 		readBytes = maxTail
 	}
+	if readBytes <= 0 {
+		return nil
+	}
 	start := info.Size() - readBytes
 
-	buf := make([]byte, readBytes)
+	buf := make([]byte, int(readBytes))
 	n, err := f.ReadAt(buf, start)
 	if err != nil && err != io.EOF {
 		return nil

--- a/cmd/hooks.go
+++ b/cmd/hooks.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bufio"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -28,9 +29,33 @@ type hubInfo struct {
 	Imports   map[string][]string
 }
 
+const (
+	DefaultHookTimeout      = 8 * time.Second
+	daemonRestartStaleAfter = 2 * time.Hour
+)
+
+type HookTimeoutError struct {
+	Hook    string
+	Timeout time.Duration
+}
+
+func (e *HookTimeoutError) Error() string {
+	return fmt.Sprintf("hook %q timed out after %s", e.Hook, e.Timeout)
+}
+
 // getHubInfo returns hub info from daemon state.
 // If daemon isn't running, falls back to a fresh scan.
 func getHubInfo(root string) *hubInfo {
+	return getHubInfoWithFallback(root, true)
+}
+
+// getHubInfoNoFallback returns cached hub information only.
+// It never triggers expensive graph scans.
+func getHubInfoNoFallback(root string) *hubInfo {
+	return getHubInfoWithFallback(root, false)
+}
+
+func getHubInfoWithFallback(root string, allowFallback bool) *hubInfo {
 	if state := watch.ReadState(root); state != nil {
 		// State may contain file/event info only (no dependency graph) on very
 		// large repos. Avoid expensive fallback scans in that case.
@@ -42,6 +67,10 @@ func getHubInfo(root string) *hubInfo {
 			Importers: state.Importers,
 			Imports:   state.Imports,
 		}
+	}
+
+	if !allowFallback {
+		return nil
 	}
 
 	// If daemon is running but state is unavailable, skip expensive fallback.
@@ -60,6 +89,74 @@ func getHubInfo(root string) *hubInfo {
 		Importers: fg.Importers,
 		Imports:   fg.Imports,
 	}
+}
+
+// RunHookWithTimeout executes a hook with a hard timeout.
+// On timeout, returns HookTimeoutError and callers should fail open.
+func RunHookWithTimeout(hookName, root string, timeout time.Duration) error {
+	if timeout <= 0 {
+		return RunHook(hookName, root)
+	}
+
+	return runWithTimeout(hookName, timeout, func() error {
+		return RunHook(hookName, root)
+	})
+}
+
+func runWithTimeout(hookName string, timeout time.Duration, fn func() error) error {
+	if timeout <= 0 {
+		return fn()
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- fn()
+	}()
+
+	select {
+	case err := <-done:
+		return err
+	case <-time.After(timeout):
+		return &HookTimeoutError{Hook: hookName, Timeout: timeout}
+	}
+}
+
+func HookTimeoutFromEnv(getenv func(string) string) time.Duration {
+	if getenv == nil {
+		return DefaultHookTimeout
+	}
+
+	value := strings.TrimSpace(getenv("CODEMAP_HOOK_TIMEOUT"))
+	if value == "" {
+		return DefaultHookTimeout
+	}
+
+	d, err := time.ParseDuration(value)
+	if err != nil {
+		return DefaultHookTimeout
+	}
+	if d < 0 {
+		return DefaultHookTimeout
+	}
+	return d
+}
+
+func IsHookTimeoutError(err error) bool {
+	var timeoutErr *HookTimeoutError
+	return errors.As(err, &timeoutErr)
+}
+
+func shouldRestartDaemon(root string, now time.Time) bool {
+	if !watch.IsRunning(root) {
+		return false
+	}
+
+	state := watch.ReadState(root)
+	if state == nil {
+		return true
+	}
+
+	return now.Sub(state.UpdatedAt) > daemonRestartStaleAfter
 }
 
 func waitForDaemonState(root string, timeout time.Duration) *watch.State {
@@ -111,6 +208,11 @@ func hookSessionStart(root string) error {
 
 	// Check for previous session context before starting new daemon
 	lastSessionEvents := getLastSessionEvents(root)
+
+	// Restart stale daemons so long-lived background processes do not drift.
+	if shouldRestartDaemon(root, time.Now()) {
+		stopDaemon(root)
+	}
 
 	// Start the watch daemon in background (if not already running)
 	if !watch.IsRunning(root) {
@@ -260,9 +362,20 @@ func showDiffVsMain(root string, fileCount int, fileCountKnown bool) {
 	}
 	args = append(args, root)
 	cmd := exec.Command(exe, args...)
-	cmd.Stdout = os.Stdout
+	var buf strings.Builder
+	cmd.Stdout = &buf
 	cmd.Stderr = os.Stderr
 	cmd.Run()
+
+	output := buf.String()
+	if len(output) > limits.MaxDiffOutputBytes {
+		output = limits.TruncateAtLineBoundary(
+			output,
+			limits.MaxDiffOutputBytes,
+			"\n\n... (diff output truncated, run `codemap --diff` for full output)\n",
+		)
+	}
+	fmt.Print(output)
 }
 
 func showLightweightDiffVsMain(root string) {
@@ -293,12 +406,41 @@ func showLightweightDiffVsMain(root string) {
 // getLastSessionEvents reads events.log for previous session context
 func getLastSessionEvents(root string) []string {
 	eventsFile := filepath.Join(root, ".codemap", "events.log")
-	data, err := os.ReadFile(eventsFile)
+	f, err := os.Open(eventsFile)
 	if err != nil {
 		return nil
 	}
+	defer f.Close()
 
-	lines := strings.Split(string(data), "\n")
+	info, err := f.Stat()
+	if err != nil || info.Size() == 0 {
+		return nil
+	}
+
+	readBytes := info.Size()
+	maxTail := int64(limits.MaxEventLogReadBytes)
+	if maxTail > 0 && readBytes > maxTail {
+		readBytes = maxTail
+	}
+	start := info.Size() - readBytes
+
+	buf := make([]byte, readBytes)
+	n, err := f.ReadAt(buf, start)
+	if err != nil && err != io.EOF {
+		return nil
+	}
+	if n == 0 {
+		return nil
+	}
+
+	text := string(buf[:n])
+	if start > 0 {
+		if idx := strings.IndexByte(text, '\n'); idx >= 0 && idx+1 < len(text) {
+			text = text[idx+1:]
+		}
+	}
+
+	lines := strings.Split(text, "\n")
 	if len(lines) == 0 {
 		return nil
 	}
@@ -474,7 +616,7 @@ func hookPromptSubmit(root string) error {
 		return nil
 	}
 
-	info := getHubInfo(root)
+	info := getHubInfoNoFallback(root)
 
 	// Look for file patterns in the prompt
 	var filesMentioned []string
@@ -551,7 +693,7 @@ func hookPreCompact(root string) error {
 		return err
 	}
 
-	info := getHubInfo(root)
+	info := getHubInfoNoFallback(root)
 	if info == nil || len(info.Hubs) == 0 {
 		return nil
 	}
@@ -661,7 +803,7 @@ func hookSessionStop(root string) error {
 			return nil
 		}
 
-		info := getHubInfo(root)
+		info := getHubInfoNoFallback(root)
 
 		fmt.Println()
 		fmt.Println("Files modified:")
@@ -788,7 +930,7 @@ func extractFilePathFromStdin() (string, error) {
 
 // checkFileImporters checks if a file is a hub and shows its importers
 func checkFileImporters(root, filePath string) error {
-	info := getHubInfo(root)
+	info := getHubInfoNoFallback(root)
 	if info == nil {
 		return nil // silently skip if deps unavailable
 	}

--- a/cmd/hooks_test.go
+++ b/cmd/hooks_test.go
@@ -6,11 +6,15 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"testing"
+	"time"
 
 	"codemap/handoff"
+	"codemap/limits"
+	"codemap/watch"
 )
 
 // TestHubInfoIsHub tests the hub detection threshold (3+ importers)
@@ -573,4 +577,428 @@ func captureOutput(f func()) string {
 	var buf bytes.Buffer
 	io.Copy(&buf, r)
 	return buf.String()
+}
+
+// writeWatchState writes a watch.State JSON file to <root>/.codemap/state.json
+// and a PID file pointing to the current process so IsRunning returns true.
+func writeWatchState(t *testing.T, root string, state watch.State) {
+	t.Helper()
+	codemapDir := filepath.Join(root, ".codemap")
+	if err := os.MkdirAll(codemapDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	data, err := json.Marshal(state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(codemapDir, "state.json"), data, 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := watch.WritePID(root); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { watch.RemovePID(root) })
+}
+
+// TestGetLastSessionEvents verifies that the 20-line budget is enforced when
+// reading the events log, protecting hook startup output from bloating context.
+func TestGetLastSessionEvents(t *testing.T) {
+	t.Run("missing file returns nil", func(t *testing.T) {
+		if got := getLastSessionEvents(t.TempDir()); got != nil {
+			t.Errorf("expected nil for missing file, got %v", got)
+		}
+	})
+
+	t.Run("empty file returns nil", func(t *testing.T) {
+		root := t.TempDir()
+		codemapDir := filepath.Join(root, ".codemap")
+		if err := os.MkdirAll(codemapDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(codemapDir, "events.log"), []byte(""), 0644); err != nil {
+			t.Fatal(err)
+		}
+		if got := getLastSessionEvents(root); got != nil {
+			t.Errorf("expected nil for empty file, got %v", got)
+		}
+	})
+
+	t.Run("returns all lines when fewer than 20", func(t *testing.T) {
+		root := t.TempDir()
+		codemapDir := filepath.Join(root, ".codemap")
+		os.MkdirAll(codemapDir, 0755)
+		lines := "ts|WRITE|a.go\nts|WRITE|b.go\nts|WRITE|c.go"
+		os.WriteFile(filepath.Join(codemapDir, "events.log"), []byte(lines), 0644)
+
+		got := getLastSessionEvents(root)
+		if len(got) != 3 {
+			t.Errorf("expected 3 events, got %d: %v", len(got), got)
+		}
+	})
+
+	t.Run("caps at 20 lines for large log (context bloat protection)", func(t *testing.T) {
+		root := t.TempDir()
+		codemapDir := filepath.Join(root, ".codemap")
+		os.MkdirAll(codemapDir, 0755)
+
+		var sb strings.Builder
+		for i := 1; i <= 35; i++ {
+			fmt.Fprintf(&sb, "ts|WRITE|file%02d.go\n", i)
+		}
+		os.WriteFile(filepath.Join(codemapDir, "events.log"), []byte(sb.String()), 0644)
+
+		got := getLastSessionEvents(root)
+		if len(got) != 20 {
+			t.Errorf("expected 20 events (cap), got %d", len(got))
+		}
+		// Should be the *last* 20 (file16.go through file35.go).
+		if !strings.Contains(got[0], "file16.go") {
+			t.Errorf("expected first retained event to be file16.go, got %q", got[0])
+		}
+		if !strings.Contains(got[19], "file35.go") {
+			t.Errorf("expected last retained event to be file35.go, got %q", got[19])
+		}
+	})
+
+	t.Run("skips blank lines when counting", func(t *testing.T) {
+		root := t.TempDir()
+		codemapDir := filepath.Join(root, ".codemap")
+		os.MkdirAll(codemapDir, 0755)
+		// 5 real entries surrounded by blank lines
+		content := "\nts|WRITE|a.go\n\nts|WRITE|b.go\n\n\nts|WRITE|c.go\n\nts|WRITE|d.go\nts|WRITE|e.go\n"
+		os.WriteFile(filepath.Join(codemapDir, "events.log"), []byte(content), 0644)
+
+		got := getLastSessionEvents(root)
+		if len(got) != 5 {
+			t.Errorf("expected 5 non-blank lines, got %d: %v", len(got), got)
+		}
+	})
+}
+
+// TestShowLastSessionContext verifies the 5-file truncation that prevents
+// large working-set context from bloating the session start output.
+func TestShowLastSessionContext(t *testing.T) {
+	t.Run("empty events list produces no output", func(t *testing.T) {
+		out := captureOutput(func() { showLastSessionContext("", []string{}) })
+		if out != "" {
+			t.Errorf("expected no output for empty events, got %q", out)
+		}
+	})
+
+	t.Run("malformed lines are skipped gracefully", func(t *testing.T) {
+		events := []string{"just one part", "two|parts", ""}
+		out := captureOutput(func() { showLastSessionContext("", events) })
+		if out != "" {
+			t.Errorf("expected no output for malformed events, got %q", out)
+		}
+	})
+
+	t.Run("shows header and file list for valid events", func(t *testing.T) {
+		events := []string{
+			"ts|WRITE|alpha.go",
+			"ts|WRITE|beta.go",
+			"ts|WRITE|gamma.go",
+		}
+		out := captureOutput(func() { showLastSessionContext("", events) })
+		if !strings.Contains(out, "Last session worked on") {
+			t.Errorf("expected header, got %q", out)
+		}
+		if strings.Contains(out, "more files") {
+			t.Errorf("should not show truncation indicator for <=5 files, got %q", out)
+		}
+		if !strings.Contains(out, "alpha.go") {
+			t.Errorf("expected alpha.go in output, got %q", out)
+		}
+	})
+
+	t.Run("truncates at 5 files with 'more files' indicator (context bloat protection)", func(t *testing.T) {
+		var events []string
+		for i := 1; i <= 8; i++ {
+			events = append(events, fmt.Sprintf("ts|WRITE|file%d.go", i))
+		}
+		out := captureOutput(func() { showLastSessionContext("", events) })
+		if !strings.Contains(out, "and 3 more files") {
+			t.Errorf("expected '3 more files' truncation, got %q", out)
+		}
+	})
+
+	t.Run("REMOVE for still-existing file is reported as 'edited'", func(t *testing.T) {
+		root := t.TempDir()
+		fileName := "survivor.go"
+		os.WriteFile(filepath.Join(root, fileName), []byte("package main\n"), 0644)
+
+		events := []string{fmt.Sprintf("ts|REMOVE|%s", fileName)}
+		out := captureOutput(func() { showLastSessionContext(root, events) })
+		if !strings.Contains(out, "edited") {
+			t.Errorf("expected 'edited' for extant file after REMOVE event, got %q", out)
+		}
+	})
+}
+
+// TestShowSessionProgress verifies that in-session hub-edit statistics are
+// reported accurately, exposing hub churn as a context-bloat signal.
+func TestShowSessionProgress(t *testing.T) {
+	t.Run("no daemon state produces no output", func(t *testing.T) {
+		out := captureOutput(func() { showSessionProgress(t.TempDir()) })
+		if out != "" {
+			t.Errorf("expected no output with no state, got %q", out)
+		}
+	})
+
+	t.Run("state with no events produces no output", func(t *testing.T) {
+		root := t.TempDir()
+		writeWatchState(t, root, watch.State{
+			UpdatedAt: time.Now(),
+			FileCount: 5,
+		})
+		out := captureOutput(func() { showSessionProgress(root) })
+		if out != "" {
+			t.Errorf("expected no output for state with no events, got %q", out)
+		}
+	})
+
+	t.Run("shows files-edited count", func(t *testing.T) {
+		root := t.TempDir()
+		writeWatchState(t, root, watch.State{
+			UpdatedAt: time.Now(),
+			FileCount: 10,
+			RecentEvents: []watch.Event{
+				{Path: "main.go", Op: "WRITE"},
+				{Path: "utils.go", Op: "WRITE"},
+				{Path: "main.go", Op: "WRITE"}, // duplicate — same file
+			},
+		})
+		out := captureOutput(func() { showSessionProgress(root) })
+		if !strings.Contains(out, "2 files edited") {
+			t.Errorf("expected '2 files edited', got %q", out)
+		}
+	})
+
+	t.Run("reports hub-edit count to surface risky churn", func(t *testing.T) {
+		root := t.TempDir()
+		writeWatchState(t, root, watch.State{
+			UpdatedAt: time.Now(),
+			FileCount: 10,
+			RecentEvents: []watch.Event{
+				{Path: "types.go", Op: "WRITE", IsHub: true},
+				{Path: "utils.go", Op: "WRITE", IsHub: false},
+				{Path: "types.go", Op: "WRITE", IsHub: true},
+			},
+		})
+		out := captureOutput(func() { showSessionProgress(root) })
+		if !strings.Contains(out, "2 hub edits") {
+			t.Errorf("expected '2 hub edits', got %q", out)
+		}
+		if !strings.Contains(out, "2 files edited") {
+			t.Errorf("expected '2 files edited', got %q", out)
+		}
+	})
+
+	t.Run("omits hub-edit label when there are none", func(t *testing.T) {
+		root := t.TempDir()
+		writeWatchState(t, root, watch.State{
+			UpdatedAt: time.Now(),
+			FileCount: 5,
+			RecentEvents: []watch.Event{
+				{Path: "main.go", Op: "WRITE", IsHub: false},
+			},
+		})
+		out := captureOutput(func() { showSessionProgress(root) })
+		if strings.Contains(out, "hub edits") {
+			t.Errorf("should not mention hub edits when count is 0, got %q", out)
+		}
+		if !strings.Contains(out, "1 files edited") {
+			t.Errorf("expected '1 files edited', got %q", out)
+		}
+	})
+}
+
+// TestGetHubInfoNoDeps verifies the guard that prevents expensive fallback scans
+// when a daemon state exists but lacks dependency graph data (large repos).
+func TestGetHubInfoNoDeps(t *testing.T) {
+	t.Run("state with all-empty deps returns nil (avoids expensive scan)", func(t *testing.T) {
+		root := t.TempDir()
+		writeWatchState(t, root, watch.State{
+			UpdatedAt: time.Now(),
+			FileCount: 2000,
+			// Hubs, Importers, and Imports are all nil/empty
+		})
+		if info := getHubInfo(root); info != nil {
+			t.Errorf("expected nil when state has no dep graph, got %+v", info)
+		}
+	})
+
+	t.Run("state with hub data returns populated hubInfo", func(t *testing.T) {
+		root := t.TempDir()
+		writeWatchState(t, root, watch.State{
+			UpdatedAt: time.Now(),
+			FileCount: 5,
+			Hubs:      []string{"types.go"},
+			Importers: map[string][]string{
+				"types.go": {"a.go", "b.go", "c.go"},
+			},
+		})
+		info := getHubInfo(root)
+		if info == nil {
+			t.Fatal("expected hubInfo when state has dep graph")
+		}
+		if len(info.Hubs) != 1 || info.Hubs[0] != "types.go" {
+			t.Errorf("expected [types.go] hubs, got %v", info.Hubs)
+		}
+		if len(info.Importers["types.go"]) != 3 {
+			t.Errorf("expected 3 importers for types.go, got %v", info.Importers["types.go"])
+		}
+	})
+
+	t.Run("state only with imports (no hubs) also returns hubInfo", func(t *testing.T) {
+		root := t.TempDir()
+		writeWatchState(t, root, watch.State{
+			UpdatedAt: time.Now(),
+			FileCount: 5,
+			Imports: map[string][]string{
+				"main.go": {"types.go"},
+			},
+		})
+		if info := getHubInfo(root); info == nil {
+			t.Error("expected hubInfo when state has at least one imports entry")
+		}
+	})
+}
+
+// TestHookPreCompact verifies that pre-compact saves hub state and prints the
+// correct output, while silently skipping when no hubs exist.
+func TestHookPreCompact(t *testing.T) {
+	t.Run("no hubs: no output and no hubs.txt created", func(t *testing.T) {
+		root := t.TempDir()
+		// All-empty state → getHubInfo returns nil → hookPreCompact exits early.
+		writeWatchState(t, root, watch.State{
+			UpdatedAt: time.Now(),
+			FileCount: 5,
+		})
+
+		out := captureOutput(func() {
+			if err := hookPreCompact(root); err != nil {
+				t.Errorf("hookPreCompact returned error: %v", err)
+			}
+		})
+
+		if out != "" {
+			t.Errorf("expected no output when no hubs, got %q", out)
+		}
+		hubsFile := filepath.Join(root, ".codemap", "hubs.txt")
+		if _, err := os.Stat(hubsFile); !os.IsNotExist(err) {
+			t.Error("expected no hubs.txt when hub list is empty")
+		}
+	})
+
+	t.Run("with hubs: creates hubs.txt and prints count", func(t *testing.T) {
+		root := t.TempDir()
+		writeWatchState(t, root, watch.State{
+			UpdatedAt: time.Now(),
+			FileCount: 20,
+			Hubs:      []string{"types.go", "utils.go", "config.go"},
+			Importers: map[string][]string{
+				"types.go":  {"a.go", "b.go", "c.go"},
+				"utils.go":  {"a.go", "b.go", "c.go"},
+				"config.go": {"a.go", "b.go", "c.go"},
+			},
+		})
+
+		out := captureOutput(func() {
+			if err := hookPreCompact(root); err != nil {
+				t.Errorf("hookPreCompact returned error: %v", err)
+			}
+		})
+
+		if !strings.Contains(out, "3 hub files tracked") {
+			t.Errorf("expected hub count in output, got %q", out)
+		}
+		if !strings.Contains(out, "hubs.txt") {
+			t.Errorf("expected hubs.txt mention, got %q", out)
+		}
+
+		hubsFile := filepath.Join(root, ".codemap", "hubs.txt")
+		content, err := os.ReadFile(hubsFile)
+		if err != nil {
+			t.Fatalf("expected hubs.txt to be created: %v", err)
+		}
+		for _, hub := range []string{"types.go", "utils.go", "config.go"} {
+			if !strings.Contains(string(content), hub) {
+				t.Errorf("expected %q in hubs.txt, got %q", hub, content)
+			}
+		}
+	})
+}
+
+// TestShowRecentHandoffSummary verifies the handoff output and its
+// MaxHandoffCompactBytes guard against context bloat.
+func TestShowRecentHandoffSummary(t *testing.T) {
+	t.Run("nil artifact produces no output", func(t *testing.T) {
+		out := captureOutput(func() { showRecentHandoffSummary(nil) })
+		if out != "" {
+			t.Errorf("expected no output for nil artifact, got %q", out)
+		}
+	})
+
+	t.Run("artifact with changed files shows header and file", func(t *testing.T) {
+		a := &handoff.Artifact{
+			Branch:  "feature/test",
+			BaseRef: "main",
+			Delta: handoff.DeltaSnapshot{
+				Changed: []handoff.FileStub{
+					{Path: "cmd/hooks.go", Status: "modified"},
+				},
+			},
+		}
+		out := captureOutput(func() { showRecentHandoffSummary(a) })
+		if !strings.Contains(out, "Recent handoff") {
+			t.Errorf("expected 'Recent handoff' header, got %q", out)
+		}
+		if !strings.Contains(out, "feature/test") {
+			t.Errorf("expected branch name, got %q", out)
+		}
+	})
+
+	t.Run("large summary is truncated to MaxHandoffCompactBytes (context bloat protection)", func(t *testing.T) {
+		// Build a NextSteps list large enough to overflow MaxHandoffCompactBytes (3000 bytes).
+		var nextSteps []string
+		for i := 0; i < 200; i++ {
+			nextSteps = append(nextSteps, fmt.Sprintf("Step %03d: do the thing with the long description that adds bytes %s", i, strings.Repeat("x", 30)))
+		}
+		a := &handoff.Artifact{
+			Branch:  "feature/huge",
+			BaseRef: "main",
+			Delta: handoff.DeltaSnapshot{
+				NextSteps: nextSteps,
+			},
+		}
+
+		// Confirm the raw compact render is actually over budget before asserting truncation.
+		raw := handoff.RenderCompact(a, 200)
+		if len(raw) <= limits.MaxHandoffCompactBytes {
+			t.Skipf("test precondition not met: raw compact render is only %d bytes (need >%d)", len(raw), limits.MaxHandoffCompactBytes)
+		}
+
+		out := captureOutput(func() { showRecentHandoffSummary(a) })
+		if !strings.Contains(out, "truncated") {
+			t.Errorf("expected truncation indicator in oversized output, got %d bytes", len(out))
+		}
+	})
+
+	t.Run("artifact with risk files includes them in summary", func(t *testing.T) {
+		a := &handoff.Artifact{
+			Branch:  "feature/risky",
+			BaseRef: "main",
+			Delta: handoff.DeltaSnapshot{
+				Changed: []handoff.FileStub{{Path: "types.go", Status: "modified"}},
+				RiskFiles: []handoff.RiskFile{
+					{Path: "types.go", Importers: 10, IsHub: true, Reason: "hub"},
+				},
+			},
+		}
+		out := captureOutput(func() { showRecentHandoffSummary(a) })
+		if !strings.Contains(out, "types.go") {
+			t.Errorf("expected risk file in summary output, got %q", out)
+		}
+	})
 }

--- a/cmd/hooks_test.go
+++ b/cmd/hooks_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -107,6 +108,106 @@ func TestRunHookRouting(t *testing.T) {
 			t.Errorf("error should list %q as available hook", hook)
 		}
 	}
+}
+
+func TestRunWithTimeout(t *testing.T) {
+	t.Run("returns function result before timeout", func(t *testing.T) {
+		errExpected := errors.New("boom")
+		err := runWithTimeout("test-hook", 50*time.Millisecond, func() error {
+			return errExpected
+		})
+		if !errors.Is(err, errExpected) {
+			t.Fatalf("expected %v, got %v", errExpected, err)
+		}
+	})
+
+	t.Run("returns timeout error when function blocks too long", func(t *testing.T) {
+		err := runWithTimeout("slow-hook", 20*time.Millisecond, func() error {
+			time.Sleep(80 * time.Millisecond)
+			return nil
+		})
+		var timeoutErr *HookTimeoutError
+		if !errors.As(err, &timeoutErr) {
+			t.Fatalf("expected HookTimeoutError, got %v", err)
+		}
+		if timeoutErr.Hook != "slow-hook" {
+			t.Fatalf("expected hook name slow-hook, got %q", timeoutErr.Hook)
+		}
+	})
+}
+
+func TestHookTimeoutFromEnv(t *testing.T) {
+	tests := []struct {
+		name string
+		env  string
+		want time.Duration
+	}{
+		{name: "empty uses default", env: "", want: DefaultHookTimeout},
+		{name: "valid duration parses", env: "150ms", want: 150 * time.Millisecond},
+		{name: "zero disables timeout", env: "0", want: 0},
+		{name: "negative falls back to default", env: "-1s", want: DefaultHookTimeout},
+		{name: "invalid falls back to default", env: "not-a-duration", want: DefaultHookTimeout},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := HookTimeoutFromEnv(func(key string) string {
+				if key != "CODEMAP_HOOK_TIMEOUT" {
+					return ""
+				}
+				return tt.env
+			})
+			if got != tt.want {
+				t.Fatalf("HookTimeoutFromEnv(%q) = %s, want %s", tt.env, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestShouldRestartDaemon(t *testing.T) {
+	t.Run("not running returns false", func(t *testing.T) {
+		if shouldRestartDaemon(t.TempDir(), time.Now()) {
+			t.Fatal("expected false when daemon is not running")
+		}
+	})
+
+	t.Run("running with fresh state returns false", func(t *testing.T) {
+		root := t.TempDir()
+		writeWatchState(t, root, watch.State{
+			UpdatedAt: time.Now().Add(-5 * time.Minute),
+			FileCount: 10,
+		})
+		if shouldRestartDaemon(root, time.Now()) {
+			t.Fatal("expected false for fresh daemon state")
+		}
+	})
+
+	t.Run("running with stale state returns true", func(t *testing.T) {
+		root := t.TempDir()
+		writeWatchState(t, root, watch.State{
+			UpdatedAt: time.Now().Add(-3 * time.Hour),
+			FileCount: 10,
+		})
+		if !shouldRestartDaemon(root, time.Now()) {
+			t.Fatal("expected true for stale daemon state")
+		}
+	})
+
+	t.Run("running without state returns true", func(t *testing.T) {
+		root := t.TempDir()
+		codemapDir := filepath.Join(root, ".codemap")
+		if err := os.MkdirAll(codemapDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := watch.WritePID(root); err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { watch.RemovePID(root) })
+
+		if !shouldRestartDaemon(root, time.Now()) {
+			t.Fatal("expected true when daemon pid exists but state is missing")
+		}
+	})
 }
 
 // TestExtractFilePath tests JSON parsing for file_path extraction
@@ -660,6 +761,29 @@ func TestGetLastSessionEvents(t *testing.T) {
 		}
 	})
 
+	t.Run("reads only tail of huge event log and still returns latest 20", func(t *testing.T) {
+		root := t.TempDir()
+		codemapDir := filepath.Join(root, ".codemap")
+		os.MkdirAll(codemapDir, 0755)
+
+		var sb strings.Builder
+		for i := 1; i <= 15000; i++ {
+			fmt.Fprintf(&sb, "ts|WRITE|file%05d.go\n", i)
+		}
+		os.WriteFile(filepath.Join(codemapDir, "events.log"), []byte(sb.String()), 0644)
+
+		got := getLastSessionEvents(root)
+		if len(got) != 20 {
+			t.Fatalf("expected 20 events from huge log tail, got %d", len(got))
+		}
+		if !strings.Contains(got[0], "file14981.go") {
+			t.Errorf("expected first retained event to be file14981.go, got %q", got[0])
+		}
+		if !strings.Contains(got[19], "file15000.go") {
+			t.Errorf("expected last retained event to be file15000.go, got %q", got[19])
+		}
+	})
+
 	t.Run("skips blank lines when counting", func(t *testing.T) {
 		root := t.TempDir()
 		codemapDir := filepath.Join(root, ".codemap")
@@ -861,6 +985,13 @@ func TestGetHubInfoNoDeps(t *testing.T) {
 		})
 		if info := getHubInfo(root); info == nil {
 			t.Error("expected hubInfo when state has at least one imports entry")
+		}
+	})
+
+	t.Run("no fallback path skips expensive fresh scan", func(t *testing.T) {
+		root := t.TempDir()
+		if info := getHubInfoNoFallback(root); info != nil {
+			t.Errorf("expected nil when no daemon state and fallback disabled, got %+v", info)
 		}
 	})
 }

--- a/cmd/hooks_test.go
+++ b/cmd/hooks_test.go
@@ -18,6 +18,15 @@ import (
 	"codemap/watch"
 )
 
+func withOwnedDaemonProcess(t *testing.T, fn func(string) bool) {
+	t.Helper()
+	prev := isOwnedDaemonProcess
+	isOwnedDaemonProcess = fn
+	t.Cleanup(func() {
+		isOwnedDaemonProcess = prev
+	})
+}
+
 // TestHubInfoIsHub tests the hub detection threshold (3+ importers)
 func TestHubInfoIsHub(t *testing.T) {
 	tests := []struct {
@@ -136,6 +145,42 @@ func TestRunWithTimeout(t *testing.T) {
 	})
 }
 
+func TestCappedStringWriter(t *testing.T) {
+	t.Run("captures full output under limit", func(t *testing.T) {
+		w := newCappedStringWriter(8)
+		n, err := w.Write([]byte("hello"))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if n != 5 {
+			t.Fatalf("expected 5 bytes written, got %d", n)
+		}
+		if got := w.String(); got != "hello" {
+			t.Fatalf("expected %q, got %q", "hello", got)
+		}
+		if w.Truncated() {
+			t.Fatal("expected writer not truncated")
+		}
+	})
+
+	t.Run("caps output and marks truncated", func(t *testing.T) {
+		w := newCappedStringWriter(4)
+		n, err := w.Write([]byte("helloworld"))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if n != len("helloworld") {
+			t.Fatalf("expected write count %d, got %d", len("helloworld"), n)
+		}
+		if got := w.String(); got != "hell" {
+			t.Fatalf("expected %q, got %q", "hell", got)
+		}
+		if !w.Truncated() {
+			t.Fatal("expected writer to be truncated")
+		}
+	})
+}
+
 func TestHookTimeoutFromEnv(t *testing.T) {
 	tests := []struct {
 		name string
@@ -166,12 +211,14 @@ func TestHookTimeoutFromEnv(t *testing.T) {
 
 func TestShouldRestartDaemon(t *testing.T) {
 	t.Run("not running returns false", func(t *testing.T) {
+		withOwnedDaemonProcess(t, func(string) bool { return true })
 		if shouldRestartDaemon(t.TempDir(), time.Now()) {
 			t.Fatal("expected false when daemon is not running")
 		}
 	})
 
 	t.Run("running with fresh state returns false", func(t *testing.T) {
+		withOwnedDaemonProcess(t, func(string) bool { return true })
 		root := t.TempDir()
 		writeWatchState(t, root, watch.State{
 			UpdatedAt: time.Now().Add(-5 * time.Minute),
@@ -183,6 +230,7 @@ func TestShouldRestartDaemon(t *testing.T) {
 	})
 
 	t.Run("running with stale state returns true", func(t *testing.T) {
+		withOwnedDaemonProcess(t, func(string) bool { return true })
 		root := t.TempDir()
 		writeWatchState(t, root, watch.State{
 			UpdatedAt: time.Now().Add(-3 * time.Hour),
@@ -194,6 +242,7 @@ func TestShouldRestartDaemon(t *testing.T) {
 	})
 
 	t.Run("running without state returns true", func(t *testing.T) {
+		withOwnedDaemonProcess(t, func(string) bool { return true })
 		root := t.TempDir()
 		codemapDir := filepath.Join(root, ".codemap")
 		if err := os.MkdirAll(codemapDir, 0755); err != nil {
@@ -206,6 +255,18 @@ func TestShouldRestartDaemon(t *testing.T) {
 
 		if !shouldRestartDaemon(root, time.Now()) {
 			t.Fatal("expected true when daemon pid exists but state is missing")
+		}
+	})
+
+	t.Run("running stale state but daemon not owned returns false", func(t *testing.T) {
+		withOwnedDaemonProcess(t, func(string) bool { return false })
+		root := t.TempDir()
+		writeWatchState(t, root, watch.State{
+			UpdatedAt: time.Now().Add(-3 * time.Hour),
+			FileCount: 10,
+		})
+		if shouldRestartDaemon(root, time.Now()) {
+			t.Fatal("expected false for unowned daemon process")
 		}
 	})
 }

--- a/limits/budget.go
+++ b/limits/budget.go
@@ -5,6 +5,7 @@ import "strings"
 const (
 	// Shared text response budgets.
 	MaxStructureOutputBytes = MaxContextOutputBytes
+	MaxDiffOutputBytes      = 30000
 	MaxHandoffCompactBytes  = 3000
 	MaxHandoffMarkdownBytes = 20000
 	MaxHandoffDetailBytes   = 12000

--- a/limits/limits.go
+++ b/limits/limits.go
@@ -5,6 +5,16 @@ const (
 	MaxContextOutputBytes = 60000 // ~15k tokens, <10% of a 200k context window
 )
 
+// Watch daemon retention limits to keep long-running sessions bounded.
+const (
+	MaxDaemonEvents      = 1000
+	MaxStateRecentEvents = 50
+
+	MaxEventLogBytes     = 512 * 1024 // rotate when events.log exceeds 512KB
+	EventLogTrimToBytes  = 384 * 1024 // keep newest 384KB after rotation
+	MaxEventLogReadBytes = 128 * 1024 // hooks only read the tail of large logs
+)
+
 // Repo-size thresholds used to scale expensive analysis work.
 const (
 	MediumRepoFileCount = 2000

--- a/limits/limits.go
+++ b/limits/limits.go
@@ -10,8 +10,8 @@ const (
 	MaxDaemonEvents      = 1000
 	MaxStateRecentEvents = 50
 
-	MaxEventLogBytes     = 512 * 1024 // rotate when events.log exceeds 512KB
-	EventLogTrimToBytes  = 384 * 1024 // keep newest 384KB after rotation
+	MaxEventLogBytes     = 512 * 1024 // trim events.log when it exceeds 512KB
+	EventLogTrimToBytes  = 384 * 1024 // keep newest 384KB after trimming
 	MaxEventLogReadBytes = 128 * 1024 // hooks only read the tail of large logs
 )
 

--- a/limits/limits_test.go
+++ b/limits/limits_test.go
@@ -9,13 +9,13 @@ import (
 // the hook system. It must never let hook output exceed the budget.
 func TestTruncateAtLineBoundary(t *testing.T) {
 	tests := []struct {
-		name        string
-		input       string
-		maxBytes    int
-		msg         string
-		wantLen     int    // exact expected length (0 = skip check)
-		wantSuffix  string // expected suffix after truncation
-		wantUnchanged bool  // expect identical output (no truncation)
+		name          string
+		input         string
+		maxBytes      int
+		msg           string
+		wantLen       int    // exact expected length (0 = skip check)
+		wantSuffix    string // expected suffix after truncation
+		wantUnchanged bool   // expect identical output (no truncation)
 	}{
 		{
 			name:          "content within budget is unchanged",
@@ -164,6 +164,21 @@ func TestHandoffBudgetForRepo(t *testing.T) {
 		if b.MaxDetailBytes == 0 {
 			t.Error("MaxDetailBytes must be nonzero")
 		}
+	}
+}
+
+func TestDaemonRetentionLimitsAreSane(t *testing.T) {
+	if MaxDaemonEvents <= MaxStateRecentEvents {
+		t.Fatalf("MaxDaemonEvents (%d) should exceed MaxStateRecentEvents (%d)", MaxDaemonEvents, MaxStateRecentEvents)
+	}
+	if MaxEventLogBytes <= EventLogTrimToBytes {
+		t.Fatalf("MaxEventLogBytes (%d) should exceed EventLogTrimToBytes (%d)", MaxEventLogBytes, EventLogTrimToBytes)
+	}
+	if MaxEventLogReadBytes <= 0 {
+		t.Fatalf("MaxEventLogReadBytes must be > 0, got %d", MaxEventLogReadBytes)
+	}
+	if MaxDiffOutputBytes <= 0 {
+		t.Fatalf("MaxDiffOutputBytes must be > 0, got %d", MaxDiffOutputBytes)
 	}
 }
 

--- a/limits/limits_test.go
+++ b/limits/limits_test.go
@@ -1,0 +1,182 @@
+package limits
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestTruncateAtLineBoundary covers the core context-bloat guard used throughout
+// the hook system. It must never let hook output exceed the budget.
+func TestTruncateAtLineBoundary(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		maxBytes    int
+		msg         string
+		wantLen     int    // exact expected length (0 = skip check)
+		wantSuffix  string // expected suffix after truncation
+		wantUnchanged bool  // expect identical output (no truncation)
+	}{
+		{
+			name:          "content within budget is unchanged",
+			input:         "line1\nline2\nline3\n",
+			maxBytes:      100,
+			wantUnchanged: true,
+		},
+		{
+			name:          "empty string is unchanged",
+			input:         "",
+			maxBytes:      100,
+			wantUnchanged: true,
+		},
+		{
+			name:          "maxBytes zero returns unchanged (guard clause)",
+			input:         "some content",
+			maxBytes:      0,
+			wantUnchanged: true,
+		},
+		{
+			name:          "maxBytes negative returns unchanged (guard clause)",
+			input:         "some content",
+			maxBytes:      -1,
+			wantUnchanged: true,
+		},
+		{
+			name:     "content exceeding budget is truncated",
+			input:    strings.Repeat("x", 10000),
+			maxBytes: 100,
+			msg:      "\n... (truncated)\n",
+		},
+		{
+			name:       "truncation appends custom message",
+			input:      strings.Repeat("a", 5000),
+			maxBytes:   1000,
+			msg:        "\n\n... (custom truncation message)\n",
+			wantSuffix: "\n\n... (custom truncation message)\n",
+		},
+		{
+			name:       "truncation appends default message when msg is empty",
+			input:      strings.Repeat("b", 5000),
+			maxBytes:   1000,
+			msg:        "",
+			wantSuffix: "\n\n... (truncated)\n",
+			// default message is 18 bytes; slack must cover it
+		},
+		{
+			name: "truncation prefers clean line boundary",
+			// Put a newline near the cutoff so truncation can split there
+			input:    strings.Repeat("z", 800) + "\n" + strings.Repeat("z", 800),
+			maxBytes: 1000,
+			msg:      "...\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := TruncateAtLineBoundary(tt.input, tt.maxBytes, tt.msg)
+
+			if tt.wantUnchanged {
+				if got != tt.input {
+					t.Errorf("expected unchanged output, got %q (len=%d)", got[:min(len(got), 50)], len(got))
+				}
+				return
+			}
+
+			// Output must fit within budget plus the appended message.
+			// When msg is empty, the function substitutes the default 18-byte message.
+			effectiveMsg := tt.msg
+			if effectiveMsg == "" {
+				effectiveMsg = "\n\n... (truncated)\n"
+			}
+			maxAllowed := tt.maxBytes + len(effectiveMsg) + 10 // small slack for line boundary
+			if len(got) > maxAllowed {
+				t.Errorf("output length %d exceeds budget %d + msg overhead", len(got), tt.maxBytes)
+			}
+
+			if tt.wantSuffix != "" && !strings.HasSuffix(got, tt.wantSuffix) {
+				t.Errorf("expected suffix %q, got %q", tt.wantSuffix, got[max(0, len(got)-len(tt.wantSuffix)):])
+			}
+		})
+	}
+}
+
+// TestAdaptiveDepth verifies that tree depth shrinks proportionally with repo size,
+// preventing hook startup from injecting massive tree output into context.
+func TestAdaptiveDepth(t *testing.T) {
+	tests := []struct {
+		name      string
+		fileCount int
+		wantDepth int
+	}{
+		{"unknown repo size defaults to shallow (0)", 0, 2},
+		{"negative treated as unknown", -1, 2},
+		{"small repo gets full depth", 100, 4},
+		{"medium repo threshold (2001)", 2001, 3},
+		{"large repo threshold (5001)", 5001, 2},
+		{"exactly medium threshold (2000)", 2000, 4},
+		{"exactly large threshold (5000)", 5000, 3},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := AdaptiveDepth(tt.fileCount)
+			if got != tt.wantDepth {
+				t.Errorf("AdaptiveDepth(%d) = %d, want %d", tt.fileCount, got, tt.wantDepth)
+			}
+		})
+	}
+}
+
+// TestHandoffBudgetForRepo verifies that handoff list sizes scale down for large
+// repos to prevent context bloat in the session handoff output.
+func TestHandoffBudgetForRepo(t *testing.T) {
+	small := HandoffBudgetForRepo(100)
+	medium := HandoffBudgetForRepo(MediumRepoFileCount + 1)
+	large := HandoffBudgetForRepo(LargeRepoFileCount + 1)
+
+	// Budgets should monotonically decrease as repo size grows.
+	if small.MaxChanged <= medium.MaxChanged {
+		t.Errorf("small repo should have larger MaxChanged than medium: %d vs %d",
+			small.MaxChanged, medium.MaxChanged)
+	}
+	if medium.MaxChanged <= large.MaxChanged {
+		t.Errorf("medium repo should have larger MaxChanged than large: %d vs %d",
+			medium.MaxChanged, large.MaxChanged)
+	}
+	if small.MaxRisk <= medium.MaxRisk {
+		t.Errorf("small repo should have larger MaxRisk than medium: %d vs %d",
+			small.MaxRisk, medium.MaxRisk)
+	}
+	if medium.MaxRisk <= large.MaxRisk {
+		t.Errorf("medium repo should have larger MaxRisk than large: %d vs %d",
+			medium.MaxRisk, large.MaxRisk)
+	}
+	if small.MaxEvents <= large.MaxEvents {
+		t.Errorf("small repo should have more MaxEvents than large: %d vs %d",
+			small.MaxEvents, large.MaxEvents)
+	}
+
+	// Markdown and detail budgets are shared (not repo-scaled) — verify they're nonzero.
+	for _, b := range []HandoffBudget{small, medium, large} {
+		if b.MaxMarkdownBytes == 0 {
+			t.Error("MaxMarkdownBytes must be nonzero")
+		}
+		if b.MaxDetailBytes == 0 {
+			t.Error("MaxDetailBytes must be nonzero")
+		}
+	}
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -48,7 +49,13 @@ func main() {
 		if len(os.Args) >= 4 {
 			root = os.Args[3]
 		}
-		if err := cmd.RunHook(hookName, root); err != nil {
+		if err := cmd.RunHookWithTimeout(hookName, root, cmd.HookTimeoutFromEnv(os.Getenv)); err != nil {
+			var timeoutErr *cmd.HookTimeoutError
+			if errors.As(err, &timeoutErr) {
+				fmt.Fprintf(os.Stderr, "Hook warning: %v\n", timeoutErr)
+				fmt.Fprintln(os.Stderr, "Continuing without hook output. Set CODEMAP_HOOK_TIMEOUT=0 to disable timeout.")
+				return
+			}
 			fmt.Fprintf(os.Stderr, "Hook error: %v\n", err)
 			os.Exit(1)
 		}

--- a/scanner/walker.go
+++ b/scanner/walker.go
@@ -64,6 +64,15 @@ func (c *GitIgnoreCache) tryLoadGitignore(dir string) {
 	}
 }
 
+// EnsureDir loads a .gitignore for dir if present.
+// Safe to call repeatedly; directories are memoized.
+func (c *GitIgnoreCache) EnsureDir(dir string) {
+	if c == nil || dir == "" {
+		return
+	}
+	c.tryLoadGitignore(dir)
+}
+
 // ShouldIgnore checks if a path should be ignored based on all applicable .gitignore files.
 // Git evaluates rules from root to leaf, with later rules overriding earlier ones.
 func (c *GitIgnoreCache) ShouldIgnore(absPath string) bool {

--- a/watch/daemon.go
+++ b/watch/daemon.go
@@ -213,9 +213,18 @@ func (d *Daemon) addWatchDirs() error {
 			return nil // skip errors
 		}
 
+		absPath, _ := filepath.Abs(path)
+
 		// Skip hidden directories and common ignores
 		name := info.Name()
 		if info.IsDir() {
+			if d.gitCache != nil {
+				d.gitCache.EnsureDir(absPath)
+				// Honor nested .gitignore rules so ignored subtrees are never watched.
+				if path != d.root && d.gitCache.ShouldIgnore(absPath) {
+					return filepath.SkipDir
+				}
+			}
 			if strings.HasPrefix(name, ".") || name == "node_modules" || name == "vendor" {
 				return filepath.SkipDir
 			}

--- a/watch/events.go
+++ b/watch/events.go
@@ -2,14 +2,17 @@ package watch
 
 import (
 	"bufio"
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
 
+	"codemap/limits"
 	"codemap/scanner"
 
 	"github.com/fsnotify/fsnotify"
@@ -81,6 +84,14 @@ func (d *Daemon) isSourceFile(path string) bool {
 
 // handleEvent processes a single file event
 func (d *Daemon) handleEvent(fsEvent fsnotify.Event) {
+	absPath, absErr := filepath.Abs(fsEvent.Name)
+	if absErr == nil && d.gitCache != nil {
+		// Ignore gitignored paths entirely so watcher churn cannot come from excluded trees.
+		if d.gitCache.ShouldIgnore(absPath) {
+			return
+		}
+	}
+
 	relPath, err := filepath.Rel(d.root, fsEvent.Name)
 	if err != nil {
 		relPath = fsEvent.Name
@@ -121,6 +132,17 @@ func (d *Daemon) handleEvent(fsEvent fsnotify.Event) {
 		// If a new directory was created, add it to the watcher
 		if info.IsDir() {
 			name := filepath.Base(fsEvent.Name)
+			if d.gitCache != nil {
+				dirPath := fsEvent.Name
+				if absErr == nil {
+					dirPath = absPath
+				}
+				d.gitCache.EnsureDir(dirPath)
+				if d.gitCache.ShouldIgnore(dirPath) {
+					d.graph.mu.Unlock()
+					return
+				}
+			}
 			// Skip hidden directories and common ignores
 			if !strings.HasPrefix(name, ".") && name != "node_modules" && name != "vendor" {
 				d.watcher.Add(fsEvent.Name)
@@ -179,7 +201,7 @@ func (d *Daemon) handleEvent(fsEvent fsnotify.Event) {
 		event.RelatedHot = d.findRelatedHot(relPath, 5*time.Minute)
 	}
 
-	d.graph.Events = append(d.graph.Events, event)
+	d.graph.Events = appendBoundedEvents(d.graph.Events, event)
 	d.graph.mu.Unlock()
 
 	// Log event
@@ -254,7 +276,6 @@ func (d *Daemon) logEvent(e Event) {
 	if err != nil {
 		return
 	}
-	defer f.Close()
 
 	// Format: timestamp | OP | path | lines | delta | dirty
 	deltaStr := ""
@@ -277,7 +298,15 @@ func (d *Daemon) logEvent(e Event) {
 		deltaStr,
 		dirtyStr,
 	)
-	f.WriteString(line)
+	if _, err := f.WriteString(line); err != nil {
+		_ = f.Close()
+		return
+	}
+	if err := f.Close(); err != nil {
+		return
+	}
+
+	_ = trimEventLogToBytes(d.eventLog, int64(limits.MaxEventLogBytes), int64(limits.EventLogTrimToBytes))
 
 	// Update state file for hooks to read
 	d.writeState()
@@ -288,11 +317,12 @@ func (d *Daemon) writeState() {
 	d.graph.mu.RLock()
 	defer d.graph.mu.RUnlock()
 
-	// Get last 50 events for timeline
+	// Keep state snapshots small and deterministic for hook reads.
 	events := d.graph.Events
-	if len(events) > 50 {
-		events = events[len(events)-50:]
+	if len(events) > limits.MaxStateRecentEvents {
+		events = events[len(events)-limits.MaxStateRecentEvents:]
 	}
+	eventsCopy := append([]Event(nil), events...)
 
 	state := State{
 		UpdatedAt:    time.Now(),
@@ -300,7 +330,7 @@ func (d *Daemon) writeState() {
 		Hubs:         []string{},
 		Importers:    map[string][]string{},
 		Imports:      map[string][]string{},
-		RecentEvents: events,
+		RecentEvents: eventsCopy,
 	}
 	if d.graph.FileGraph != nil {
 		state.Hubs = d.graph.FileGraph.HubFiles()
@@ -315,6 +345,54 @@ func (d *Daemon) writeState() {
 
 	stateFile := filepath.Join(d.root, ".codemap", "state.json")
 	os.WriteFile(stateFile, data, 0644)
+}
+
+func appendBoundedEvents(events []Event, event Event) []Event {
+	events = append(events, event)
+	if len(events) <= limits.MaxDaemonEvents {
+		return events
+	}
+
+	// Reallocate to release references to the old backing array.
+	trimmed := append([]Event(nil), events[len(events)-limits.MaxDaemonEvents:]...)
+	return trimmed
+}
+
+func trimEventLogToBytes(path string, maxBytes, keepBytes int64) error {
+	if maxBytes <= 0 || keepBytes <= 0 || keepBytes > maxBytes {
+		return nil
+	}
+
+	info, err := os.Stat(path)
+	if err != nil || info.Size() <= maxBytes {
+		return nil
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	if keepBytes > info.Size() {
+		keepBytes = info.Size()
+	}
+	start := info.Size() - keepBytes
+	tail := make([]byte, keepBytes)
+	n, err := f.ReadAt(tail, start)
+	if err != nil && err != io.EOF {
+		return err
+	}
+	tail = tail[:n]
+	if len(tail) == 0 {
+		return nil
+	}
+
+	if idx := bytes.IndexByte(tail, '\n'); start > 0 && idx >= 0 && idx+1 < len(tail) {
+		tail = tail[idx+1:]
+	}
+
+	return os.WriteFile(path, tail, 0644)
 }
 
 // countLines counts lines in a file efficiently (no full read into memory)

--- a/watch/events_limits_test.go
+++ b/watch/events_limits_test.go
@@ -1,0 +1,69 @@
+package watch
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"codemap/limits"
+)
+
+func TestAppendBoundedEventsCapsHistory(t *testing.T) {
+	total := limits.MaxDaemonEvents + 200
+	events := make([]Event, 0, total)
+	for i := 0; i < total; i++ {
+		events = appendBoundedEvents(events, Event{
+			Time: time.Unix(int64(i), 0),
+			Path: fmt.Sprintf("file%04d.go", i),
+		})
+	}
+
+	if len(events) != limits.MaxDaemonEvents {
+		t.Fatalf("expected %d retained events, got %d", limits.MaxDaemonEvents, len(events))
+	}
+
+	firstExpected := fmt.Sprintf("file%04d.go", total-limits.MaxDaemonEvents)
+	lastExpected := fmt.Sprintf("file%04d.go", total-1)
+	if events[0].Path != firstExpected {
+		t.Fatalf("expected first retained event %q, got %q", firstExpected, events[0].Path)
+	}
+	if events[len(events)-1].Path != lastExpected {
+		t.Fatalf("expected last retained event %q, got %q", lastExpected, events[len(events)-1].Path)
+	}
+}
+
+func TestTrimEventLogToBytes(t *testing.T) {
+	tmpDir := t.TempDir()
+	logPath := filepath.Join(tmpDir, "events.log")
+
+	var sb strings.Builder
+	for i := 0; i < 1200; i++ {
+		fmt.Fprintf(&sb, "2026-02-27 12:00:00 | WRITE  | src/file%04d.go |  100 |    +1 | dirty\n", i)
+	}
+	if err := os.WriteFile(logPath, []byte(sb.String()), 0644); err != nil {
+		t.Fatalf("failed to seed log file: %v", err)
+	}
+
+	if err := trimEventLogToBytes(logPath, 4096, 2048); err != nil {
+		t.Fatalf("trimEventLogToBytes returned error: %v", err)
+	}
+
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("failed to read trimmed log: %v", err)
+	}
+	if len(data) > 2048 {
+		t.Fatalf("expected trimmed log <= 2048 bytes, got %d", len(data))
+	}
+
+	content := string(data)
+	if strings.Contains(content, "file0001.go") {
+		t.Fatalf("expected oldest entries to be trimmed out, got unexpected early entry")
+	}
+	if !strings.Contains(content, "file1199.go") {
+		t.Fatalf("expected newest entry to be retained after trim")
+	}
+}

--- a/watch/process_unix.go
+++ b/watch/process_unix.go
@@ -1,0 +1,17 @@
+//go:build !windows
+
+package watch
+
+import (
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+func processCommandLine(pid int) (string, error) {
+	out, err := exec.Command("ps", "-p", strconv.Itoa(pid), "-o", "command=").Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}

--- a/watch/process_windows.go
+++ b/watch/process_windows.go
@@ -1,0 +1,10 @@
+//go:build windows
+
+package watch
+
+import "errors"
+
+func processCommandLine(pid int) (string, error) {
+	_ = pid
+	return "", errors.New("process command line lookup not supported on windows")
+}

--- a/watch/state.go
+++ b/watch/state.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"time"
 )
@@ -54,6 +55,36 @@ func ReadPID(root string) (int, error) {
 func RemovePID(root string) {
 	pidFile := filepath.Join(root, ".codemap", "watch.pid")
 	os.Remove(pidFile)
+}
+
+// IsOwnedDaemon checks whether the PID file points to a codemap watch daemon
+// for this repository root.
+func IsOwnedDaemon(root string) bool {
+	pid, err := ReadPID(root)
+	if err != nil || pid <= 0 {
+		return false
+	}
+
+	cmdline, err := processCommandLine(pid)
+	if err != nil {
+		return false
+	}
+	cmdline = strings.TrimSpace(cmdline)
+	if cmdline == "" {
+		return false
+	}
+
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		absRoot = root
+	}
+	if absRoot == "" {
+		return false
+	}
+
+	return strings.Contains(cmdline, "watch") &&
+		strings.Contains(cmdline, "daemon") &&
+		strings.Contains(cmdline, absRoot)
 }
 
 // IsRunning checks if the daemon is running

--- a/watch/watch_test.go
+++ b/watch/watch_test.go
@@ -3,6 +3,7 @@ package watch
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -341,6 +342,66 @@ func TestNonSourceFileIgnored(t *testing.T) {
 		if e.Path == "readme.txt" || e.Path == "config.json" {
 			t.Errorf("Non-source file should be ignored: %s", e.Path)
 		}
+	}
+}
+
+func TestWatchIgnoresGitignoredDirectories(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "codemap-watch-gitignore-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	if err := os.WriteFile(filepath.Join(tmpDir, ".gitignore"), []byte("third_party/\n"), 0644); err != nil {
+		t.Fatalf("Failed to create .gitignore: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpDir, "tracked.go"), []byte("package main\n"), 0644); err != nil {
+		t.Fatalf("Failed to create tracked file: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(tmpDir, "third_party", "freerdp"), 0755); err != nil {
+		t.Fatalf("Failed to create ignored dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpDir, "third_party", "freerdp", "ignored.go"), []byte("package ignored\n"), 0644); err != nil {
+		t.Fatalf("Failed to create ignored file: %v", err)
+	}
+
+	daemon, err := NewDaemon(tmpDir, false)
+	if err != nil {
+		t.Fatalf("NewDaemon failed: %v", err)
+	}
+	if err := daemon.Start(); err != nil {
+		t.Fatalf("Start failed: %v", err)
+	}
+	defer daemon.Stop()
+
+	time.Sleep(500 * time.Millisecond)
+
+	if err := os.WriteFile(filepath.Join(tmpDir, "tracked.go"), []byte("package main\n// touched\n"), 0644); err != nil {
+		t.Fatalf("Failed to modify tracked file: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpDir, "third_party", "freerdp", "ignored.go"), []byte("package ignored\n// touched\n"), 0644); err != nil {
+		t.Fatalf("Failed to modify ignored file: %v", err)
+	}
+
+	time.Sleep(700 * time.Millisecond)
+
+	events := daemon.GetEvents(200)
+	if len(events) == 0 {
+		t.Skip("fsnotify may not work reliably in temp directories on this platform")
+	}
+
+	foundTrackedWrite := false
+	for _, e := range events {
+		if e.Op == "WRITE" && e.Path == "tracked.go" {
+			foundTrackedWrite = true
+		}
+		if strings.HasPrefix(filepath.ToSlash(e.Path), "third_party/") {
+			t.Fatalf("expected gitignored path to be excluded from watcher events, got: %s %s", e.Op, e.Path)
+		}
+	}
+
+	if !foundTrackedWrite {
+		t.Fatalf("expected a WRITE event for tracked.go, got events: %+v", events)
 	}
 }
 


### PR DESCRIPTION
## Summary
This extends the hook coverage work with runtime hardening for the real-world context bloat + hang/crash reports.

## What changed
- Added hard retention limits for watch daemon state/logs:
  - bounded in-memory events
  - `events.log` rollover/trim
  - tail-only reads for session-start history
- Made interactive hooks (`prompt-submit`, `pre-edit`, `post-edit`, `pre-compact`, session-stop fallback path) use cached daemon hub data only (no expensive fallback graph scans).
- Added hook fail-open timeout (`CODEMAP_HOOK_TIMEOUT`, default `8s`) so hooks cannot block Claude input indefinitely.
- Added stale daemon restart check at `session-start` for unhealthy/abandoned daemon state.
- Made watcher `.gitignore`-aware for both directory registration and event ingestion, including nested ignored repos.
- Capped branch diff hook output to reduce context injection from large diffs.
- Added coverage tooling:
  - `make coverage`
  - CI coverage floor enforcement (`>=30%` total on ubuntu/go1.23)

## Tests
- Expanded hook tests for timeout/env parsing/stale-daemon behavior and no-fallback hub lookup.
- Added watch tests for gitignored directory event exclusion.
- Added daemon retention/trim tests.
- Existing hook/limits coverage tests from PR #30 remain included.

## Validation
- `go test ./...`
- `make coverage` (currently total coverage: `33.0%`)

## Related
- Addresses #29
- Supersedes test-only PR #30 by including runtime fixes + tests together.
