### PR TITLE
fix(mcp): Unify executable entrypoints

### DIFF
--- a/cmd/codemap-mcp/main.go
+++ b/cmd/codemap-mcp/main.go
@@ -1,16 +1,13 @@
 package main
 
 import (
-	"context"
-	"fmt"
 	"os"
 
-	codemapmcp "codemap/mcp"
+	"codemap/cmd"
 )
 
 func main() {
-	if err := codemapmcp.Run(context.Background()); err != nil {
-		fmt.Fprintf(os.Stderr, "MCP server error: %v\n", err)
-		os.Exit(1)
+	if code := cmd.RunMCP(); code != 0 {
+		os.Exit(code)
 	}
 }

--- a/cmd/mcp.go
+++ b/cmd/mcp.go
@@ -1,0 +1,22 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	codemapmcp "codemap/mcp"
+)
+
+// RunMCP runs the shared stdio server and returns its process exit status.
+func RunMCP() int {
+	return runMCP(codemapmcp.Run)
+}
+
+func runMCP(runner func(context.Context) error) int {
+	if err := runner(context.Background()); err != nil {
+		fmt.Fprintf(os.Stderr, "MCP server error: %v\n", err)
+		return 1
+	}
+	return 0
+}

--- a/cmd/mcp_test.go
+++ b/cmd/mcp_test.go
@@ -1,0 +1,17 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestRunMCPReturnsServerStatus(t *testing.T) {
+	if code := runMCP(func(context.Context) error { return nil }); code != 0 {
+		t.Fatalf("RunMCP success exit code = %d, want 0", code)
+	}
+
+	if code := runMCP(func(context.Context) error { return errors.New("boom") }); code != 1 {
+		t.Fatalf("RunMCP failure exit code = %d, want 1", code)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -18,7 +17,6 @@ import (
 	"codemap/config"
 	"codemap/handoff"
 	"codemap/limits"
-	codemapmcp "codemap/mcp"
 	"codemap/render"
 	"codemap/scanner"
 	"codemap/watch"
@@ -108,9 +106,8 @@ func main() {
 
 	// Handle "mcp" subcommand before global flag parsing
 	if len(os.Args) >= 2 && os.Args[1] == "mcp" {
-		if err := codemapmcp.Run(context.Background()); err != nil {
-			fmt.Fprintf(os.Stderr, "MCP server error: %v\n", err)
-			os.Exit(1)
+		if code := cmd.RunMCP(); code != 0 {
+			os.Exit(code)
 		}
 		return
 	}

--- a/mcp_fallback_entrypoints_test.go
+++ b/mcp_fallback_entrypoints_test.go
@@ -35,6 +35,12 @@ func TestMCPEntrypointsMatchConfigFallback(t *testing.T) {
 	if !strings.Contains(cliResult, "Matches excluded by `only` config:") {
 		t.Fatalf("fallback guidance missing: %s", cliResult)
 	}
+
+	cliResult = probeFallbackTestBinary(t, cli, []string{"mcp", "ignored"}, root)
+	standaloneResult = probeFallbackTestBinary(t, standalone, []string{"ignored"}, root)
+	if cliResult != standaloneResult {
+		t.Fatalf("legacy argument handling differs:\ncodemap mcp: %s\ncodemap-mcp: %s", cliResult, standaloneResult)
+	}
 }
 
 func buildFallbackTestBinary(t *testing.T, output, pkg string) string {


### PR DESCRIPTION
## What does this PR do?

- Route both MCP executables through one shared `cmd.RunMCP` entrypoint.
- Preserve existing invocation behavior, including tolerated legacy arguments.
- Centralize server error-to-exit-status handling without changing the stdio server.
- Add process-level parity coverage for both executables and focused exit-status tests.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] New language support
- [ ] Documentation
- [x] Other: behavior-preserving refactor

## Checklist

- [x] Tested locally with focused regressions and the full platform checks listed below.
- [x] Read `CONTRIBUTING.md`; this PR does not add language support.
- [x] No documentation update is needed because user-facing behavior is unchanged.

## Additional notes

The executables duplicated startup and error handling. This focused refactor removes that drift and provides an independently mergeable foundation for [PR #79](https://github.com/JordanCoin/codemap/pull/79) without adding Codex-specific setup or plugin behavior.

Verification:

- `TestRunMCPReturnsServerStatus` covers successful and failed server execution.
- `TestMCPEntrypointsMatchConfigFallback` covers real MCP handshakes, tool calls, and legacy argument parity.
- macOS ARM64, Go 1.26.5: `go vet ./...` and `go test -race ./... -count=1`.
- Linux ARM64, Go 1.24.13: `go vet ./...` and `go test -p 1 ./... -count=1`.

Developed with carefully directed, manually reviewed AI assistance.

Co-Authored-By: GPT-5.6 Sol <codex@openai.com>
