### PR TITLE
feat(config): surface matches hidden by extension filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,10 @@ Example `.codemap/config.json`:
 {
   "only": ["rs", "sh", "sql", "toml", "yml"],
   "exclude": ["docs/reference", "docs/research"],
+  "guidance": {
+    "missing_extension_hints": true,
+    "ignored_extensions": []
+  },
   "depth": 4,
   "mode": "auto",
   "budgets": {
@@ -330,6 +334,8 @@ Example `.codemap/config.json`:
   }
 }
 ```
+
+When an MCP file search has no visible results but finds real matches hidden by `only`, Codemap reports the matching paths and suggests which extensions to include. These hints still respect `exclude` and never modify project config. Set `guidance.missing_extension_hints` to `false` to disable all hints, or list extensions in `guidance.ignored_extensions` to suppress only those suggestions.
 
 All fields are optional. CLI flags always override config values.
 Hook-specific policy fields are optional and bounded by safe defaults.

--- a/cmd/context.go
+++ b/cmd/context.go
@@ -307,7 +307,7 @@ func detectLanguagesFromFiles(root string) map[string]bool {
 
 	// Include subdirectory source files. Reuse the scan result for countSourceFiles too.
 	gitCache := scanner.NewGitIgnoreCache(root)
-	if files, err := scanner.ScanFiles(root, gitCache, nil, nil); err == nil {
+	if files, err := scanner.ScanConfiguredFiles(root, gitCache); err == nil {
 		for _, f := range files {
 			addLang(scanner.DetectLanguage(f.Path))
 		}
@@ -353,7 +353,7 @@ func countSourceFiles(root string) int {
 		return count
 	}
 	gitCache := scanner.NewGitIgnoreCache(root)
-	files, err := scanner.ScanFiles(root, gitCache, nil, nil)
+	files, err := scanner.ScanConfiguredFiles(root, gitCache)
 	if err != nil {
 		return 0
 	}

--- a/cmd/context_test.go
+++ b/cmd/context_test.go
@@ -61,6 +61,16 @@ func TestBuildContextEnvelopeRespectsConfiguredFilters(t *testing.T) {
 	}
 }
 
+func TestCountSourceFilesReturnsZeroWhenConfiguredScanFails(t *testing.T) {
+	cachedFileCount = -1
+	t.Cleanup(func() { cachedFileCount = -1 })
+
+	missingRoot := filepath.Join(t.TempDir(), "missing")
+	if got := countSourceFiles(missingRoot); got != 0 {
+		t.Fatalf("countSourceFiles(missing root) = %d, want 0", got)
+	}
+}
+
 func mustWriteFile(t *testing.T, path, content string) {
 	t.Helper()
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {

--- a/cmd/context_test.go
+++ b/cmd/context_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 )
 
@@ -38,6 +39,25 @@ func TestDetectLanguagesFromFiles_SubdirectorySources(t *testing.T) {
 	}
 	if !langs["go"] {
 		t.Fatalf("expected go from subdirectory source, got %#v", langs)
+	}
+}
+
+func TestBuildContextEnvelopeRespectsConfiguredFilters(t *testing.T) {
+	root := t.TempDir()
+	mustWriteFile(t, filepath.Join(root, ".codemap", "config.json"), `{"only":["go"],"exclude":["generated"]}`)
+	mustWriteFile(t, filepath.Join(root, "main.go"), "package main\n")
+	mustWriteFile(t, filepath.Join(root, "schema.ts"), "export const schema = 1\n")
+	mustWriteFile(t, filepath.Join(root, "generated", "hidden.go"), "package generated\n")
+
+	cachedFileCount = -1
+	t.Cleanup(func() { cachedFileCount = -1 })
+	envelope := buildContextEnvelope(root, "", true)
+
+	if envelope.Project.FileCount != 1 {
+		t.Fatalf("file count = %d, want 1", envelope.Project.FileCount)
+	}
+	if !reflect.DeepEqual(envelope.Project.Languages, []string{"go"}) {
+		t.Fatalf("languages = %#v, want [go]", envelope.Project.Languages)
 	}
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -13,13 +13,37 @@ import (
 // ProjectConfig holds per-project defaults from .codemap/config.json.
 // All fields are optional; zero values mean "no preference".
 type ProjectConfig struct {
-	Only    []string      `json:"only,omitempty"`
-	Exclude []string      `json:"exclude,omitempty"`
-	Depth   int           `json:"depth,omitempty"`
-	Mode    string        `json:"mode,omitempty"`
-	Budgets HookBudgets   `json:"budgets,omitempty"`
-	Routing RoutingConfig `json:"routing,omitempty"`
-	Drift   DriftConfig   `json:"drift,omitempty"`
+	Only     []string       `json:"only,omitempty"`
+	Exclude  []string       `json:"exclude,omitempty"`
+	Depth    int            `json:"depth,omitempty"`
+	Mode     string         `json:"mode,omitempty"`
+	Budgets  HookBudgets    `json:"budgets,omitempty"`
+	Routing  RoutingConfig  `json:"routing,omitempty"`
+	Drift    DriftConfig    `json:"drift,omitempty"`
+	Guidance GuidanceConfig `json:"guidance,omitempty"`
+}
+
+// GuidanceConfig controls optional suggestions without changing project config.
+type GuidanceConfig struct {
+	MissingExtensionHints *bool    `json:"missing_extension_hints,omitempty"`
+	IgnoredExtensions     []string `json:"ignored_extensions,omitempty"`
+}
+
+// MissingExtensionHintsEnabled defaults missing-extension guidance to on.
+func (c ProjectConfig) MissingExtensionHintsEnabled() bool {
+	return c.Guidance.MissingExtensionHints == nil || *c.Guidance.MissingExtensionHints
+}
+
+// IgnoresGuidanceForExtension reports whether guidance is disabled for ext.
+func (c ProjectConfig) IgnoresGuidanceForExtension(ext string) bool {
+	ext = strings.TrimPrefix(strings.TrimSpace(ext), ".")
+	for _, ignored := range c.Guidance.IgnoredExtensions {
+		ignored = strings.TrimPrefix(strings.TrimSpace(ignored), ".")
+		if strings.EqualFold(ext, ignored) {
+			return true
+		}
+	}
+	return false
 }
 
 // HookBudgets configures per-hook output constraints.
@@ -127,6 +151,9 @@ func (c ProjectConfig) IsZero() bool {
 		return false
 	}
 	if c.Drift.Enabled || c.Drift.RecentCommits > 0 || len(c.Drift.RequireDocsFor) > 0 {
+		return false
+	}
+	if c.Guidance.MissingExtensionHints != nil || len(c.Guidance.IgnoredExtensions) > 0 {
 		return false
 	}
 	return true

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -258,6 +258,38 @@ func TestProjectConfigStateHelpers(t *testing.T) {
 	})
 }
 
+func TestGuidanceConfigHelpers(t *testing.T) {
+	var zero ProjectConfig
+	if !zero.MissingExtensionHintsEnabled() {
+		t.Fatal("expected missing-extension hints to default to enabled")
+	}
+
+	enabled, disabled := true, false
+	if !(ProjectConfig{Guidance: GuidanceConfig{MissingExtensionHints: &enabled}}).MissingExtensionHintsEnabled() {
+		t.Fatal("expected explicitly enabled missing-extension hints")
+	}
+	if (ProjectConfig{Guidance: GuidanceConfig{MissingExtensionHints: &disabled}}).MissingExtensionHintsEnabled() {
+		t.Fatal("expected explicitly disabled missing-extension hints")
+	}
+
+	cfg := ProjectConfig{Guidance: GuidanceConfig{IgnoredExtensions: []string{" .Proto ", "SUM"}}}
+	for _, ext := range []string{".proto", " PROTO", ".sum"} {
+		if !cfg.IgnoresGuidanceForExtension(ext) {
+			t.Fatalf("expected extension %q to be ignored", ext)
+		}
+	}
+	if cfg.IgnoresGuidanceForExtension(".rs") {
+		t.Fatal("did not expect rs guidance to be ignored")
+	}
+
+	if (ProjectConfig{Guidance: GuidanceConfig{MissingExtensionHints: &enabled}}).IsZero() {
+		t.Fatal("config with missing-extension policy must not be zero")
+	}
+	if (ProjectConfig{Guidance: GuidanceConfig{IgnoredExtensions: []string{"proto"}}}).IsZero() {
+		t.Fatal("config with ignored guidance extensions must not be zero")
+	}
+}
+
 func TestAssessSetup(t *testing.T) {
 	t.Run("missing config needs setup", func(t *testing.T) {
 		assessment := AssessSetup(t.TempDir())

--- a/mcp/find_guidance.go
+++ b/mcp/find_guidance.go
@@ -47,12 +47,15 @@ func formatOnlyFilterHint(pattern string, matches []scanner.FileInfo) string {
 	}
 	sort.Strings(exts)
 
-	output := fmt.Sprintf("No configured files found matching '%s'.\n\nPotential matches excluded by `only` config:\n%s", pattern, strings.Join(paths, "\n"))
+	output := fmt.Sprintf("No configured files found matching '%s'.\n\nMatches excluded by `only` config:\n%s", pattern, strings.Join(paths, "\n"))
 	if remaining := len(matches) - len(paths); remaining > 0 {
 		output += fmt.Sprintf("\n... and %d more", remaining)
 	}
 	if len(exts) > 0 {
-		output += fmt.Sprintf("\n\nConsider adding %s to `.codemap/config.json` `only`.", strings.Join(exts, ", "))
+		extList := strings.Join(exts, ", ")
+		output += fmt.Sprintf("\n\nTell your agent: “include suggestions for %s”, “ignore suggestions for %s”, or “disable suggestions for this repo”.", extList, extList)
+	} else {
+		output += "\n\nTell your agent: “disable suggestions for this repo”."
 	}
-	return output + " No configuration was changed. Set `guidance.missing_extension_hints` to false or add an extension to `guidance.ignored_extensions` to suppress this guidance."
+	return output + "\n\nNo config changed."
 }

--- a/mcp/find_guidance.go
+++ b/mcp/find_guidance.go
@@ -1,0 +1,58 @@
+package codemapmcp
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"codemap/config"
+	"codemap/scanner"
+)
+
+func findConfiguredMatches(root, pattern string, files []scanner.FileInfo) (visible []string, filtered []scanner.FileInfo, hintsEnabled bool) {
+	cfg := config.Load(root)
+	pattern = strings.ToLower(pattern)
+	for _, file := range files {
+		if !strings.Contains(strings.ToLower(file.Path), pattern) {
+			continue
+		}
+		if scanner.MatchesFilters(file.Path, file.Ext, cfg.Only, cfg.Exclude) {
+			visible = append(visible, file.Path)
+			continue
+		}
+		if !scanner.MatchesFilters(file.Path, file.Ext, cfg.Only, nil) &&
+			scanner.MatchesFilters(file.Path, file.Ext, nil, cfg.Exclude) &&
+			!cfg.IgnoresGuidanceForExtension(file.Ext) {
+			filtered = append(filtered, file)
+		}
+	}
+	return visible, filtered, cfg.MissingExtensionHintsEnabled()
+}
+
+func formatOnlyFilterHint(pattern string, matches []scanner.FileInfo) string {
+	const maxPaths = 5
+	paths := make([]string, 0, min(len(matches), maxPaths))
+	extensions := make(map[string]struct{})
+	for i, match := range matches {
+		if i < maxPaths {
+			paths = append(paths, match.Path)
+		}
+		if ext := strings.TrimPrefix(strings.ToLower(match.Ext), "."); ext != "" {
+			extensions[ext] = struct{}{}
+		}
+	}
+	exts := make([]string, 0, len(extensions))
+	for ext := range extensions {
+		exts = append(exts, ext)
+	}
+	sort.Strings(exts)
+
+	output := fmt.Sprintf("No configured files found matching '%s'.\n\nPotential matches excluded by `only` config:\n%s", pattern, strings.Join(paths, "\n"))
+	if remaining := len(matches) - len(paths); remaining > 0 {
+		output += fmt.Sprintf("\n... and %d more", remaining)
+	}
+	if len(exts) > 0 {
+		output += fmt.Sprintf("\n\nConsider adding %s to `.codemap/config.json` `only`.", strings.Join(exts, ", "))
+	}
+	return output + " No configuration was changed. Set `guidance.missing_extension_hints` to false or add an extension to `guidance.ignored_extensions` to suppress this guidance."
+}

--- a/mcp/main.go
+++ b/mcp/main.go
@@ -221,7 +221,7 @@ func handleGetStructure(ctx context.Context, req *mcp.CallToolRequest, input Pat
 	}
 
 	gitCache := scanner.NewGitIgnoreCache(input.Path)
-	files, err := scanner.ScanFiles(input.Path, gitCache, nil, nil)
+	files, err := scanner.ScanConfiguredFiles(input.Path, gitCache)
 	if err != nil {
 		return errorResult("Scan error: " + err.Error()), nil, nil
 	}
@@ -331,7 +331,7 @@ func handleGetDiff(ctx context.Context, req *mcp.CallToolRequest, input DiffInpu
 	}
 
 	gitCache := scanner.NewGitIgnoreCache(input.Path)
-	files, err := scanner.ScanFiles(input.Path, gitCache, nil, nil)
+	files, err := scanner.ScanConfiguredFiles(input.Path, gitCache)
 	if err != nil {
 		return errorResult("Scan error: " + err.Error()), nil, nil
 	}
@@ -480,7 +480,7 @@ func handleListProjects(ctx context.Context, req *mcp.CallToolRequest, input Lis
 // Uses the same scanner logic as the main codemap command (respects nested .gitignore files)
 func getProjectStats(path string) string {
 	gitCache := scanner.NewGitIgnoreCache(path)
-	files, err := scanner.ScanFiles(path, gitCache, nil, nil)
+	files, err := scanner.ScanConfiguredFiles(path, gitCache)
 	if err != nil {
 		return "(error scanning)"
 	}

--- a/mcp/main.go
+++ b/mcp/main.go
@@ -362,15 +362,12 @@ func handleFindFile(ctx context.Context, req *mcp.CallToolRequest, input FindInp
 	}
 
 	// Filter files matching pattern (case-insensitive)
-	var matches []string
-	pattern := strings.ToLower(input.Pattern)
-	for _, f := range files {
-		if strings.Contains(strings.ToLower(f.Path), pattern) {
-			matches = append(matches, f.Path)
-		}
-	}
+	matches, filteredMatches, hintsEnabled := findConfiguredMatches(input.Path, input.Pattern, files)
 
 	if len(matches) == 0 {
+		if hintsEnabled && len(filteredMatches) > 0 {
+			return textResult(formatOnlyFilterHint(input.Pattern, filteredMatches)), nil, nil
+		}
 		return textResult("No files found matching '" + input.Pattern + "'"), nil, nil
 	}
 

--- a/mcp/main_more_test.go
+++ b/mcp/main_more_test.go
@@ -109,6 +109,95 @@ func TestHandleGetDependenciesAndDiff(t *testing.T) {
 	}
 }
 
+func TestMCPScansRespectConfiguredFilters(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	if !scanner.NewAstGrepAnalyzer().Available() {
+		t.Skip("ast-grep not available")
+	}
+
+	root := makeMCPGitRepo(t, "main")
+	files := map[string]string{
+		".codemap/config.json": `{"only":["go"],"exclude":["excluded"]}`,
+		"go.mod":               "module example.com/mcpfiltered\n\ngo 1.22\n",
+		"pkg/types/types.go":   "package types\n\ntype Item struct{}\n",
+		"a/a.go":               "package a\n\nimport _ \"example.com/mcpfiltered/pkg/types\"\n",
+		"b/b.go":               "package b\n\nimport _ \"example.com/mcpfiltered/pkg/types\"\n",
+		"c/c.go":               "package c\n\nimport _ \"example.com/mcpfiltered/pkg/types\"\n",
+		"schema.ts":            "export const schema = 1\n",
+		"excluded/d/d.go":      "package d\n\nimport _ \"example.com/mcpfiltered/pkg/types\"\n",
+	}
+	for path, content := range files {
+		full := filepath.Join(root, path)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	runGitMCPTestCmd(t, root, "add", ".")
+	runGitMCPTestCmd(t, root, "-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "-m", "fixture")
+
+	for path, content := range map[string]string{
+		"a/a.go":          "package a\n\nimport _ \"example.com/mcpfiltered/pkg/types\"\n\nfunc Changed() {}\n",
+		"schema.ts":       "export const schema = 2\n",
+		"excluded/d/d.go": "package d\n\nimport _ \"example.com/mcpfiltered/pkg/types\"\n\nfunc Changed() {}\n",
+	} {
+		if err := os.WriteFile(filepath.Join(root, path), []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	structure, _, err := handleGetStructure(context.Background(), nil, PathInput{Path: root})
+	if err != nil {
+		t.Fatalf("handleGetStructure error: %v", err)
+	}
+	structureOut := resultText(t, structure)
+	for _, want := range []string{"main.go", "types.go", "a.go"} {
+		if !strings.Contains(structureOut, want) {
+			t.Fatalf("structure missing %q:\n%s", want, structureOut)
+		}
+	}
+	for _, unwanted := range []string{"schema.ts", "excluded"} {
+		if strings.Contains(structureOut, unwanted) {
+			t.Fatalf("structure contains configured-out %q:\n%s", unwanted, structureOut)
+		}
+	}
+
+	diff, _, err := handleGetDiff(context.Background(), nil, DiffInput{Path: root, Ref: "main"})
+	if err != nil {
+		t.Fatalf("handleGetDiff error: %v", err)
+	}
+	diffOut := resultText(t, diff)
+	if !strings.Contains(diffOut, "a.go") || strings.Contains(diffOut, "schema.ts") || strings.Contains(diffOut, "excluded") {
+		t.Fatalf("unexpected filtered diff:\n%s", diffOut)
+	}
+
+	deps, _, err := handleGetDependencies(context.Background(), nil, PathInput{Path: root})
+	if err != nil {
+		t.Fatalf("handleGetDependencies error: %v", err)
+	}
+	depsOut := resultText(t, deps)
+	if strings.Contains(depsOut, "schema.ts") || strings.Contains(depsOut, "excluded/d/d.go") {
+		t.Fatalf("dependencies contain configured-out files:\n%s", depsOut)
+	}
+
+	hubs, _, err := handleGetHubs(context.Background(), nil, PathInput{Path: root})
+	if err != nil {
+		t.Fatalf("handleGetHubs error: %v", err)
+	}
+	hubsOut := resultText(t, hubs)
+	if !strings.Contains(hubsOut, "pkg/types/types.go (3 importers)") || strings.Contains(hubsOut, "excluded/d/d.go") {
+		t.Fatalf("unexpected filtered hubs:\n%s", hubsOut)
+	}
+
+	if got := getProjectStats(root); !strings.Contains(got, "(5 files, Go") {
+		t.Fatalf("project stats = %q, want 5 filtered Go files", got)
+	}
+}
+
 func TestHandleWatchLifecycleAndActivity(t *testing.T) {
 	withWatcherRegistry(t)
 

--- a/mcp/main_test.go
+++ b/mcp/main_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"codemap/handoff"
+	"codemap/scanner"
 	"codemap/watch"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -184,6 +185,22 @@ func TestHandleFindFileExplainsOnlyFilteredMatches(t *testing.T) {
 				t.Fatalf("config changed: got %q, want %q", gotConfig, tt.config)
 			}
 		})
+	}
+}
+
+func TestFormatOnlyFilterHintOffersSortedAgentChoices(t *testing.T) {
+	matches := []scanner.FileInfo{
+		{Path: "schema.sum", Ext: ".sum"},
+		{Path: "schema.proto", Ext: ".proto"},
+	}
+
+	out := formatOnlyFilterHint("schema", matches)
+	want := "Tell your agent: “include suggestions for proto, sum”, “ignore suggestions for proto, sum”, or “disable suggestions for this repo”."
+	if !strings.Contains(out, want) {
+		t.Fatalf("missing concise agent choices:\n%s", out)
+	}
+	if strings.Contains(out, ".codemap/config.json") || strings.Contains(out, "guidance.") {
+		t.Fatalf("response exposes config implementation details:\n%s", out)
 	}
 }
 

--- a/mcp/main_test.go
+++ b/mcp/main_test.go
@@ -120,6 +120,73 @@ func TestHandleFindFileAndStatus(t *testing.T) {
 	}
 }
 
+func TestHandleFindFileExplainsOnlyFilteredMatches(t *testing.T) {
+	tests := []struct {
+		name     string
+		config   string
+		wantHint bool
+		wantPath bool
+	}{
+		{
+			name:     "default guidance",
+			config:   `{"only":["go"]}`,
+			wantHint: true,
+			wantPath: true,
+		},
+		{
+			name:   "guidance disabled",
+			config: `{"only":["go"],"guidance":{"missing_extension_hints":false}}`,
+		},
+		{
+			name:   "extension ignored",
+			config: `{"only":["go"],"guidance":{"ignored_extensions":["proto"]}}`,
+		},
+		{
+			name:   "explicitly excluded",
+			config: `{"only":["go"],"exclude":["schema.proto"]}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			if err := os.MkdirAll(filepath.Join(root, ".codemap"), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			configPath := filepath.Join(root, ".codemap", "config.json")
+			if err := os.WriteFile(configPath, []byte(tt.config), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(root, "schema.proto"), []byte("syntax = \"proto3\";\n"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			res, _, err := handleFindFile(context.Background(), nil, FindInput{Path: root, Pattern: "schema"})
+			if err != nil {
+				t.Fatalf("handleFindFile error: %v", err)
+			}
+			out := resultText(t, res)
+			hasHint := strings.Contains(out, "by `only` config:")
+			if hasHint != tt.wantHint {
+				t.Fatalf("hint presence = %v, want %v:\n%s", hasHint, tt.wantHint, out)
+			}
+			if strings.Contains(out, "schema.proto") != tt.wantPath {
+				t.Fatalf("path presence = %v, want %v:\n%s", strings.Contains(out, "schema.proto"), tt.wantPath, out)
+			}
+			if !tt.wantHint && out != "No files found matching 'schema'" {
+				t.Fatalf("unexpected plain miss output: %s", out)
+			}
+			gotConfig, err := os.ReadFile(configPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(gotConfig) != tt.config {
+				t.Fatalf("config changed: got %q, want %q", gotConfig, tt.config)
+			}
+		})
+	}
+}
+
 func TestHandleGetStructureUsesStateHubs(t *testing.T) {
 	root := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(root, ".codemap"), 0o755); err != nil {

--- a/mcp/main_test.go
+++ b/mcp/main_test.go
@@ -204,6 +204,55 @@ func TestFormatOnlyFilterHintOffersSortedAgentChoices(t *testing.T) {
 	}
 }
 
