### PR TITLE
fix(watch): preserve final rapid-write state

### DIFF
--- a/watch/events.go
+++ b/watch/events.go
@@ -114,7 +114,7 @@ func (d *Daemon) eventLoop() {
 				continue
 			}
 
-			if debouncer.shouldSkip(event, time.Now()) {
+			if d.shouldSkipEvent(debouncer, event, time.Now()) {
 				continue
 			}
 
@@ -130,6 +130,26 @@ func (d *Daemon) eventLoop() {
 			}
 		}
 	}
+}
+
+func (d *Daemon) shouldSkipEvent(debouncer *eventDebouncer, event fsnotify.Event, now time.Time) bool {
+	if !debouncer.shouldSkip(event, now) {
+		return false
+	}
+	info, err := os.Stat(event.Name)
+	if err != nil {
+		return false
+	}
+	relPath, err := filepath.Rel(d.root, event.Name)
+	if err != nil {
+		return false
+	}
+
+	d.graph.mu.RLock()
+	cached := d.graph.State[relPath]
+	matches := cached != nil && cached.Size == info.Size()
+	d.graph.mu.RUnlock()
+	return matches
 }
 
 // isSourceFile checks if a file should be tracked.

--- a/watch/events_debounce_test.go
+++ b/watch/events_debounce_test.go
@@ -1,11 +1,47 @@
 package watch
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/fsnotify/fsnotify"
 )
+
+func TestDaemonDoesNotDebounceWriteWhenCachedSizeIsStale(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "main.go")
+	if err := os.WriteFile(path, []byte("package main\n\nfunc changed() {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	d := &Daemon{
+		root: root,
+		graph: &Graph{State: map[string]*FileState{
+			"main.go": {Size: 0},
+		}},
+	}
+	debouncer := newEventDebouncer(100 * time.Millisecond)
+	event := fsnotify.Event{Name: path, Op: fsnotify.Write}
+	base := time.Unix(0, 0)
+
+	if d.shouldSkipEvent(debouncer, event, base) {
+		t.Fatal("first write should not be skipped")
+	}
+	if d.shouldSkipEvent(debouncer, event, base.Add(10*time.Millisecond)) {
+		t.Fatal("final write should refresh stale cached state")
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	d.graph.State["main.go"].Size = info.Size()
+	if !d.shouldSkipEvent(debouncer, event, base.Add(20*time.Millisecond)) {
+		t.Fatal("duplicate write should be skipped once cached state is current")
+	}
+}
 
 func TestEventDebouncerSkipsRapidWrites(t *testing.T) {
 	debouncer := newEventDebouncer(100 * time.Millisecond)

--- a/watch/more_test.go
+++ b/watch/more_test.go
@@ -156,7 +156,7 @@ func TestDaemonStartTracksWriteEventsAndState(t *testing.T) {
 
 	waitForWatchCondition(t, 2*time.Second, func() bool {
 		events := d.GetEvents(0)
-		return len(events) > 0
+		return len(events) > 0 && events[len(events)-1].Path == "main.go" && events[len(events)-1].Delta > 0
 	})
 
 	events := d.GetEvents(0)


### PR DESCRIPTION
## What does this PR do?

- Preserve the final state from rapid successive file writes.
- Skip a debounced write only when the cached file size already matches the file on disk.
- Refresh stale graph state instead of treating every write inside the debounce window as a duplicate.
- Strengthen the daemon test to require the final source-file event and a positive delta.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] New language support
- [ ] Documentation
- [ ] Other (describe below)

## Checklist

- [x] I've tested this locally with `go build && ./codemap .`
- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) (for new language support)
- [ ] I've updated documentation if needed

## Additional notes

Filesystem watchers can emit multiple write notifications for one logical save. Time-based debouncing alone could discard the final notification while the cached graph still described an earlier file state. The debounce decision now checks the current file size against the cached state before skipping a rapid write.

Focused debounce/daemon tests pass with the full race suite, formatting,
module verification, vet, staticcheck, and a debug build/smoke run.

Reviewer setup:

```bash
set -euo pipefail

ROOT=$PWD
BRANCH=fix/watch-debounce
REVIEW_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/codemap-watch-debounce.XXXXXX")
WT="$REVIEW_ROOT/worktree"
DEBUG_BIN="$REVIEW_ROOT/codemap-debug"
COVERAGE_OUT="$REVIEW_ROOT/coverage.out"

git worktree add --detach "$WT" "$BRANCH"

cleanup() {
  cd "$ROOT"
  git worktree remove --force "$WT"
  rm -rf "$REVIEW_ROOT"
}
trap cleanup EXIT

cd "$WT"
go fmt ./...
git diff --exit-code
go mod verify
go vet ./...
staticcheck ./...
go test ./watch -run 'TestDaemonDoesNotDebounceWriteWhenCachedSizeIsStale|TestEventDebouncerSkipsRapidWrites|TestDaemonStartTracksWriteEventsAndState' -count=1
go test -race -coverprofile="$COVERAGE_OUT" ./...
go build -gcflags='all=-N -l' -o "$DEBUG_BIN" .
"$DEBUG_BIN" .
cleanup
trap - EXIT
```

Developed with carefully directed, manually reviewed AI assistance. `Allow edits by maintainers` is enabled, so maintainers are welcome to fix wording or make minor cleanup directly; broader review feedback will be incorporated.

Co-Authored-By: GPT-5.6 Sol <codex@openai.com>