### PR TITLE
ci: don't red-fail main when coverage-badge gist push fails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,9 @@ jobs:
 
       - name: Update coverage badge
         if: matrix.os == 'ubuntu-latest' && matrix.go-version == '1.23' && github.ref == 'refs/heads/main'
+        # Cosmetic gist badge update; a bad/expired GIST_TOKEN must not red-fail
+        # the whole main build. Rotate GIST_TOKEN (PAT with gist scope) to restore.
+        continue-on-error: true
         uses: schneegans/dynamic-badges-action@v1.7.0
         with:
           auth: ${{ secrets.GIST_TOKEN }}


### PR DESCRIPTION
## Problem
Main CI has been failing on every push (since #73) — but **not** because of tests. The `Test (ubuntu-latest, 1.23)` job's **"Update coverage badge"** step (`schneegans/dynamic-badges-action`) returns **401 Unauthorized** pushing to the coverage gist, which fails the whole job. Tests pass (coverage computes fine); only the badge push fails.

## Fix
Mark the cosmetic badge step `continue-on-error: true` so an expired/invalid `GIST_TOKEN` no longer red-fails the build.

## Follow-up (needs maintainer)
The badge itself won't update until `GIST_TOKEN` (a PAT with `gist` scope, for gist `6ffe3276…`) is rotated in repo secrets. This PR just stops it from breaking CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)