### PR TITLE
feat: context protocol, HTTP API, and agent-aware handoff

### DIFF
--- a/cmd/context.go
+++ b/cmd/context.go
@@ -1,0 +1,223 @@
+package cmd
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"codemap/config"
+	"codemap/handoff"
+	"codemap/scanner"
+	"codemap/skills"
+	"codemap/watch"
+)
+
+// ContextEnvelope is the standardized output format that any AI tool can consume.
+type ContextEnvelope struct {
+	Version    int            `json:"version"`
+	GeneratedAt time.Time    `json:"generated_at"`
+	Project    ProjectContext `json:"project"`
+	Intent     *TaskIntent   `json:"intent,omitempty"`
+	WorkingSet *WorkingSetContext `json:"working_set,omitempty"`
+	Skills     []SkillRef    `json:"skills,omitempty"`
+	Handoff    *HandoffRef   `json:"handoff,omitempty"`
+	Budget     BudgetInfo    `json:"budget"`
+}
+
+// ProjectContext contains high-level project metadata.
+type ProjectContext struct {
+	Root      string   `json:"root"`
+	Branch    string   `json:"branch"`
+	FileCount int      `json:"file_count"`
+	Languages []string `json:"languages"`
+	HubCount  int      `json:"hub_count"`
+	TopHubs   []string `json:"top_hubs,omitempty"`
+}
+
+// WorkingSetContext is a summary of the current working set.
+type WorkingSetContext struct {
+	FileCount int                   `json:"file_count"`
+	HubCount  int                   `json:"hub_count"`
+	TopFiles  []WorkingFileContext  `json:"top_files,omitempty"`
+}
+
+// WorkingFileContext is a single file in the working set summary.
+type WorkingFileContext struct {
+	Path      string `json:"path"`
+	EditCount int    `json:"edit_count"`
+	NetDelta  int    `json:"net_delta"`
+	IsHub     bool   `json:"is_hub,omitempty"`
+}
+
+// SkillRef is a lightweight reference to a matched skill.
+type SkillRef struct {
+	Name   string `json:"name"`
+	Score  int    `json:"score"`
+	Reason string `json:"reason,omitempty"`
+}
+
+// HandoffRef points to the latest handoff artifact.
+type HandoffRef struct {
+	Path         string    `json:"path"`
+	GeneratedAt  time.Time `json:"generated_at,omitempty"`
+	ChangedFiles int       `json:"changed_files"`
+	RiskFiles    int       `json:"risk_files"`
+}
+
+// BudgetInfo reports how much context was generated.
+type BudgetInfo struct {
+	TotalBytes int `json:"total_bytes"`
+	Compact    bool `json:"compact"`
+}
+
+// RunContext handles the "codemap context" subcommand.
+func RunContext(args []string, root string) {
+	fs := flag.NewFlagSet("context", flag.ExitOnError)
+	forPrompt := fs.String("for", "", "Pre-classify intent for this prompt")
+	compact := fs.Bool("compact", false, "Minimal output for token-constrained agents")
+	if err := fs.Parse(args); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	if fs.NArg() > 0 {
+		root = fs.Arg(0)
+	}
+
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	envelope := buildContextEnvelope(absRoot, *forPrompt, *compact)
+
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(envelope); err != nil {
+		fmt.Fprintf(os.Stderr, "Error encoding context: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func buildContextEnvelope(root, prompt string, compact bool) ContextEnvelope {
+	projCfg := config.Load(root)
+	info := getHubInfoNoFallback(root)
+
+	envelope := ContextEnvelope{
+		Version:     1,
+		GeneratedAt: time.Now(),
+		Project:     buildProjectContext(root, info),
+		Budget:      BudgetInfo{Compact: compact},
+	}
+
+	// Intent classification (if prompt provided)
+	if prompt != "" {
+		topK := projCfg.RoutingTopKOrDefault()
+		files := extractMentionedFiles(prompt, topK)
+		intent := classifyIntent(prompt, files, info, projCfg)
+		envelope.Intent = &intent
+
+		// Match skills against intent
+		if !compact {
+			if idx, err := skills.LoadSkills(root); err == nil && idx != nil {
+				var langs []string
+				for _, f := range files {
+					if lang := scanner.DetectLanguage(f); lang != "" {
+						langs = append(langs, lang)
+					}
+				}
+				matches := idx.MatchSkills(intent.Category, files, langs, 3)
+				for _, m := range matches {
+					envelope.Skills = append(envelope.Skills, SkillRef{
+						Name:   m.Skill.Meta.Name,
+						Score:  m.Score,
+						Reason: m.Reason,
+					})
+				}
+			}
+		}
+	}
+
+	// Working set from daemon
+	if state := watch.ReadState(root); state != nil && state.WorkingSet != nil {
+		ws := state.WorkingSet
+		wsCtx := &WorkingSetContext{
+			FileCount: ws.Size(),
+			HubCount:  ws.HubCount(),
+		}
+		limit := 10
+		if compact {
+			limit = 3
+		}
+		for _, wf := range ws.HotFiles(limit) {
+			wsCtx.TopFiles = append(wsCtx.TopFiles, WorkingFileContext{
+				Path:      wf.Path,
+				EditCount: wf.EditCount,
+				NetDelta:  wf.NetDelta,
+				IsHub:     wf.IsHub,
+			})
+		}
+		envelope.WorkingSet = wsCtx
+	}
+
+	// Handoff reference
+	if !compact {
+		if artifact, err := handoff.ReadLatest(root); err == nil && artifact != nil {
+			ref := &HandoffRef{
+				Path:        handoff.LatestPath(root),
+				GeneratedAt: artifact.GeneratedAt,
+			}
+			ref.ChangedFiles = len(artifact.Delta.Changed)
+			ref.RiskFiles = len(artifact.Delta.RiskFiles)
+			envelope.Handoff = ref
+		}
+	}
+
+	// Calculate budget
+	data, _ := json.Marshal(envelope)
+	envelope.Budget.TotalBytes = len(data)
+
+	return envelope
+}
+
+func buildProjectContext(root string, info *hubInfo) ProjectContext {
+	ctx := ProjectContext{
+		Root: root,
+	}
+
+	// Get branch
+	if branch, ok := gitCurrentBranch(root); ok {
+		ctx.Branch = branch
+	}
+
+	// Count files and detect languages from daemon state
+	if state := watch.ReadState(root); state != nil {
+		ctx.FileCount = state.FileCount
+		ctx.HubCount = len(state.Hubs)
+		if len(state.Hubs) > 5 {
+			ctx.TopHubs = state.Hubs[:5]
+		} else {
+			ctx.TopHubs = state.Hubs
+		}
+	}
+
+	// Detect languages from file extensions
+	langSet := make(map[string]bool)
+	if info != nil {
+		for file := range info.Importers {
+			if lang := scanner.DetectLanguage(file); lang != "" {
+				langSet[lang] = true
+			}
+		}
+	}
+	for lang := range langSet {
+		ctx.Languages = append(ctx.Languages, lang)
+	}
+
+	return ctx
+}
+

--- a/cmd/hooks.go
+++ b/cmd/hooks.go
@@ -1164,7 +1164,60 @@ func writeSessionHandoff(root string, state *watch.State) error {
 	if err != nil {
 		return err
 	}
+
+	// Record this agent session in handoff history
+	agentEntry := handoff.AgentEntry{
+		AgentID:   detectAgentID(),
+		StartedAt: sessionStartTime(state),
+		EndedAt:   time.Now(),
+	}
+	if state != nil {
+		seen := make(map[string]bool)
+		for _, e := range state.RecentEvents {
+			if !seen[e.Path] {
+				seen[e.Path] = true
+				agentEntry.FilesEdited = append(agentEntry.FilesEdited, e.Path)
+			}
+		}
+	}
+
+	// Carry over history from previous artifact and append current session
+	if prev, err := handoff.ReadLatest(root); err == nil && prev != nil {
+		artifact.AgentHistory = prev.AgentHistory
+	}
+	artifact.AgentHistory = append(artifact.AgentHistory, agentEntry)
+
+	// Cap history to last 20 entries
+	if len(artifact.AgentHistory) > 20 {
+		artifact.AgentHistory = artifact.AgentHistory[len(artifact.AgentHistory)-20:]
+	}
+
 	return handoff.WriteLatest(root, artifact)
+}
+
+// detectAgentID returns the current AI agent based on environment signals.
+func detectAgentID() string {
+	// Claude Code sets CLAUDE_CODE=1
+	if os.Getenv("CLAUDE_CODE") == "1" || os.Getenv("CLAUDE_CODE_ENTRYPOINT") != "" {
+		return "claude-code"
+	}
+	// Codex sets CODEX=1
+	if os.Getenv("CODEX") == "1" {
+		return "codex"
+	}
+	// Cursor sets CURSOR=1
+	if os.Getenv("CURSOR_SESSION_ID") != "" {
+		return "cursor"
+	}
+	return "unknown"
+}
+
+// sessionStartTime estimates when this session started from daemon events.
+func sessionStartTime(state *watch.State) time.Time {
+	if state != nil && len(state.RecentEvents) > 0 {
+		return state.RecentEvents[0].Time
+	}
+	return time.Now()
 }
 
 func resolveHandoffBaseRef(root string) string {

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -1,0 +1,153 @@
+package cmd
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"codemap/skills"
+	"codemap/watch"
+)
+
+// RunServe starts a lightweight HTTP server exposing codemap's intelligence.
+func RunServe(args []string, root string) {
+	fs := flag.NewFlagSet("serve", flag.ExitOnError)
+	port := fs.Int("port", 9471, "Port to listen on")
+	if err := fs.Parse(args); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	if fs.NArg() > 0 {
+		root = fs.Arg(0)
+	}
+
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	mux := http.NewServeMux()
+
+	// GET /api/context — full context envelope
+	mux.HandleFunc("/api/context", func(w http.ResponseWriter, r *http.Request) {
+		prompt := r.URL.Query().Get("intent")
+		compact := r.URL.Query().Get("compact") == "true"
+		envelope := buildContextEnvelope(absRoot, prompt, compact)
+		writeJSON(w, envelope)
+	})
+
+	// GET /api/skills — list available skills
+	mux.HandleFunc("/api/skills", func(w http.ResponseWriter, r *http.Request) {
+		idx, err := skills.LoadSkills(absRoot)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+
+		// Optional filters
+		lang := r.URL.Query().Get("language")
+		category := r.URL.Query().Get("category")
+
+		if category != "" || lang != "" {
+			var langs []string
+			if lang != "" {
+				langs = []string{lang}
+			}
+			matches := idx.MatchSkills(category, nil, langs, 10)
+			writeJSON(w, matches)
+			return
+		}
+
+		// Return all skill metadata (no bodies)
+		type skillMeta struct {
+			Name        string   `json:"name"`
+			Description string   `json:"description"`
+			Source      string   `json:"source"`
+			Keywords    []string `json:"keywords,omitempty"`
+			Languages   []string `json:"languages,omitempty"`
+			Priority    int      `json:"priority,omitempty"`
+		}
+		var meta []skillMeta
+		for _, s := range idx.Skills {
+			meta = append(meta, skillMeta{
+				Name:        s.Meta.Name,
+				Description: s.Meta.Description,
+				Source:      s.Source,
+				Keywords:    s.Meta.Keywords,
+				Languages:   s.Meta.Languages,
+				Priority:    s.Meta.Priority,
+			})
+		}
+		writeJSON(w, meta)
+	})
+
+	// GET /api/skills/:name — get full skill
+	mux.HandleFunc("/api/skills/", func(w http.ResponseWriter, r *http.Request) {
+		name := strings.TrimPrefix(r.URL.Path, "/api/skills/")
+		if name == "" {
+			writeError(w, http.StatusBadRequest, "skill name required")
+			return
+		}
+
+		idx, err := skills.LoadSkills(absRoot)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+
+		skill, ok := idx.ByName[name]
+		if !ok {
+			writeError(w, http.StatusNotFound, fmt.Sprintf("skill %q not found", name))
+			return
+		}
+		writeJSON(w, skill)
+	})
+
+	// GET /api/working-set — current session working set
+	mux.HandleFunc("/api/working-set", func(w http.ResponseWriter, r *http.Request) {
+		state := watch.ReadState(absRoot)
+		if state == nil || state.WorkingSet == nil {
+			writeJSON(w, map[string]string{"status": "no working set available"})
+			return
+		}
+		writeJSON(w, state.WorkingSet)
+	})
+
+	// GET /api/health — simple health check
+	mux.HandleFunc("/api/health", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, map[string]string{"status": "ok", "root": absRoot})
+	})
+
+	addr := fmt.Sprintf(":%d", *port)
+	fmt.Printf("codemap serve — listening on http://localhost%s\n", addr)
+	fmt.Printf("  GET /api/context?intent=refactor+auth&compact=true\n")
+	fmt.Printf("  GET /api/skills?language=go&category=refactor\n")
+	fmt.Printf("  GET /api/skills/<name>\n")
+	fmt.Printf("  GET /api/working-set\n")
+	fmt.Printf("  GET /api/health\n")
+	fmt.Println()
+
+	if err := http.ListenAndServe(addr, mux); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func writeJSON(w http.ResponseWriter, v interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	enc.Encode(v)
+}
+
+func writeError(w http.ResponseWriter, code int, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	json.NewEncoder(w).Encode(map[string]string{"error": msg})
+}

--- a/handoff/types.go
+++ b/handoff/types.go
@@ -70,6 +70,15 @@ type CacheMetrics struct {
 	PreviousCombinedHash string  `json:"previous_combined_hash,omitempty"`
 }
 
+// AgentEntry records which agent worked on this codebase and when.
+type AgentEntry struct {
+	AgentID     string    `json:"agent_id"`               // "claude-code", "codex", "cursor", custom
+	StartedAt   time.Time `json:"started_at"`
+	EndedAt     time.Time `json:"ended_at,omitempty"`
+	FilesEdited []string  `json:"files_edited,omitempty"`
+	Summary     string    `json:"summary,omitempty"`
+}
+
 // Artifact is the persisted handoff payload shared between agents.
 type Artifact struct {
 	SchemaVersion int            `json:"schema_version"`
@@ -83,6 +92,9 @@ type Artifact struct {
 	DeltaHash     string         `json:"delta_hash"`
 	CombinedHash  string         `json:"combined_hash"`
 	Metrics       CacheMetrics   `json:"metrics"`
+
+	// Agent history — tracks which agents have worked on this codebase.
+	AgentHistory []AgentEntry `json:"agent_history,omitempty"`
 
 	// Legacy top-level fields preserved for backward compatibility.
 	// Deprecated: these mirrors will be removed in schema v2 after clients migrate to Prefix/Delta.

--- a/main.go
+++ b/main.go
@@ -111,6 +111,20 @@ func main() {
 		return
 	}
 
+	// Handle "context" subcommand before global flag parsing
+	if len(os.Args) >= 2 && os.Args[1] == "context" {
+		root, _ := os.Getwd()
+		cmd.RunContext(os.Args[2:], root)
+		return
+	}
+
+	// Handle "serve" subcommand before global flag parsing
+	if len(os.Args) >= 2 && os.Args[1] == "serve" {
+		root, _ := os.Getwd()
+		cmd.RunServe(os.Args[2:], root)
+		return
+	}
+
 	// Handle "handoff" subcommand before global flag parsing
 	if len(os.Args) >= 2 && os.Args[1] == "handoff" {
 		runHandoffSubcommand(os.Args[2:])


### PR DESCRIPTION
## Summary

Phase 3 — the final phase. Makes codemap's intelligence consumable by **any** AI tool.

### `codemap context` — Universal JSON Envelope
```bash
codemap context                          # Full envelope
codemap context --for "refactor auth"    # With pre-classified intent
codemap context --compact                # Minimal for token-constrained agents
```

Output includes project info, intent classification, working set, matched skills, and handoff reference — everything an AI tool needs in one call.

### `codemap serve` — HTTP API
```
codemap serve --port 9471
  GET /api/context?intent=refactor+auth&compact=true
  GET /api/skills?language=go&category=refactor
  GET /api/skills/<name>
  GET /api/working-set
  GET /api/health
```

Enables VS Code extensions, CI pipelines, web dashboards, and non-MCP AI tools to consume codemap intelligence.

### Agent-Aware Handoff History
- `AgentEntry` records which agent worked, when, and what it edited
- Auto-detects Claude Code, Codex, and Cursor from environment
- History carried across sessions, capped at 20 entries
- True multi-agent continuity — each agent sees what previous agents did

## Test plan
- [x] `go test ./... -race` — all 10 packages pass
- [x] `codemap context --for "refactor auth"` returns full envelope with intent + skills
- [x] `codemap context --compact` strips skills/handoff, limits working set
- [x] Binary builds on all platforms (inherits from Phase 1/2 CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)