### PR TITLE
test: raise coverage to 77.5%

### DIFF
--- a/cmd/hooks.go
+++ b/cmd/hooks.go
@@ -36,6 +36,10 @@ const (
 )
 
 var isOwnedDaemonProcess = watch.IsOwnedDaemon
+var hookExecutablePath = os.Executable
+var hookExecCommand = exec.Command
+var hookWatchIsRunning = watch.IsRunning
+var daemonStartupPause = time.Sleep
 
 var promptFileExtensions = []string{"go", "tsx", "ts", "jsx", "js", "py", "rs", "rb", "java", "swift", "kt", "c", "cpp", "h"}
 
@@ -623,17 +627,17 @@ func showRecentHandoffSummary(artifact *handoff.Artifact) {
 
 // startDaemon launches the watch daemon in background
 func startDaemon(root string) {
-	exe, err := os.Executable()
+	exe, err := hookExecutablePath()
 	if err != nil {
 		return
 	}
-	cmd := exec.Command(exe, "watch", "start", root)
+	cmd := hookExecCommand(exe, "watch", "start", root)
 	cmd.Stdout = nil
 	cmd.Stderr = nil
 	cmd.Stdin = nil
 	cmd.Start()
 	// Give daemon a moment to initialize
-	time.Sleep(200 * time.Millisecond)
+	daemonStartupPause(200 * time.Millisecond)
 }
 
 // hookPreEdit warns before editing hub files (reads JSON from stdin)
@@ -1044,14 +1048,14 @@ func gitSymbolicRef(root, ref string) (string, bool) {
 
 // stopDaemon stops the watch daemon
 func stopDaemon(root string) {
-	if !watch.IsRunning(root) {
+	if !hookWatchIsRunning(root) {
 		return
 	}
-	exe, err := os.Executable()
+	exe, err := hookExecutablePath()
 	if err != nil {
 		return
 	}
-	cmd := exec.Command(exe, "watch", "stop", root)
+	cmd := hookExecCommand(exe, "watch", "stop", root)
 	cmd.Run()
 }
 
@@ -1190,7 +1194,7 @@ func hookSessionStartMultiRepo(root string, childRepos []string) error {
 	fmt.Printf("   %d repositories in %s\n", len(childRepos), filepath.Base(root))
 	fmt.Println()
 
-	exe, err := os.Executable()
+	exe, err := hookExecutablePath()
 	if err != nil {
 		return err
 	}
@@ -1213,7 +1217,7 @@ func hookSessionStartMultiRepo(root string, childRepos []string) error {
 			args = append(args, "--exclude", strings.Join(projCfg.Exclude, ","))
 		}
 		args = append(args, repoPath)
-		cmd := exec.Command(exe, args...)
+		cmd := hookExecCommand(exe, args...)
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 		cmd.Run()

--- a/cmd/hooks_more_test.go
+++ b/cmd/hooks_more_test.go
@@ -18,6 +18,41 @@ import (
 	"codemap/watch"
 )
 
+func withHookRuntimeStubs(
+	t *testing.T,
+	exePath func() (string, error),
+	cmdFactory func(name string, args ...string) *exec.Cmd,
+	isRunning func(string) bool,
+	sleep func(time.Duration),
+) {
+	t.Helper()
+
+	prevExePath := hookExecutablePath
+	prevCmdFactory := hookExecCommand
+	prevIsRunning := hookWatchIsRunning
+	prevSleep := daemonStartupPause
+
+	if exePath != nil {
+		hookExecutablePath = exePath
+	}
+	if cmdFactory != nil {
+		hookExecCommand = cmdFactory
+	}
+	if isRunning != nil {
+		hookWatchIsRunning = isRunning
+	}
+	if sleep != nil {
+		daemonStartupPause = sleep
+	}
+
+	t.Cleanup(func() {
+		hookExecutablePath = prevExePath
+		hookExecCommand = prevCmdFactory
+		hookWatchIsRunning = prevIsRunning
+		daemonStartupPause = prevSleep
+	})
+}
+
 func captureOutputAndError(t *testing.T, fn func()) (string, string) {
 	t.Helper()
 
@@ -542,6 +577,104 @@ func TestHookSessionStopSummaryBranches(t *testing.T) {
 
 		if !strings.Contains(out, "Files modified:") || !strings.Contains(out, "main.go") {
 			t.Fatalf("expected modified file list, got:\n%s", out)
+		}
+	})
+}
+
+func TestDaemonCommandHelpersAndMultiRepoShellout(t *testing.T) {
+	t.Run("start daemon shells out to watch start", func(t *testing.T) {
+		var gotName string
+		var gotArgs []string
+		withHookRuntimeStubs(
+			t,
+			func() (string, error) { return "/tmp/codemap-hook", nil },
+			func(name string, args ...string) *exec.Cmd {
+				gotName = name
+				gotArgs = append([]string(nil), args...)
+				return exec.Command("sh", "-c", "exit 0")
+			},
+			nil,
+			func(time.Duration) {},
+		)
+
+		startDaemon("/repo")
+		if gotName != "/tmp/codemap-hook" {
+			t.Fatalf("startDaemon executable = %q, want /tmp/codemap-hook", gotName)
+		}
+		wantArgs := []string{"watch", "start", "/repo"}
+		if strings.Join(gotArgs, "|") != strings.Join(wantArgs, "|") {
+			t.Fatalf("startDaemon args = %v, want %v", gotArgs, wantArgs)
+		}
+	})
+
+	t.Run("stop daemon shells out only when running", func(t *testing.T) {
+		var callCount int
+		var gotArgs []string
+		withHookRuntimeStubs(
+			t,
+			func() (string, error) { return "/tmp/codemap-hook", nil },
+			func(name string, args ...string) *exec.Cmd {
+				callCount++
+				gotArgs = append([]string(nil), args...)
+				return exec.Command("sh", "-c", "exit 0")
+			},
+			func(string) bool { return true },
+			nil,
+		)
+
+		stopDaemon("/repo")
+		if callCount != 1 {
+			t.Fatalf("expected stopDaemon to shell out once, got %d", callCount)
+		}
+		wantArgs := []string{"watch", "stop", "/repo"}
+		if strings.Join(gotArgs, "|") != strings.Join(wantArgs, "|") {
+			t.Fatalf("stopDaemon args = %v, want %v", gotArgs, wantArgs)
+		}
+	})
+
+	t.Run("multi repo start shells out for each child repo", func(t *testing.T) {
+		root := t.TempDir()
+		for _, repo := range []string{"svc-a", "svc-b"} {
+			repoPath := filepath.Join(root, repo)
+			if err := os.MkdirAll(repoPath, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			writeProjectConfig(t, repoPath, config.ProjectConfig{
+				Depth:   3,
+				Only:    []string{"go"},
+				Exclude: []string{"vendor"},
+			})
+		}
+
+		var calls [][]string
+		withHookRuntimeStubs(
+			t,
+			func() (string, error) { return "/tmp/codemap-hook", nil },
+			func(name string, args ...string) *exec.Cmd {
+				calls = append(calls, append([]string{name}, args...))
+				return exec.Command("sh", "-c", "exit 0")
+			},
+			nil,
+			nil,
+		)
+
+		out := captureOutput(func() {
+			if err := hookSessionStartMultiRepo(root, []string{"svc-a", "svc-b"}); err != nil {
+				t.Fatalf("hookSessionStartMultiRepo() error: %v", err)
+			}
+		})
+		if !strings.Contains(out, "Multi-Repo Project Context") || !strings.Contains(out, "2 repositories") {
+			t.Fatalf("expected multi-repo header output, got:\n%s", out)
+		}
+		if len(calls) != 2 {
+			t.Fatalf("expected 2 shell-outs, got %d", len(calls))
+		}
+		for i, repo := range []string{"svc-a", "svc-b"} {
+			repoPath := filepath.Join(root, repo)
+			want := []string{"/tmp/codemap-hook", "--depth", "3", "--only", "go", "--exclude", "vendor", repoPath}
+			if strings.Join(calls[i], "|") != strings.Join(want, "|") {
+				t.Fatalf("call %d = %v, want %v", i, calls[i], want)
+			}
 		}
 	})
 }

--- a/cmd/hooks_test.go
+++ b/cmd/hooks_test.go
@@ -1,11 +1,9 @@
 package cmd
 
 import (
-	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -766,17 +764,26 @@ func TestHandoffMatchesBranch(t *testing.T) {
 // captureOutput captures stdout during function execution
 func captureOutput(f func()) string {
 	old := os.Stdout
-	r, w, _ := os.Pipe()
-	os.Stdout = w
+	outFile, err := os.CreateTemp("", "codemap-cmd-output-*")
+	if err != nil {
+		panic(err)
+	}
+	defer os.Remove(outFile.Name())
 
-	f()
+	func() {
+		defer func() {
+			_ = outFile.Close()
+			os.Stdout = old
+		}()
+		os.Stdout = outFile
+		f()
+	}()
 
-	w.Close()
-	os.Stdout = old
-
-	var buf bytes.Buffer
-	io.Copy(&buf, r)
-	return buf.String()
+	data, err := os.ReadFile(outFile.Name())
+	if err != nil {
+		panic(err)
+	}
+	return string(data)
 }
 
 // writeWatchState writes a watch.State JSON file to <root>/.codemap/state.json

--- a/handoff/build_more_test.go
+++ b/handoff/build_more_test.go
@@ -1,0 +1,58 @@
+package handoff
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestChangedFromEventsDedupesAndSorts(t *testing.T) {
+	events := []EventSummary{
+		{Path: "pkg/types.go"},
+		{Path: "main.go"},
+		{Path: "pkg/types.go"},
+		{Path: "a.go"},
+	}
+
+	got := changedFromEvents(events)
+	want := []string{"a.go", "main.go", "pkg/types.go"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("changedFromEvents() = %v, want %v", got, want)
+	}
+}
+
+func TestPrioritizeChangedPathsPrefersRiskBeforeRemainingOrder(t *testing.T) {
+	changed := []string{"a.go", "b.go", "c.go", "d.go"}
+	risk := []RiskFile{
+		{Path: "c.go", Importers: 5},
+		{Path: "missing.go", Importers: 4},
+		{Path: "a.go", Importers: 3},
+	}
+
+	got := prioritizeChangedPaths(changed, risk, 3)
+	want := []string{"c.go", "a.go", "b.go"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("prioritizeChangedPaths() = %v, want %v", got, want)
+	}
+}
+
+func TestBuildCacheMetricsTracksReuseAccounting(t *testing.T) {
+	previous := &Artifact{
+		CombinedHash: "combined",
+		PrefixHash:   "prefix",
+		DeltaHash:    "delta",
+	}
+
+	got := buildCacheMetrics(previous, "prefix", "delta", 20, 30)
+	if !got.PrefixReused || !got.DeltaReused {
+		t.Fatalf("expected both layers to be reused, got %+v", got)
+	}
+	if got.UnchangedBytes != 50 || got.TotalBytes != 50 {
+		t.Fatalf("unexpected byte accounting: %+v", got)
+	}
+	if got.ReuseRatio != 1 {
+		t.Fatalf("expected reuse ratio 1, got %v", got.ReuseRatio)
+	}
+	if got.PreviousCombinedHash != "combined" {
+		t.Fatalf("previous combined hash = %q, want combined", got.PreviousCombinedHash)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -22,6 +22,27 @@ import (
 	"codemap/watch"
 )
 
+type watchProcess interface {
+	Start() error
+	Stop()
+	FileCount() int
+	GetEvents(limit int) []watch.Event
+}
+
+var (
+	newWatchProcess = func(root string, verbose bool) (watchProcess, error) {
+		return watch.NewDaemon(root, verbose)
+	}
+	watchIsRunning  = watch.IsRunning
+	stopWatchDaemon = watch.Stop
+	writeWatchPID   = watch.WritePID
+	removeWatchPID  = watch.RemovePID
+	executablePath  = os.Executable
+	execCommand     = exec.Command
+	notifySignals   = signal.Notify
+	terminalChecker = isTerminal
+)
+
 func main() {
 	// Handle "watch" subcommand before flag parsing
 	if len(os.Args) >= 2 && os.Args[1] == "watch" {
@@ -350,7 +371,7 @@ func runWatchMode(root string, verbose bool) {
 	fmt.Println("codemap watch - Live code graph daemon")
 	fmt.Println()
 
-	daemon, err := watch.NewDaemon(root, verbose)
+	daemon, err := newWatchProcess(root, verbose)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
@@ -370,7 +391,7 @@ func runWatchMode(root string, verbose bool) {
 
 	// Wait for interrupt
 	sigChan := make(chan os.Signal, 1)
-	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
+	notifySignals(sigChan, os.Interrupt, syscall.SIGTERM)
 	<-sigChan
 
 	fmt.Println()
@@ -445,17 +466,17 @@ func runWatchSubcommand(subCmd, root string) {
 
 	switch subCmd {
 	case "start":
-		if watch.IsRunning(absRoot) {
+		if watchIsRunning(absRoot) {
 			fmt.Println("Watch daemon already running")
 			return
 		}
 		// Fork a background daemon
-		exe, err := os.Executable()
+		exe, err := executablePath()
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 			os.Exit(1)
 		}
-		cmd := exec.Command(exe, "watch", "daemon", absRoot)
+		cmd := execCommand(exe, "watch", "daemon", absRoot)
 		cmd.Stdout = nil
 		cmd.Stderr = nil
 		cmd.Stdin = nil
@@ -472,18 +493,18 @@ func runWatchSubcommand(subCmd, root string) {
 		runDaemon(absRoot)
 
 	case "stop":
-		if !watch.IsRunning(absRoot) {
+		if !watchIsRunning(absRoot) {
 			fmt.Println("Watch daemon not running")
 			return
 		}
-		if err := watch.Stop(absRoot); err != nil {
+		if err := stopWatchDaemon(absRoot); err != nil {
 			fmt.Fprintf(os.Stderr, "Error stopping daemon: %v\n", err)
 			os.Exit(1)
 		}
 		fmt.Println("Watch daemon stopped")
 
 	case "status":
-		if watch.IsRunning(absRoot) {
+		if watchIsRunning(absRoot) {
 			state := watch.ReadState(absRoot)
 			if state != nil {
 				fmt.Printf("Watch daemon running\n")
@@ -636,7 +657,7 @@ func runHandoffSubcommand(args []string) {
 }
 
 func runDaemon(root string) {
-	daemon, err := watch.NewDaemon(root, false)
+	daemon, err := newWatchProcess(root, false)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
@@ -648,15 +669,15 @@ func runDaemon(root string) {
 	}
 
 	// Write PID file
-	watch.WritePID(root)
+	writeWatchPID(root)
 
 	// Wait for stop signal (SIGTERM or state file removal)
 	sigChan := make(chan os.Signal, 1)
-	signal.Notify(sigChan, syscall.SIGTERM, syscall.SIGINT)
+	notifySignals(sigChan, syscall.SIGTERM, syscall.SIGINT)
 	<-sigChan
 
 	daemon.Stop()
-	watch.RemovePID(root)
+	removeWatchPID(root)
 }
 
 // isGitHubURL checks if the input looks like a GitHub repo URL
@@ -683,7 +704,7 @@ func cloneRepo(url string, repoName string) (string, error) {
 	}
 
 	// Only animate if stderr is a real terminal
-	isTTY := isTerminal(os.Stderr)
+	isTTY := terminalChecker(os.Stderr)
 
 	var done chan bool
 	if isTTY {
@@ -709,7 +730,7 @@ func cloneRepo(url string, repoName string) (string, error) {
 	}
 
 	// Shallow clone (quiet)
-	cmd := exec.Command("git", "clone", "--depth", "1", "--single-branch", "-q", url, tempDir)
+	cmd := execCommand("git", "clone", "--depth", "1", "--single-branch", "-q", url, tempDir)
 	cloneErr := cmd.Run()
 
 	if isTTY {

--- a/main_helpers_test.go
+++ b/main_helpers_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bytes"
 	"encoding/json"
 	"flag"
 	"io"
@@ -194,25 +193,28 @@ func TestMainJSONModeUsesConfigDefaults(t *testing.T) {
 func captureMainOutput(fn func()) string {
 	oldStdout := os.Stdout
 	oldStderr := os.Stderr
-	r, w, err := os.Pipe()
+	outFile, err := os.CreateTemp("", "codemap-main-output-*")
 	if err != nil {
 		panic(err)
 	}
-	defer r.Close()
+	defer os.Remove(outFile.Name())
 
-	os.Stdout = w
-	os.Stderr = w
-	defer func() {
-		os.Stdout = oldStdout
-		os.Stderr = oldStderr
+	func() {
+		defer func() {
+			_ = outFile.Close()
+			os.Stdout = oldStdout
+			os.Stderr = oldStderr
+		}()
+		os.Stdout = outFile
+		os.Stderr = outFile
+		fn()
 	}()
 
-	fn()
-	_ = w.Close()
-
-	var buf bytes.Buffer
-	_, _ = io.Copy(&buf, r)
-	return buf.String()
+	data, err := os.ReadFile(outFile.Name())
+	if err != nil {
+		panic(err)
+	}
+	return string(data)
 }
 
 func runMainWithArgs(t *testing.T, args []string) string {

--- a/main_more_test.go
+++ b/main_more_test.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -15,6 +16,87 @@ import (
 	"codemap/scanner"
 	"codemap/watch"
 )
+
+type fakeWatchProcess struct {
+	startErr  error
+	started   bool
+	stopped   bool
+	fileCount int
+	events    []watch.Event
+}
+
+func (f *fakeWatchProcess) Start() error {
+	f.started = true
+	return f.startErr
+}
+
+func (f *fakeWatchProcess) Stop() {
+	f.stopped = true
+}
+
+func (f *fakeWatchProcess) FileCount() int {
+	return f.fileCount
+}
+
+func (f *fakeWatchProcess) GetEvents(limit int) []watch.Event {
+	if limit <= 0 || len(f.events) <= limit {
+		return append([]watch.Event(nil), f.events...)
+	}
+	return append([]watch.Event(nil), f.events[len(f.events)-limit:]...)
+}
+
+func withMainRuntimeStubs(
+	t *testing.T,
+	watchFactory func(root string, verbose bool) (watchProcess, error),
+	signalNotifier func(c chan<- os.Signal, sig ...os.Signal),
+	cmdFactory func(name string, args ...string) *exec.Cmd,
+	exePath func() (string, error),
+	isRunning func(string) bool,
+	stopWatch func(string) error,
+	terminal func(*os.File) bool,
+) {
+	t.Helper()
+
+	prevWatchFactory := newWatchProcess
+	prevNotifier := notifySignals
+	prevCmdFactory := execCommand
+	prevExePath := executablePath
+	prevIsRunning := watchIsRunning
+	prevStopWatch := stopWatchDaemon
+	prevTerminal := terminalChecker
+
+	if watchFactory != nil {
+		newWatchProcess = watchFactory
+	}
+	if signalNotifier != nil {
+		notifySignals = signalNotifier
+	}
+	if cmdFactory != nil {
+		execCommand = cmdFactory
+	}
+	if exePath != nil {
+		executablePath = exePath
+	}
+	if isRunning != nil {
+		watchIsRunning = isRunning
+	}
+	if stopWatch != nil {
+		stopWatchDaemon = stopWatch
+	}
+	if terminal != nil {
+		terminalChecker = terminal
+	}
+
+	t.Cleanup(func() {
+		newWatchProcess = prevWatchFactory
+		notifySignals = prevNotifier
+		execCommand = prevCmdFactory
+		executablePath = prevExePath
+		watchIsRunning = prevIsRunning
+		stopWatchDaemon = prevStopWatch
+		terminalChecker = prevTerminal
+	})
+}
 
 func captureMainStreams(t *testing.T, fn func()) (string, string) {
 	t.Helper()
@@ -58,7 +140,7 @@ func captureMainStreams(t *testing.T, fn func()) (string, string) {
 }
 
 func runCodemapWithInput(input string, args ...string) (string, string, error) {
-	cmd := exec.Command("./codemap_test_binary", args...)
+	cmd := exec.Command(codemapTestBinaryPath, args...)
 	if input != "" {
 		cmd.Stdin = strings.NewReader(input)
 	}
@@ -68,6 +150,15 @@ func runCodemapWithInput(input string, args ...string) (string, string, error) {
 	cmd.Stderr = &stderr
 	err := cmd.Run()
 	return out.String(), stderr.String(), err
+}
+
+func runGitMainTestCmd(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v failed: %v\n%s", args, err, string(out))
+	}
 }
 
 func writeMainWatchState(t *testing.T, root string, state watch.State, running bool) {
@@ -111,6 +202,18 @@ func writeImportersFixture(t *testing.T, root string) {
 			t.Fatal(err)
 		}
 	}
+}
+
+func makeMainGitRepo(t *testing.T, branch string) string {
+	t.Helper()
+
+	root := t.TempDir()
+	writeImportersFixture(t, root)
+	runGitMainTestCmd(t, root, "init")
+	runGitMainTestCmd(t, root, "add", ".")
+	runGitMainTestCmd(t, root, "-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "-m", "init")
+	runGitMainTestCmd(t, root, "branch", "-M", branch)
+	return root
 }
 
 func TestRunWatchSubcommandMessages(t *testing.T) {
@@ -194,6 +297,384 @@ func TestRunImportersMode(t *testing.T) {
 		if !strings.Contains(stdout, check) {
 			t.Fatalf("expected %q in output, got:\n%s", check, stdout)
 		}
+	}
+}
+
+func TestRunDepsModeJSONAndMainDispatchesDepsAndImporters(t *testing.T) {
+	if !scanner.NewAstGrepAnalyzer().Available() {
+		t.Skip("ast-grep not available")
+	}
+
+	root := t.TempDir()
+	writeImportersFixture(t, root)
+
+	stdout, _ := captureMainStreams(t, func() {
+		runDepsMode(root, root, true, "main", map[string]bool{"a/a.go": true})
+	})
+
+	var depsProject scanner.DepsProject
+	if err := json.Unmarshal([]byte(stdout), &depsProject); err != nil {
+		t.Fatalf("expected deps JSON output, got error %v with body:\n%s", err, stdout)
+	}
+	if depsProject.Mode != "deps" {
+		t.Fatalf("deps mode = %q, want deps", depsProject.Mode)
+	}
+	if depsProject.DiffRef != "main" {
+		t.Fatalf("deps diff_ref = %q, want main", depsProject.DiffRef)
+	}
+	if len(depsProject.Files) != 1 || depsProject.Files[0].Path != "a/a.go" {
+		t.Fatalf("expected diff filter to keep only a/a.go, got %+v", depsProject.Files)
+	}
+
+	stdout = runMainWithArgs(t, []string{"codemap", "--deps", "--json", root})
+	if err := json.Unmarshal([]byte(stdout), &depsProject); err != nil {
+		t.Fatalf("expected main deps JSON output, got error %v with body:\n%s", err, stdout)
+	}
+	if depsProject.Mode != "deps" || len(depsProject.Files) == 0 {
+		t.Fatalf("expected deps project output, got %+v", depsProject)
+	}
+
+	stdout = runMainWithArgs(t, []string{"codemap", "--importers", "main.go", root})
+	if !strings.Contains(stdout, "File: main.go") {
+		t.Fatalf("expected importers output for main.go, got:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, "Imports 1 hub(s): pkg/types/types.go") {
+		t.Fatalf("expected hub import summary for main.go, got:\n%s", stdout)
+	}
+}
+
+func TestRunHandoffSubcommandBuildAndDetailJSON(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	root := makeMainGitRepo(t, "feature/handoff-main")
+	if err := os.WriteFile(filepath.Join(root, "pkg", "types", "types.go"), []byte("package types\n\ntype Item struct{ Value string }\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	writeMainWatchState(t, root, watch.State{
+		UpdatedAt: time.Now(),
+		FileCount: 5,
+		Importers: map[string][]string{
+			"pkg/types/types.go": {"a/a.go", "b/b.go", "c/c.go", "main.go"},
+		},
+		Imports: map[string][]string{
+			"main.go": {"pkg/types/types.go"},
+		},
+		RecentEvents: []watch.Event{
+			{Time: time.Now().Add(-time.Minute), Op: "WRITE", Path: "pkg/types/types.go", Delta: 2, IsHub: true},
+		},
+	}, false)
+
+	stdout, _ := captureMainStreams(t, func() {
+		runHandoffSubcommand([]string{"--json", "--no-save", root})
+	})
+
+	var artifact handoff.Artifact
+	if err := json.Unmarshal([]byte(stdout), &artifact); err != nil {
+		t.Fatalf("expected handoff JSON output, got error %v with body:\n%s", err, stdout)
+	}
+	if artifact.Branch != "feature/handoff-main" {
+		t.Fatalf("artifact branch = %q, want feature/handoff-main", artifact.Branch)
+	}
+	if len(artifact.Delta.Changed) == 0 || artifact.Delta.Changed[0].Path != "pkg/types/types.go" {
+		t.Fatalf("expected changed type file in artifact, got %+v", artifact.Delta.Changed)
+	}
+	if _, err := os.Stat(handoff.LatestPath(root)); !os.IsNotExist(err) {
+		t.Fatalf("expected --no-save to skip latest artifact write, got err=%v", err)
+	}
+
+	stdout, _ = captureMainStreams(t, func() {
+		runHandoffSubcommand([]string{root})
+	})
+	for _, check := range []string{"# Handoff", "Saved:", "Prefix:", "Delta:", "Metrics:"} {
+		if !strings.Contains(stdout, check) {
+			t.Fatalf("expected %q in handoff output, got:\n%s", check, stdout)
+		}
+	}
+
+	stdout, _ = captureMainStreams(t, func() {
+		runHandoffSubcommand([]string{"--latest", "--detail", "pkg/types/types.go", "--json", root})
+	})
+
+	var detail handoff.FileDetail
+	if err := json.Unmarshal([]byte(stdout), &detail); err != nil {
+		t.Fatalf("expected handoff detail JSON output, got error %v with body:\n%s", err, stdout)
+	}
+	if detail.Path != "pkg/types/types.go" {
+		t.Fatalf("detail path = %q, want pkg/types/types.go", detail.Path)
+	}
+	if len(detail.Importers) != 4 {
+		t.Fatalf("expected 4 importers in detail, got %+v", detail.Importers)
+	}
+}
+
+func TestRunWatchModeRunDaemonAndWatchStart(t *testing.T) {
+	t.Run("watch mode prints summary after interrupt", func(t *testing.T) {
+		fake := &fakeWatchProcess{
+			fileCount: 7,
+			events: []watch.Event{
+				{Path: "main.go", Op: "WRITE"},
+				{Path: "pkg/types.go", Op: "CREATE"},
+			},
+		}
+		withMainRuntimeStubs(
+			t,
+			func(root string, verbose bool) (watchProcess, error) { return fake, nil },
+			func(c chan<- os.Signal, sig ...os.Signal) { c <- os.Interrupt },
+			nil,
+			nil,
+			nil,
+			nil,
+			nil,
+		)
+
+		stdout, _ := captureMainStreams(t, func() { runWatchMode(t.TempDir(), false) })
+		for _, check := range []string{"codemap watch - Live code graph daemon", "Watching:", "Press Ctrl+C to stop", "Session summary:", "Files tracked: 7", "Events logged: 2"} {
+			if !strings.Contains(stdout, check) {
+				t.Fatalf("expected %q in watch mode output, got:\n%s", check, stdout)
+			}
+		}
+		if !fake.started || !fake.stopped {
+			t.Fatalf("expected fake watch process to start and stop, got %+v", fake)
+		}
+	})
+
+	t.Run("daemon writes and removes pid around lifecycle", func(t *testing.T) {
+		fake := &fakeWatchProcess{}
+		root := t.TempDir()
+		withMainRuntimeStubs(
+			t,
+			func(root string, verbose bool) (watchProcess, error) { return fake, nil },
+			func(c chan<- os.Signal, sig ...os.Signal) { c <- syscall.SIGTERM },
+			nil,
+			nil,
+			nil,
+			nil,
+			nil,
+		)
+
+		runDaemon(root)
+		if !fake.started || !fake.stopped {
+			t.Fatalf("expected fake daemon to start and stop, got %+v", fake)
+		}
+		if _, err := os.Stat(filepath.Join(root, ".codemap", "watch.pid")); !os.IsNotExist(err) {
+			t.Fatalf("expected pid file to be removed after daemon stops, got err=%v", err)
+		}
+	})
+
+	t.Run("watch start shells out to daemon entrypoint", func(t *testing.T) {
+		root := t.TempDir()
+		var gotName string
+		var gotArgs []string
+		withMainRuntimeStubs(
+			t,
+			nil,
+			nil,
+			func(name string, args ...string) *exec.Cmd {
+				gotName = name
+				gotArgs = append([]string(nil), args...)
+				return exec.Command("sh", "-c", "exit 0")
+			},
+			func() (string, error) { return "/tmp/codemap-test", nil },
+			func(string) bool { return false },
+			nil,
+			nil,
+		)
+
+		stdout, _ := captureMainStreams(t, func() { runWatchSubcommand("start", root) })
+		if gotName != "/tmp/codemap-test" {
+			t.Fatalf("watch start executable = %q, want /tmp/codemap-test", gotName)
+		}
+		absRoot, _ := filepath.Abs(root)
+		wantArgs := []string{"watch", "daemon", absRoot}
+		if strings.Join(gotArgs, "|") != strings.Join(wantArgs, "|") {
+			t.Fatalf("watch start args = %v, want %v", gotArgs, wantArgs)
+		}
+		if !strings.Contains(stdout, "Watch daemon started (pid ") {
+			t.Fatalf("expected start output, got:\n%s", stdout)
+		}
+	})
+}
+
+func TestCloneRepoUsesCommandAndCleansUpOnFailure(t *testing.T) {
+	withMainRuntimeStubs(
+		t,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		func(*os.File) bool { return false },
+	)
+
+	t.Run("success", func(t *testing.T) {
+		var gotName string
+		var gotArgs []string
+		withMainRuntimeStubs(
+			t,
+			nil,
+			nil,
+			func(name string, args ...string) *exec.Cmd {
+				gotName = name
+				gotArgs = append([]string(nil), args...)
+				dest := args[len(args)-1]
+				return exec.Command("sh", "-c", `mkdir -p "$1/.git"; echo ok > "$1/README.md"`, "sh", dest)
+			},
+			nil,
+			nil,
+			nil,
+			func(*os.File) bool { return false },
+		)
+
+		dir, err := cloneRepo("github.com/acme/codemap", "acme/codemap")
+		if err != nil {
+			t.Fatalf("cloneRepo() error: %v", err)
+		}
+		t.Cleanup(func() { _ = os.RemoveAll(dir) })
+		if gotName != "git" {
+			t.Fatalf("cloneRepo command = %q, want git", gotName)
+		}
+		wantPrefix := []string{"clone", "--depth", "1", "--single-branch", "-q", "https://github.com/acme/codemap"}
+		if strings.Join(gotArgs[:len(wantPrefix)], "|") != strings.Join(wantPrefix, "|") {
+			t.Fatalf("cloneRepo args = %v, want prefix %v", gotArgs, wantPrefix)
+		}
+		if _, err := os.Stat(filepath.Join(dir, "README.md")); err != nil {
+			t.Fatalf("expected cloned README to exist: %v", err)
+		}
+	})
+
+	t.Run("failure removes temp dir", func(t *testing.T) {
+		var failedDest string
+		withMainRuntimeStubs(
+			t,
+			nil,
+			nil,
+			func(name string, args ...string) *exec.Cmd {
+				failedDest = args[len(args)-1]
+				return exec.Command("sh", "-c", "exit 1")
+			},
+			nil,
+			nil,
+			nil,
+			func(*os.File) bool { return false },
+		)
+
+		dir, err := cloneRepo("gitlab.com/acme/codemap", "acme/codemap")
+		if err == nil {
+			t.Fatal("expected cloneRepo failure")
+		}
+		if dir != "" {
+			t.Fatalf("expected empty dir on clone failure, got %q", dir)
+		}
+		if _, statErr := os.Stat(failedDest); !os.IsNotExist(statErr) {
+			t.Fatalf("expected failed clone temp dir to be removed, got err=%v", statErr)
+		}
+	})
+}
+
+func TestMainWatchCloneAndDiffModes(t *testing.T) {
+	t.Run("watch flag dispatches to watch mode", func(t *testing.T) {
+		fake := &fakeWatchProcess{fileCount: 3, events: []watch.Event{{Path: "main.go", Op: "WRITE"}}}
+		withMainRuntimeStubs(
+			t,
+			func(root string, verbose bool) (watchProcess, error) { return fake, nil },
+			func(c chan<- os.Signal, sig ...os.Signal) { c <- os.Interrupt },
+			nil,
+			nil,
+			nil,
+			nil,
+			nil,
+		)
+
+		stdout := runMainWithArgs(t, []string{"codemap", "--watch", t.TempDir()})
+		if !strings.Contains(stdout, "codemap watch - Live code graph daemon") || !strings.Contains(stdout, "Events logged: 1") {
+			t.Fatalf("expected watch mode output, got:\n%s", stdout)
+		}
+	})
+
+	t.Run("github url path clones and renders json project", func(t *testing.T) {
+		withMainRuntimeStubs(
+			t,
+			nil,
+			nil,
+			func(name string, args ...string) *exec.Cmd {
+				dest := args[len(args)-1]
+				return exec.Command("sh", "-c", `mkdir -p "$1"; printf 'package main\n' > "$1/main.go"`, "sh", dest)
+			},
+			nil,
+			nil,
+			nil,
+			func(*os.File) bool { return false },
+		)
+
+		stdout := runMainWithArgs(t, []string{"codemap", "--json", "github.com/acme/codemap"})
+		var project scanner.Project
+		if err := json.Unmarshal([]byte(stdout), &project); err != nil {
+			t.Fatalf("expected cloned project JSON output, got error %v with body:\n%s", err, stdout)
+		}
+		if project.Name != "acme/codemap" {
+			t.Fatalf("project name = %q, want acme/codemap", project.Name)
+		}
+		if project.RemoteURL != "github.com/acme/codemap" {
+			t.Fatalf("project remote URL = %q, want github.com/acme/codemap", project.RemoteURL)
+		}
+		if len(project.Files) != 1 || project.Files[0].Path != "main.go" {
+			t.Fatalf("expected cloned project files to include main.go, got %+v", project.Files)
+		}
+	})
+
+	t.Run("diff json includes changed file annotations", func(t *testing.T) {
+		if _, err := exec.LookPath("git"); err != nil {
+			t.Skip("git not available")
+		}
+
+		root := makeMainGitRepo(t, "main")
+		if err := os.WriteFile(filepath.Join(root, "main.go"), []byte("package main\n\nfunc changed() {}\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		stdout := runMainWithArgs(t, []string{"codemap", "--json", "--diff", "--ref", "HEAD", root})
+		var project scanner.Project
+		if err := json.Unmarshal([]byte(stdout), &project); err != nil {
+			t.Fatalf("expected diff project JSON output, got error %v with body:\n%s", err, stdout)
+		}
+		if project.DiffRef != "HEAD" {
+			t.Fatalf("project diff_ref = %q, want HEAD", project.DiffRef)
+		}
+		if len(project.Files) != 1 || project.Files[0].Path != "main.go" {
+			t.Fatalf("expected only changed main.go in diff output, got %+v", project.Files)
+		}
+		if project.Files[0].Added == 0 && project.Files[0].Removed == 0 {
+			t.Fatalf("expected diff annotations on changed file, got %+v", project.Files[0])
+		}
+	})
+}
+
+func TestRunDepsModeRenderedOutputAndMainTreeModes(t *testing.T) {
+	if !scanner.NewAstGrepAnalyzer().Available() {
+		t.Skip("ast-grep not available")
+	}
+
+	root := t.TempDir()
+	writeImportersFixture(t, root)
+
+	stdout, _ := captureMainStreams(t, func() {
+		runDepsMode(root, root, false, "main", nil)
+	})
+	if !strings.Contains(stdout, "Dependency Flow") {
+		t.Fatalf("expected rendered dependency graph output, got:\n%s", stdout)
+	}
+
+	stdout = runMainWithArgs(t, []string{"codemap", root})
+	if !strings.Contains(stdout, "Files:") {
+		t.Fatalf("expected tree mode output, got:\n%s", stdout)
+	}
+
+	stdout = runMainWithArgs(t, []string{"codemap", "--skyline", root})
+	if strings.TrimSpace(stdout) == "" {
+		t.Fatal("expected skyline output")
 	}
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -12,20 +12,29 @@ import (
 	"codemap/scanner"
 )
 
+var codemapTestBinaryPath string
+
 // TestMain runs before all tests
 func TestMain(m *testing.M) {
+	tmpDir, err := os.MkdirTemp("", "codemap-test-bin-*")
+	if err != nil {
+		os.Exit(1)
+	}
+	codemapTestBinaryPath = filepath.Join(tmpDir, "codemap_test_binary")
+
 	// Build the binary for integration tests
-	cmd := exec.Command("go", "build", "-o", "codemap_test_binary", ".")
+	cmd := exec.Command("go", "build", "-o", codemapTestBinaryPath, ".")
 	if err := cmd.Run(); err != nil {
+		_ = os.RemoveAll(tmpDir)
 		os.Exit(1)
 	}
 	code := m.Run()
-	os.Remove("codemap_test_binary")
+	_ = os.RemoveAll(tmpDir)
 	os.Exit(code)
 }
 
 func runCodemap(args ...string) (string, error) {
-	cmd := exec.Command("./codemap_test_binary", args...)
+	cmd := exec.Command(codemapTestBinaryPath, args...)
 	var out bytes.Buffer
 	var stderr bytes.Buffer
 	cmd.Stdout = &out

--- a/scanner/integration_more_test.go
+++ b/scanner/integration_more_test.go
@@ -1,0 +1,82 @@
+package scanner
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeScannerDepsFixture(t *testing.T, root string) {
+	t.Helper()
+
+	files := map[string]string{
+		"go.mod":             "module example.com/demo\n\ngo 1.22\n",
+		"pkg/types/types.go": "package types\n\ntype Item struct{}\n",
+		"a/a.go":             "package a\n\nimport _ \"example.com/demo/pkg/types\"\n\nfunc UseA() {}\n",
+		"b/b.go":             "package b\n\nimport _ \"example.com/demo/pkg/types\"\n\nfunc UseB() {}\n",
+		"c/c.go":             "package c\n\nimport _ \"example.com/demo/pkg/types\"\n\nfunc UseC() {}\n",
+		"main.go":            "package main\n\nimport _ \"example.com/demo/pkg/types\"\n\nfunc main() {}\n",
+	}
+	for path, content := range files {
+		full := filepath.Join(root, path)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func TestScanForDepsBuildFileGraphAndAnalyzeImpact(t *testing.T) {
+	if !NewAstGrepAnalyzer().Available() {
+		t.Skip("ast-grep not available")
+	}
+
+	root := t.TempDir()
+	writeScannerDepsFixture(t, root)
+
+	analyses, err := ScanForDeps(root)
+	if err != nil {
+		t.Fatalf("ScanForDeps() error: %v", err)
+	}
+	byPath := make(map[string]FileAnalysis, len(analyses))
+	for _, analysis := range analyses {
+		byPath[analysis.Path] = analysis
+	}
+	if got := byPath["a/a.go"].Imports; len(got) != 1 || got[0] != "example.com/demo/pkg/types" {
+		t.Fatalf("expected a/a.go to import types package, got %+v", got)
+	}
+	if got := byPath["main.go"].Functions; len(got) != 1 || got[0] != "main" {
+		t.Fatalf("expected main.go to expose main(), got %+v", got)
+	}
+
+	fg, err := BuildFileGraph(root)
+	if err != nil {
+		t.Fatalf("BuildFileGraph() error: %v", err)
+	}
+	if fg.Module != "example.com/demo" {
+		t.Fatalf("file graph module = %q, want example.com/demo", fg.Module)
+	}
+	if got := fg.Importers["pkg/types/types.go"]; len(got) != 4 {
+		t.Fatalf("expected 4 importers for pkg/types/types.go, got %+v", got)
+	}
+	if !fg.IsHub("pkg/types/types.go") {
+		t.Fatal("expected pkg/types/types.go to be detected as a hub")
+	}
+
+	impacts := AnalyzeImpact(root, []FileInfo{{Path: "pkg/types/types.go"}})
+	if len(impacts) == 0 {
+		t.Fatal("expected AnalyzeImpact to report at least one impacted file")
+	}
+
+	maxUsedBy := 0
+	for _, impact := range impacts {
+		if impact.UsedBy > maxUsedBy {
+			maxUsedBy = impact.UsedBy
+		}
+	}
+	if maxUsedBy < 4 {
+		t.Fatalf("expected impacted file usage count >= 4, got %+v", impacts)
+	}
+}

--- a/watch/more_test.go
+++ b/watch/more_test.go
@@ -1,0 +1,186 @@
+package watch
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"slices"
+	"testing"
+	"time"
+
+	"codemap/scanner"
+)
+
+func waitForWatchCondition(t *testing.T, timeout time.Duration, cond func() bool) {
+	t.Helper()
+
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatal("timed out waiting for watch condition")
+}
+
+func runGitWatchTestCmd(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v failed: %v\n%s", args, err, string(out))
+	}
+}
+
+func TestGetGraphWriteInitialStateAndFindRelatedHot(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".codemap"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	d := &Daemon{
+		root: root,
+		graph: &Graph{
+			Files: map[string]*scanner.FileInfo{
+				"pkg/types.go": {Path: "pkg/types.go"},
+				"main.go":      {Path: "main.go"},
+				"other.go":     {Path: "other.go"},
+			},
+			Events: []Event{
+				{Time: time.Now().Add(-10 * time.Minute), Op: "WRITE", Path: "stale.go"},
+				{Time: time.Now().Add(-30 * time.Second), Op: "WRITE", Path: "main.go"},
+				{Time: time.Now().Add(-15 * time.Second), Op: "CREATE", Path: "other.go"},
+			},
+			FileGraph: &scanner.FileGraph{
+				Imports: map[string][]string{
+					"main.go": {"pkg/types.go"},
+				},
+				Importers: map[string][]string{
+					"pkg/types.go": {"main.go", "other.go"},
+				},
+			},
+		},
+	}
+
+	if got := d.GetGraph(); got != d.graph {
+		t.Fatal("expected GetGraph to return the active graph pointer")
+	}
+
+	hot := d.findRelatedHot("pkg/types.go", time.Minute)
+	slices.Sort(hot)
+	if len(hot) != 2 || hot[0] != "main.go" || hot[1] != "other.go" {
+		t.Fatalf("findRelatedHot() = %v, want [main.go other.go]", hot)
+	}
+
+	d.WriteInitialState()
+	data, err := os.ReadFile(filepath.Join(root, ".codemap", "state.json"))
+	if err != nil {
+		t.Fatalf("expected state file to be written: %v", err)
+	}
+
+	var state State
+	if err := json.Unmarshal(data, &state); err != nil {
+		t.Fatalf("expected valid state JSON: %v", err)
+	}
+	if state.FileCount != 3 {
+		t.Fatalf("state file_count = %d, want 3", state.FileCount)
+	}
+	if len(state.RecentEvents) != 3 {
+		t.Fatalf("state recent events = %d, want 3", len(state.RecentEvents))
+	}
+	if len(state.Importers["pkg/types.go"]) != 2 {
+		t.Fatalf("expected importers to be persisted, got %+v", state.Importers)
+	}
+}
+
+func TestIsFileDirty(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	root := t.TempDir()
+	runGitWatchTestCmd(t, root, "init")
+	file := filepath.Join(root, "main.go")
+	if err := os.WriteFile(file, []byte("package main\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGitWatchTestCmd(t, root, "add", ".")
+	runGitWatchTestCmd(t, root, "-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "-m", "init")
+
+	if isFileDirty(root, "main.go") {
+		t.Fatal("expected committed file to be clean")
+	}
+
+	if err := os.WriteFile(file, []byte("package main\n\nfunc changed() {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if !isFileDirty(root, "main.go") {
+		t.Fatal("expected modified file to be dirty")
+	}
+}
+
+func TestDaemonStartTracksWriteEventsAndState(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	root := t.TempDir()
+	runGitWatchTestCmd(t, root, "init")
+	file := filepath.Join(root, "main.go")
+	if err := os.WriteFile(file, []byte("package main\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGitWatchTestCmd(t, root, "add", ".")
+	runGitWatchTestCmd(t, root, "-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "-m", "init")
+
+	d, err := NewDaemon(root, false)
+	if err != nil {
+		t.Fatalf("NewDaemon() error: %v", err)
+	}
+	defer d.Stop()
+
+	if err := d.Start(); err != nil {
+		t.Fatalf("Start() error: %v", err)
+	}
+
+	waitForWatchCondition(t, 2*time.Second, func() bool {
+		state := ReadState(root)
+		return state != nil && state.FileCount >= 1
+	})
+
+	if err := os.WriteFile(file, []byte("package main\n\nfunc changed() {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	waitForWatchCondition(t, 2*time.Second, func() bool {
+		events := d.GetEvents(0)
+		return len(events) > 0
+	})
+
+	events := d.GetEvents(0)
+	last := events[len(events)-1]
+	if last.Path != "main.go" {
+		t.Fatalf("last event path = %q, want main.go", last.Path)
+	}
+	if last.Op != "WRITE" && last.Op != "CREATE" {
+		t.Fatalf("last event op = %q, want WRITE or CREATE", last.Op)
+	}
+	if !last.Dirty {
+		t.Fatalf("expected modified file event to be marked dirty, got %+v", last)
+	}
+	if last.Delta <= 0 {
+		t.Fatalf("expected positive line delta for write event, got %+v", last)
+	}
+
+	waitForWatchCondition(t, 2*time.Second, func() bool {
+		state := ReadState(root)
+		return state != nil && len(state.RecentEvents) > 0
+	})
+
+	state := ReadState(root)
+	if state == nil || len(state.RecentEvents) == 0 {
+		t.Fatalf("expected watch state with recent events, got %+v", state)
+	}
+}


### PR DESCRIPTION
## Summary
- raise total coverage from 71.7% to 77.5%
- add direct in-process coverage for main CLI paths, scanner graph/deps integration, handoff helpers, watch helpers, and cmd daemon shellout paths
- replace pipe-based stdout capture helpers that were causing blocked tests during larger output and coverage runs

## Coverage
- total: 77.5%
- root package: 61.2%
- scanner: 81.2%
- handoff: 80.2%
- watch: 76.4%

## Validation
- `staticcheck ./...`
- `go test ./... -count=1`
- `go test -coverprofile=/tmp/codemap-final2.cover ./...`
- `go tool cover -func=/tmp/codemap-final2.cover`

## Remaining gap to 80%
- `main.go`: remaining branch coverage in `main`, `cloneRepo`, `runHandoffSubcommand`, `runWatchSubcommand`
- `cmd/hooks.go`: `RunHook`, `showDiffVsMain`, and some hook orchestration paths
- `mcp/main.go`: still has meaningful uncovered handler surface
