### PR TITLE
test: improve render coverage from 7.8% to 18.6%

### DIFF
--- a/render/tree_test.go
+++ b/render/tree_test.go
@@ -401,6 +401,10 @@ func TestCreateBuildings(t *testing.T) {
 	})
 
 	t.Run("assigns scaled heights and trims long extension labels", func(t *testing.T) {
+		prevRng := rng
+		t.Cleanup(func() {
+			rng = prevRng
+		})
 		rng = rand.New(rand.NewPCG(42, 0))
 		sorted := []extAgg{
 			{ext: ".verylong", size: 1000, count: 1},


### PR DESCRIPTION
## Summary
- add deterministic table-driven tests for `render` helper logic in `render/tree_test.go`
- cover `titleCase`, `getSystemName`, `filterCodeFiles`, `aggregateByExtension`, `getBuildingChar`, `createBuildings`, and empty-source `Depgraph`
- keep production source unchanged (tests only)

## Coverage
| Package | Before | After |
|---|---:|---:|
| codemap/render | 7.8% | 18.6% |
| **TOTAL** | **34.8%** | **36.9%** |

## Validation
- `go test -race -coverprofile=coverage.out ./...`
- `go vet ./...`
- `gofmt -l .`

## Coverage Floor
Current CI floor in `.github/workflows/ci.yml` is `min=30.0`.
Total coverage increase is `+2.1` points, so floor was not bumped (requires `+5`).