+func TestFindConfiguredMatchesSeparatesVisibleAndHintableFiles(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".codemap"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	configJSON := `{"only":["go"],"exclude":["schema-excluded.proto"],"guidance":{"ignored_extensions":["sum"]}}`
+	if err := os.WriteFile(filepath.Join(root, ".codemap", "config.json"), []byte(configJSON), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	files := []scanner.FileInfo{
+		{Path: "notes.txt", Ext: ".txt"},
+		{Path: "schema.go", Ext: ".go"},
+		{Path: "schema.proto", Ext: ".proto"},
+		{Path: "schema-excluded.proto", Ext: ".proto"},
+		{Path: "schema.sum", Ext: ".sum"},
+	}
+	visible, filtered, hintsEnabled := findConfiguredMatches(root, "SCHEMA", files)
+	if strings.Join(visible, ",") != "schema.go" {
+		t.Fatalf("visible matches = %v, want [schema.go]", visible)
+	}
+	if len(filtered) != 1 || filtered[0].Path != "schema.proto" {
+		t.Fatalf("filtered matches = %+v, want only schema.proto", filtered)
+	}
+	if !hintsEnabled {
+		t.Fatal("expected hints to remain enabled by default")
+	}
+}
+
+func TestFormatOnlyFilterHintBoundsExtensionlessMatches(t *testing.T) {
+	matches := []scanner.FileInfo{
+		{Path: "schema-1"},
+		{Path: "schema-2"},
+		{Path: "schema-3"},
+		{Path: "schema-4"},
+		{Path: "schema-5"},
+		{Path: "schema-6"},
+	}
+	out := formatOnlyFilterHint("schema", matches)
+	for _, want := range []string{"schema-1", "schema-5", "... and 1 more", "disable suggestions for this repo", "No config changed."} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("missing %q from bounded hint:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "schema-6") {
+		t.Fatalf("bounded hint exposed sixth path:\n%s", out)
+	}
+}
+
 func TestHandleGetStructureUsesStateHubs(t *testing.T) {
 	root := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(root, ".codemap"), 0o755); err != nil {

--- a/mcp_fallback_entrypoints_test.go
+++ b/mcp_fallback_entrypoints_test.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+func TestMCPEntrypointsMatchConfigFallback(t *testing.T) {
+	binDir := t.TempDir()
+	cli := buildFallbackTestBinary(t, filepath.Join(binDir, "codemap"), ".")
+	standalone := buildFallbackTestBinary(t, filepath.Join(binDir, "codemap-mcp"), "./cmd/codemap-mcp")
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".codemap"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".codemap", "config.json"), []byte(`{"only":["go"]}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "schema.proto"), []byte("syntax = \"proto3\";\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cliResult := probeFallbackTestBinary(t, cli, []string{"mcp"}, root)
+	standaloneResult := probeFallbackTestBinary(t, standalone, nil, root)
+	if cliResult != standaloneResult {
+		t.Fatalf("find_file differs:\ncodemap mcp: %s\ncodemap-mcp: %s", cliResult, standaloneResult)
+	}
+	if !strings.Contains(cliResult, "Matches excluded by `only` config:") {
+		t.Fatalf("fallback guidance missing: %s", cliResult)
+	}
+}
+
+func buildFallbackTestBinary(t *testing.T, output, pkg string) string {
+	t.Helper()
+	command := exec.Command("go", "build", "-o", output, pkg)
+	if data, err := command.CombinedOutput(); err != nil {
+		t.Fatalf("build %s: %v\n%s", pkg, err, data)
+	}
+	return output
+}
+
+func probeFallbackTestBinary(t *testing.T, binary string, args []string, root string) string {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	client := mcp.NewClient(&mcp.Implementation{Name: "fallback-parity-test", Version: "1"}, nil)
+	session, err := client.Connect(ctx, &mcp.CommandTransport{Command: exec.Command(binary, args...)}, nil)
+	if err != nil {
+		t.Fatalf("connect %s: %v", binary, err)
+	}
+	defer session.Close()
+	result, err := session.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "find_file",
+		Arguments: map[string]any{"path": root, "pattern": "schema"},
+	})
+	if err != nil {
+		t.Fatalf("find_file from %s: %v", binary, err)
+	}
+	var text []string
+	for _, content := range result.Content {
+		if item, ok := content.(*mcp.TextContent); ok {
+			text = append(text, item.Text)
+		}
+	}
+	return strings.Join(text, "\n")
+}

--- a/scanner/filegraph.go
+++ b/scanner/filegraph.go
@@ -47,6 +47,8 @@ func BuildFileGraphFromAnalyses(root string, analyses []FileAnalysis) (*FileGrap
 		return nil, err
 	}
 
+	analyses = filterConfiguredAnalyses(root, analyses)
+
 	fg := &FileGraph{
 		Root:        absRoot,
 		Imports:     make(map[string][]string),
@@ -63,7 +65,7 @@ func BuildFileGraphFromAnalyses(root string, analyses []FileAnalysis) (*FileGrap
 
 	// Scan all files
 	gitCache := NewGitIgnoreCache(root)
-	files, err := ScanFiles(root, gitCache, nil, nil)
+	files, err := ScanConfiguredFiles(root, gitCache)
 	if err != nil {
 		return nil, err
 	}

--- a/scanner/integration_more_test.go
+++ b/scanner/integration_more_test.go
@@ -3,6 +3,7 @@ package scanner
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -78,5 +79,56 @@ func TestScanForDepsBuildFileGraphAndAnalyzeImpact(t *testing.T) {
 	}
 	if maxUsedBy < 4 {
 		t.Fatalf("expected impacted file usage count >= 4, got %+v", impacts)
+	}
+}
+
+func TestDependencyAndGraphScansRespectConfiguredFilters(t *testing.T) {
+	if !NewAstGrepAnalyzer().Available() {
+		t.Skip("ast-grep not available")
+	}
+
+	root := t.TempDir()
+	files := map[string]string{
+		".codemap/config.json": `{"only":["go"],"exclude":["excluded"]}`,
+		"go.mod":               "module example.com/filtered\n\ngo 1.22\n",
+		"pkg/types/types.go":   "package types\n\ntype Item struct{}\n",
+		"a/a.go":               "package a\n\nimport _ \"example.com/filtered/pkg/types\"\n",
+		"b/b.go":               "package b\n\nimport _ \"example.com/filtered/pkg/types\"\n",
+		"c/c.go":               "package c\n\nimport _ \"example.com/filtered/pkg/types\"\n",
+		"schema.ts":            "import './blocked'\n",
+		"excluded/d/d.go":      "package d\n\nimport _ \"example.com/filtered/pkg/types\"\n",
+	}
+	for path, content := range files {
+		full := filepath.Join(root, path)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	analyses, err := ScanForDeps(root)
+	if err != nil {
+		t.Fatalf("ScanForDeps() error: %v", err)
+	}
+	for _, analysis := range analyses {
+		if analysis.Path == "schema.ts" || strings.HasPrefix(analysis.Path, "excluded/") {
+			t.Fatalf("configured-out dependency analysis returned: %s", analysis.Path)
+		}
+	}
+
+	fg, err := BuildFileGraph(root)
+	if err != nil {
+		t.Fatalf("BuildFileGraph() error: %v", err)
+	}
+	if got := fg.Importers["pkg/types/types.go"]; len(got) != 3 {
+		t.Fatalf("filtered hub importers = %#v, want exactly 3", got)
+	}
+	if _, ok := fg.Imports["excluded/d/d.go"]; ok {
+		t.Fatal("excluded Go file remains in graph")
+	}
+	if _, ok := fg.Imports["schema.ts"]; ok {
+		t.Fatal("extension-filtered file remains in graph")
 	}
 }

--- a/scanner/integration_more_test.go
+++ b/scanner/integration_more_test.go
@@ -3,6 +3,7 @@ package scanner
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -130,5 +131,57 @@ func TestDependencyAndGraphScansRespectConfiguredFilters(t *testing.T) {
 	}
 	if _, ok := fg.Imports["schema.ts"]; ok {
 		t.Fatal("extension-filtered file remains in graph")
+	}
+}
+
+func TestConfiguredScanHelpers(t *testing.T) {
+	if !MatchesFilters("main.go", ".go", []string{"go"}, nil) {
+		t.Fatal("expected exported filter helper to accept configured extension")
+	}
+	if MatchesFilters("main.ts", ".ts", []string{"go"}, nil) {
+		t.Fatal("expected exported filter helper to reject unconfigured extension")
+	}
+
+	root := t.TempDir()
+	analyses := []FileAnalysis{{Path: "schema.ts"}}
+	got := filterConfiguredAnalyses(root, analyses)
+	if len(got) != 1 || got[0].Path != "schema.ts" {
+		t.Fatalf("unconfigured analysis filter = %+v, want original analysis", got)
+	}
+
+	if _, err := ScanConfiguredFiles(filepath.Join(root, "missing"), nil); err == nil {
+		t.Fatal("expected configured scan of missing root to fail")
+	}
+}
+
+func TestScanForDepsPropagatesScanError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("requires shell script execution")
+	}
+
+	binDir := t.TempDir()
+	fakeBinary := filepath.Join(binDir, "ast-grep")
+	script := "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then echo 'ast-grep 0.40.0'; exit 0; fi\nprintf '[invalid'\n"
+	if err := os.WriteFile(fakeBinary, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir)
+
+	if _, err := ScanForDeps(t.TempDir()); err == nil {
+		t.Fatal("expected malformed ast-grep output to propagate a scan error")
+	}
+}
+
+func TestScanForDepsPropagatesSetupError(t *testing.T) {
+	invalidTemp := filepath.Join(t.TempDir(), "not-a-directory")
+	if err := os.WriteFile(invalidTemp, []byte("occupied"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("TMPDIR", invalidTemp)
+	t.Setenv("TMP", invalidTemp)
+	t.Setenv("TEMP", invalidTemp)
+
+	if _, err := ScanForDeps(t.TempDir()); err == nil {
+		t.Fatal("expected invalid temporary directory to propagate a scanner setup error")
 	}
 }

--- a/scanner/walker.go
+++ b/scanner/walker.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"codemap/config"
+
 	ignore "github.com/sabhiram/go-gitignore"
 )
 
@@ -292,17 +294,43 @@ func ScanFiles(root string, cache *GitIgnoreCache, only []string, exclude []stri
 	return files, err
 }
 
+// ScanConfiguredFiles scans using the active setup root's project filters.
+func ScanConfiguredFiles(root string, cache *GitIgnoreCache) ([]FileInfo, error) {
+	cfg := config.Load(root)
+	return ScanFiles(root, cache, cfg.Only, cfg.Exclude)
+}
+
+func filterConfiguredAnalyses(root string, analyses []FileAnalysis) []FileAnalysis {
+	cfg := config.Load(root)
+	if len(cfg.Only) == 0 && len(cfg.Exclude) == 0 {
+		return analyses
+	}
+
+	filtered := make([]FileAnalysis, 0, len(analyses))
+	for _, analysis := range analyses {
+		path := filepath.ToSlash(analysis.Path)
+		if MatchesFilters(path, filepath.Ext(path), cfg.Only, cfg.Exclude) {
+			filtered = append(filtered, analysis)
+		}
+	}
+	return filtered
+}
+
 // ScanForDeps uses ast-grep for batched dependency analysis.
 func ScanForDeps(root string) ([]FileAnalysis, error) {
-	scanner, err := NewAstGrepScanner()
+	astScanner, err := NewAstGrepScanner()
 	if err != nil {
 		return nil, err
 	}
-	defer scanner.Close()
+	defer astScanner.Close()
 
-	if !scanner.Available() {
+	if !astScanner.Available() {
 		return nil, ErrAstGrepNotFound
 	}
 
-	return scanner.ScanDirectory(root)
+	analyses, err := astScanner.ScanDirectory(root)
+	if err != nil {
+		return nil, err
+	}
+	return filterConfiguredAnalyses(root, analyses), nil
 }

--- a/scanner/walker.go
+++ b/scanner/walker.go
@@ -201,6 +201,11 @@ func shouldIncludeFile(relPath string, ext string, only []string, exclude []stri
 	return true
 }
 
+// MatchesFilters reports whether a file passes project only/exclude filters.
+func MatchesFilters(relPath string, ext string, only []string, exclude []string) bool {
+	return shouldIncludeFile(relPath, ext, only, exclude)
+}
+
 // LoadGitignore loads .gitignore from root if it exists
 // Deprecated: Use NewGitIgnoreCache for nested gitignore support
 func LoadGitignore(root string) *ignore.GitIgnore {

--- a/watch/more_test.go
+++ b/watch/more_test.go
@@ -154,13 +154,20 @@ func TestDaemonStartTracksWriteEventsAndState(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	var last Event
 	waitForWatchCondition(t, 2*time.Second, func() bool {
 		events := d.GetEvents(0)
-		return len(events) > 0
+		for i := len(events) - 1; i >= 0; i-- {
+			event := events[i]
+			if event.Path == "main.go" &&
+				(event.Op == "WRITE" || event.Op == "CREATE") &&
+				event.Dirty && event.Delta > 0 {
+				last = event
+				return true
+			}
+		}
+		return false
 	})
-
-	events := d.GetEvents(0)
-	last := events[len(events)-1]
 	if last.Path != "main.go" {
 		t.Fatalf("last event path = %q, want main.go", last.Path)
 	}


### PR DESCRIPTION
## What does this PR do?

- Make MCP file searches respect the project's `only` and `exclude` filters.
- Apply those filters consistently to context, structure, project-statistics, dependency, and file-graph scans.
- When `only` hides real matches, report them and explain how to include or suppress their extensions.
- Enable extension hints by default with `guidance.missing_extension_hints`; set it to `false` to disable them.
- Allow selected hints to be suppressed with `guidance.ignored_extensions`.

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] New language support
- [ ] Documentation
- [ ] Other (describe below)

## Checklist

- [x] I've tested this locally with `go build && ./codemap .`
- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) (for new language support)
- [x] I've updated documentation if needed

## Additional notes

Repository languages evolve after initial setup. Actionable misses prevent agents from repeatedly failing or silently falling back to raw filesystem searches, without rescanning or changing config automatically.

Focused MCP, context, dependency, and file-graph tests pass with the full race
suite, formatting, module verification, vet, staticcheck, and a built-binary
parity probe. The probe confirmed the CLI context, MCP structure, and MCP project
statistics all report the same configured file count.

Reviewer setup:

```bash
set -euo pipefail

ROOT=$PWD
BRANCH=feat/config-only-fallback
REVIEW_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/codemap-config-fallback.XXXXXX")
WT="$REVIEW_ROOT/worktree"
DEBUG_BIN="$REVIEW_ROOT/codemap-debug"
COVERAGE_OUT="$REVIEW_ROOT/coverage.out"

git worktree add --detach "$WT" "$BRANCH"

cleanup() {
  cd "$ROOT"
  git worktree remove --force "$WT"
  rm -rf "$REVIEW_ROOT"
}
trap cleanup EXIT

cd "$WT"
go fmt ./...
git diff --exit-code
go mod verify
go vet ./...
staticcheck ./...
go test -race -coverprofile="$COVERAGE_OUT" ./...
go build -gcflags='all=-N -l' -o "$DEBUG_BIN" .
"$DEBUG_BIN" .
cleanup
trap - EXIT
```

Developed with carefully directed, manually reviewed AI assistance. `Allow edits by maintainers` is enabled, so maintainers are welcome to fix wording or make minor cleanup directly; broader review feedback will be incorporated.

Co-Authored-By: GPT-5.6 Sol <codex@openai.com>
