### PR TITLE
feat(mcp): Add structured analysis results

### DIFF
--- a/mcp/analysis_output.go
+++ b/mcp/analysis_output.go
@@ -1,0 +1,180 @@
+package codemapmcp
+
+import (
+	"codemap/handoff"
+	"codemap/scanner"
+)
+
+const maxStructuredItems = 500
+
+type StructureOutput struct {
+	Kind         string          `json:"kind"`
+	Project      scanner.Project `json:"project"`
+	Hubs         []string        `json:"hubs"`
+	Truncated    bool            `json:"truncated"`
+	OmittedCount int             `json:"omitted_count"`
+}
+
+type DiffOutput struct {
+	Kind         string          `json:"kind"`
+	Ref          string          `json:"ref"`
+	Project      scanner.Project `json:"project"`
+	Truncated    bool            `json:"truncated"`
+	OmittedCount int             `json:"omitted_count"`
+}
+
+type ImportersOutput struct {
+	Kind           string   `json:"kind"`
+	Root           string   `json:"root"`
+	Mode           string   `json:"mode"`
+	File           string   `json:"file"`
+	Importers      []string `json:"importers"`
+	Imports        []string `json:"imports"`
+	HubImports     []string `json:"hub_imports"`
+	ImporterCount  int      `json:"importer_count"`
+	IsHub          bool     `json:"is_hub"`
+	CoverageStatus string   `json:"coverage_status"`
+	CoverageNotes  []string `json:"coverage_notes"`
+	Truncated      bool     `json:"truncated"`
+	OmittedCount   int      `json:"omitted_count"`
+}
+
+type HandoffOutput struct {
+	Kind         string                  `json:"kind"`
+	Artifact     *handoff.Artifact       `json:"artifact,omitempty"`
+	Prefix       *handoff.PrefixSnapshot `json:"prefix,omitempty"`
+	Delta        *handoff.DeltaSnapshot  `json:"delta,omitempty"`
+	FileDetail   *handoff.FileDetail     `json:"file_detail,omitempty"`
+	Message      string                  `json:"message,omitempty"`
+	Truncated    bool                    `json:"truncated"`
+	OmittedCount int                     `json:"omitted_count"`
+}
+
+func boundedProject(project scanner.Project) (scanner.Project, int) {
+	bounded := project
+	var omittedCount int
+	bounded.Files, omittedCount = boundedSlice(project.Files)
+	bounded.Impact, omittedCount = addBounded(project.Impact, omittedCount)
+	return bounded, omittedCount
+}
+
+func newStructureOutput(project scanner.Project, hubs []string) StructureOutput {
+	bounded, omittedCount := boundedProject(project)
+	boundedHubs, omittedCount := addBounded(hubs, omittedCount)
+	return StructureOutput{Kind: "structure", Project: bounded, Hubs: boundedHubs, Truncated: omittedCount > 0, OmittedCount: omittedCount}
+}
+
+func newDiffOutput(kind, ref string, project scanner.Project) DiffOutput {
+	bounded, omittedCount := boundedProject(project)
+	return DiffOutput{Kind: kind, Ref: ref, Project: bounded, Truncated: omittedCount > 0, OmittedCount: omittedCount}
+}
+
+func newImportersOutput(root, file string, graph *scanner.FileGraph) ImportersOutput {
+	importers := append([]string(nil), graph.Importers[file]...)
+	imports := append([]string(nil), graph.Imports[file]...)
+	hubImports := make([]string, 0, len(imports))
+	for _, imported := range imports {
+		if graph.IsHub(imported) {
+			hubImports = append(hubImports, imported)
+		}
+	}
+	boundedImporters, omittedCount := boundedSlice(importers)
+	boundedImports, omittedCount := addBounded(imports, omittedCount)
+	boundedHubs, omittedCount := addBounded(hubImports, omittedCount)
+	kind := "importers"
+	if len(importers) == 0 {
+		kind = "empty"
+	}
+	return ImportersOutput{
+		Kind: kind, Root: root, Mode: "importers", File: file,
+		Importers: boundedImporters, Imports: boundedImports, HubImports: boundedHubs,
+		ImporterCount: len(importers), IsHub: graph.IsHub(file),
+		CoverageStatus: graph.Coverage.Status, CoverageNotes: nonNilCopy(graph.Coverage.Notes),
+		Truncated: omittedCount > 0, OmittedCount: omittedCount,
+	}
+}
+
+func newHandoffOutput(kind string, artifact *handoff.Artifact) HandoffOutput {
+	output := HandoffOutput{Kind: kind}
+	var omittedCount int
+	switch kind {
+	case "artifact":
+		output.Artifact, omittedCount = boundedArtifact(artifact)
+	case "prefix":
+		bounded, omitted := boundedPrefix(artifact.Prefix)
+		output.Prefix = &bounded
+		omittedCount = omitted
+	case "delta":
+		bounded, omitted := addBoundedDelta(artifact.Delta, 0)
+		output.Delta = &bounded
+		omittedCount = omitted
+	}
+	output.Truncated = omittedCount > 0
+	output.OmittedCount = omittedCount
+	return output
+}
+
+func boundedFileDetail(detail *handoff.FileDetail) HandoffOutput {
+	bounded := *detail
+	var omittedCount int
+	bounded.Importers, omittedCount = boundedSlice(detail.Importers)
+	bounded.Imports, omittedCount = addBounded(detail.Imports, omittedCount)
+	bounded.RecentEvents, omittedCount = addBounded(detail.RecentEvents, omittedCount)
+	return HandoffOutput{Kind: "file_detail", FileDetail: &bounded, Truncated: omittedCount > 0, OmittedCount: omittedCount}
+}
+
+func boundedSlice[T any](values []T) ([]T, int) {
+	if len(values) <= maxStructuredItems {
+		return nonNilCopy(values), 0
+	}
+	return nonNilCopy(values[:maxStructuredItems]), len(values) - maxStructuredItems
+}
+
+func nonNilCopy[T any](values []T) []T {
+	return append(make([]T, 0, len(values)), values...)
+}
+
+func boundedArtifact(artifact *handoff.Artifact) (*handoff.Artifact, int) {
+	bounded := *artifact
+	omittedCount := 0
+	bounded.Prefix, omittedCount = boundedPrefix(artifact.Prefix)
+	bounded.Delta, omittedCount = addBoundedDelta(artifact.Delta, omittedCount)
+	bounded.AgentHistory, omittedCount = addBounded(artifact.AgentHistory, omittedCount)
+	for index := range bounded.AgentHistory {
+		bounded.AgentHistory[index].FilesEdited, omittedCount = addBounded(bounded.AgentHistory[index].FilesEdited, omittedCount)
+	}
+	bounded.ChangedFiles, omittedCount = addMirrorBounded(artifact.ChangedFiles, len(artifact.Delta.Changed), omittedCount)
+	bounded.RiskFiles, omittedCount = addMirrorBounded(artifact.RiskFiles, len(artifact.Delta.RiskFiles), omittedCount)
+	bounded.RecentEvents, omittedCount = addMirrorBounded(artifact.RecentEvents, len(artifact.Delta.RecentEvents), omittedCount)
+	bounded.NextSteps, omittedCount = addMirrorBounded(artifact.NextSteps, len(artifact.Delta.NextSteps), omittedCount)
+	bounded.OpenQuestions, omittedCount = addMirrorBounded(artifact.OpenQuestions, len(artifact.Delta.OpenQuestions), omittedCount)
+	return &bounded, omittedCount
+}
+
+func boundedPrefix(prefix handoff.PrefixSnapshot) (handoff.PrefixSnapshot, int) {
+	bounded := prefix
+	var omittedCount int
+	bounded.Hubs, omittedCount = boundedSlice(prefix.Hubs)
+	return bounded, omittedCount
+}
+
+func addBoundedDelta(delta handoff.DeltaSnapshot, omittedCount int) (handoff.DeltaSnapshot, int) {
+	bounded := delta
+	bounded.Changed, omittedCount = addBounded(delta.Changed, omittedCount)
+	bounded.RiskFiles, omittedCount = addBounded(delta.RiskFiles, omittedCount)
+	bounded.RecentEvents, omittedCount = addBounded(delta.RecentEvents, omittedCount)
+	bounded.NextSteps, omittedCount = addBounded(delta.NextSteps, omittedCount)
+	bounded.OpenQuestions, omittedCount = addBounded(delta.OpenQuestions, omittedCount)
+	return bounded, omittedCount
+}
+
+func addBounded[T any](values []T, omittedCount int) ([]T, int) {
+	bounded, newlyOmitted := boundedSlice(values)
+	return bounded, omittedCount + newlyOmitted
+}
+
+func addMirrorBounded[T any](values []T, mirroredLength, omittedCount int) ([]T, int) {
+	bounded, newlyOmitted := boundedSlice(values)
+	mirroredOmitted := max(0, mirroredLength-maxStructuredItems)
+	return bounded, omittedCount + max(0, newlyOmitted-mirroredOmitted)
+}

--- a/mcp/main.go
+++ b/mcp/main.go
@@ -25,6 +25,7 @@ import (
 	"codemap/skills"
 	"codemap/watch"
 
+	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
@@ -165,8 +166,9 @@ func NewServer(options RuntimeOptions) *mcp.Server {
 
 	// Tool: get_structure - Get project tree view
 	mcp.AddTool(server, &mcp.Tool{
-		Name:        "get_structure",
-		Description: "Get the project structure as a tree view. Shows files organized by directory with language detection, file sizes, and highlights the top 5 largest source files. Use this to understand how a codebase is organized.",
+		Name:         "get_structure",
+		Description:  "Get the project structure as a tree view. Shows files organized by directory with language detection, file sizes, and highlights the top 5 largest source files. Use this to understand how a codebase is organized.",
+		OutputSchema: mustSchemaFor[StructureOutput](),
 	}, handleGetStructure)
 
 	// Tool: get_dependencies - Get dependency graph
@@ -177,8 +179,9 @@ func NewServer(options RuntimeOptions) *mcp.Server {
 
 	// Tool: get_diff - Get changed files with impact analysis
 	mcp.AddTool(server, &mcp.Tool{
-		Name:        "get_diff",
-		Description: "Get files changed compared to a git branch, with line counts and impact analysis showing which changed files are imported by others. Use this to understand what work has been done and what might break.",
+		Name:         "get_diff",
+		Description:  "Get files changed compared to a git branch, with line counts and impact analysis showing which changed files are imported by others. Use this to understand what work has been done and what might break.",
+		OutputSchema: mustSchemaFor[DiffOutput](),
 	}, handleGetDiff)
 
 	// Tool: find_file - Find files by pattern
@@ -189,8 +192,9 @@ func NewServer(options RuntimeOptions) *mcp.Server {
 
 	// Tool: get_importers - Find what imports a file
 	mcp.AddTool(server, &mcp.Tool{
-		Name:        "get_importers",
-		Description: "Find all files that import/depend on a specific file. Use this to understand the impact of changing a file.",
+		Name:         "get_importers",
+		Description:  "Find all files that import/depend on a specific file. Use this to understand the impact of changing a file.",
+		OutputSchema: mustSchemaFor[ImportersOutput](),
 	}, handleGetImporters)
 
 	// Tool: status - Verify MCP connection
@@ -241,8 +245,9 @@ func NewServer(options RuntimeOptions) *mcp.Server {
 
 	// Tool: get_handoff - Build/read cross-agent handoff artifact
 	mcp.AddTool(server, &mcp.Tool{
-		Name:        "get_handoff",
-		Description: "Build or read a layered handoff artifact for agent switching. Prefix = stable project context, delta = recent work. Supports lazy per-file detail via file=<path>. Set save=true to persist generated artifacts.",
+		Name:         "get_handoff",
+		Description:  "Build or read a layered handoff artifact for agent switching. Prefix = stable project context, delta = recent work. Supports lazy per-file detail via file=<path>. Set save=true to persist generated artifacts.",
+		OutputSchema: mustSchemaFor[HandoffOutput](),
 	}, handleGetHandoff)
 
 	// Tool: get_working_set - Get current session's working set
@@ -287,6 +292,14 @@ func errorResult(text string) *mcp.CallToolResult {
 		},
 		IsError: true,
 	}
+}
+
+func mustSchemaFor[T any]() *jsonschema.Schema {
+	schema, err := jsonschema.For[T](nil)
+	if err != nil {
+		panic(fmt.Sprintf("infer MCP schema: %v", err))
+	}
+	return schema
 }
 
 func handleGetStructure(ctx context.Context, req *mcp.CallToolRequest, input StructureInput) (*mcp.CallToolResult, any, error) {
@@ -360,7 +373,7 @@ func handleGetStructure(ctx context.Context, req *mcp.CallToolRequest, input Str
 		}
 	}
 
-	return textResult(output), nil, nil
+	return textResult(output), newStructureOutput(project, hubs), nil
 }
 
 func handleGetDependencies(ctx context.Context, req *mcp.CallToolRequest, input PathInput) (*mcp.CallToolResult, any, error) {
@@ -405,7 +418,7 @@ func handleGetDiff(ctx context.Context, req *mcp.CallToolRequest, input DiffInpu
 	}
 
 	if len(diffInfo.Changed) == 0 {
-		return textResult("No files changed vs " + ref), nil, nil
+		return textResult("No files changed vs " + ref), newDiffOutput("empty", ref, scanner.Project{Root: absRoot, Mode: "tree", DiffRef: ref}), nil
 	}
 
 	gitCache := scanner.NewGitIgnoreCache(input.Path)
@@ -429,7 +442,7 @@ func handleGetDiff(ctx context.Context, req *mcp.CallToolRequest, input DiffInpu
 	render.Tree(&buf, project)
 	output := stripANSI(buf.String())
 
-	return textResult(output), nil, nil
+	return textResult(output), newDiffOutput("diff", ref, project), nil
 }
 
 func handleFindFile(ctx context.Context, req *mcp.CallToolRequest, input FindInput) (*mcp.CallToolResult, any, error) {
@@ -609,14 +622,20 @@ func getProjectStats(path string) string {
 }
 
 func handleGetImporters(ctx context.Context, req *mcp.CallToolRequest, input ImportersInput) (*mcp.CallToolResult, any, error) {
-	fg, err := scanner.BuildFileGraph(input.Path)
+	absRoot, err := filepath.Abs(input.Path)
+	if err != nil {
+		return errorResult("Invalid path: " + err.Error()), nil, nil
+	}
+	fg, err := scanner.BuildFileGraph(absRoot)
 	if err != nil {
 		return errorResult("Failed to build file graph: " + err.Error()), nil, nil
 	}
 
-	importers := fg.Importers[input.File]
+	file := normalizeImporterFile(absRoot, input.File)
+	importers := fg.Importers[file]
+	structured := newImportersOutput(absRoot, file, fg)
 	if len(importers) == 0 {
-		return textResult("No files import '" + input.File + "'" + mcpCoverageText(fg)), nil, nil
+		return textResult("No files import '" + file + "'" + mcpCoverageText(fg)), structured, nil
 	}
 
 	isHub := scanner.CountHubImporters(importers) >= scanner.HubThreshold
@@ -625,7 +644,17 @@ func handleGetImporters(ctx context.Context, req *mcp.CallToolRequest, input Imp
 		hubNote = " ⚠️ HUB FILE"
 	}
 
-	return textResult(fmt.Sprintf("%d files import '%s':%s\n%s%s", len(importers), input.File, hubNote, strings.Join(importers, "\n"), mcpCoverageText(fg))), nil, nil
+	return textResult(fmt.Sprintf("%d files import '%s':%s\n%s%s", len(importers), file, hubNote, strings.Join(importers, "\n"), mcpCoverageText(fg))), structured, nil
+}
+
+func normalizeImporterFile(root, file string) string {
+	file = filepath.FromSlash(file)
+	if filepath.IsAbs(file) {
+		if relative, err := filepath.Rel(root, file); err == nil {
+			file = relative
+		}
+	}
+	return filepath.Clean(file)
 }
 
 func mcpCoverageText(fg *scanner.FileGraph) string {
@@ -655,7 +684,8 @@ func handleGetHandoff(ctx context.Context, req *mcp.CallToolRequest, input Hando
 			return errorResult("Failed to read handoff: " + err.Error()), nil, nil
 		}
 		if artifact == nil {
-			return textResult("No saved handoff found at " + handoff.LatestPath(absRoot)), nil, nil
+			message := "No saved handoff found at " + handoff.LatestPath(absRoot)
+			return textResult(message), HandoffOutput{Kind: "not_found", Message: message}, nil
 		}
 	} else {
 		baseRef := input.Ref
@@ -692,31 +722,39 @@ func handleGetHandoff(ctx context.Context, req *mcp.CallToolRequest, input Hando
 		if err != nil {
 			return errorResult("Failed to load handoff detail: " + err.Error()), nil, nil
 		}
+		structured := boundedFileDetail(detail)
 		if input.JSON {
 			data, err := json.MarshalIndent(detail, "", "  ")
 			if err != nil {
 				return errorResult("Failed to serialize handoff detail: " + err.Error()), nil, nil
 			}
-			return textResult(string(data)), nil, nil
+			return textResult(string(data)), structured, nil
 		}
 		out := handoff.RenderFileDetailMarkdown(detail)
 		out = limits.TruncateAtLineBoundary(out, limits.MaxHandoffDetailBytes, "\n\n... (handoff detail truncated)\n")
-		return textResult(out), nil, nil
+		return textResult(out), structured, nil
 	}
+
+	kind := "artifact"
+	if input.Prefix {
+		kind = "prefix"
+	} else if input.Delta {
+		kind = "delta"
+	}
+	structured := newHandoffOutput(kind, artifact)
 
 	if input.JSON {
 		var payload any = artifact
-		switch {
-		case input.Prefix:
-			payload = artifact.Prefix
-		case input.Delta:
-			payload = artifact.Delta
+		if input.Prefix {
+			payload = &artifact.Prefix
+		} else if input.Delta {
+			payload = &artifact.Delta
 		}
 		data, err := json.MarshalIndent(payload, "", "  ")
 		if err != nil {
 			return errorResult("Failed to serialize handoff: " + err.Error()), nil, nil
 		}
-		return textResult(string(data)), nil, nil
+		return textResult(string(data)), structured, nil
 	}
 
 	var out string
@@ -729,7 +767,7 @@ func handleGetHandoff(ctx context.Context, req *mcp.CallToolRequest, input Hando
 		out = handoff.RenderMarkdown(artifact)
 	}
 	out = limits.TruncateAtLineBoundary(out, limits.MaxHandoffMarkdownBytes, "\n\n... (handoff output truncated)\n")
-	return textResult(out), nil, nil
+	return textResult(out), structured, nil
 }
 
 // ANSI escape code pattern

--- a/mcp/structured_contract_test.go
+++ b/mcp/structured_contract_test.go
@@ -1,0 +1,227 @@
+package codemapmcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"codemap/handoff"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+func TestAnalysisToolsAdvertiseAndReturnStructuredEnvelopes(t *testing.T) {
+	root := writeParityRepository(t)
+	session := connectParitySession(t)
+	tools, err := session.ListTools(context.Background(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"get_structure", "get_diff", "get_importers", "get_handoff"} {
+		if findParityTool(t, tools.Tools, name).OutputSchema == nil {
+			t.Fatalf("%s does not advertise an output schema", name)
+		}
+	}
+
+	cases := []struct {
+		label string
+		tool  string
+		args  map[string]any
+		kind  string
+	}{
+		{"structure", "get_structure", map[string]any{"path": root, "depth": 2}, "structure"},
+		{"diff", "get_diff", map[string]any{"path": root, "ref": "HEAD~1"}, "diff"},
+		{"empty_diff", "get_diff", map[string]any{"path": root, "ref": "HEAD"}, "empty"},
+		{"importers", "get_importers", map[string]any{"path": root, "file": "pkg/types/types.go"}, "importers"},
+		{"absolute_importers", "get_importers", map[string]any{"path": root, "file": filepath.Join(root, "pkg/types/types.go")}, "importers"},
+		{"empty_importers", "get_importers", map[string]any{"path": root, "file": "main.go"}, "empty"},
+		{"handoff", "get_handoff", map[string]any{"path": root, "ref": "HEAD~1"}, "artifact"},
+		{"handoff_prefix", "get_handoff", map[string]any{"path": root, "ref": "HEAD~1", "prefix": true}, "prefix"},
+		{"handoff_delta", "get_handoff", map[string]any{"path": root, "ref": "HEAD~1", "delta": true}, "delta"},
+		{"missing_handoff", "get_handoff", map[string]any{"path": root, "latest": true}, "not_found"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.label, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			result, err := session.CallTool(ctx, &mcp.CallToolParams{Name: tc.tool, Arguments: tc.args})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if result.IsError || result.StructuredContent == nil || resultText(t, result) == "" {
+				t.Fatalf("%s result = %#v", tc.tool, result)
+			}
+			payload := structuredParityMap(t, result.StructuredContent)
+			if payload["kind"] != tc.kind {
+				t.Fatalf("%s kind = %#v, want %q", tc.tool, payload["kind"], tc.kind)
+			}
+			if _, ok := payload["truncated"]; !ok {
+				t.Fatalf("%s payload lacks truncation metadata: %#v", tc.tool, payload)
+			}
+			if _, ok := payload["omitted_count"]; !ok {
+				t.Fatalf("%s payload lacks omitted count: %#v", tc.tool, payload)
+			}
+		})
+	}
+}
+
+func TestStructuredImporterPreservesCLIReportFields(t *testing.T) {
+	root := writeParityRepository(t)
+	session := connectParitySession(t)
+	result, err := session.CallTool(context.Background(), &mcp.CallToolParams{
+		Name:      "get_importers",
+		Arguments: map[string]any{"path": root, "file": "pkg/types/types.go"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload := structuredParityMap(t, result.StructuredContent)
+	for _, field := range []string{"imports", "importers", "hub_imports", "importer_count", "is_hub", "coverage_status", "coverage_notes"} {
+		if _, ok := payload[field]; !ok {
+			t.Fatalf("structured importer payload lacks %q: %#v", field, payload)
+		}
+	}
+}
+
+func TestNormalizeImporterFileUsesNativeGraphKeys(t *testing.T) {
+	root := filepath.Join(string(filepath.Separator)+"repo", "project")
+	want := filepath.Join("pkg", "types", "types.go")
+	for _, input := range []string{
+		"pkg/types/types.go",
+		filepath.Join(root, "pkg", "types", "types.go"),
+	} {
+		if got := normalizeImporterFile(root, input); got != want {
+			t.Fatalf("normalizeImporterFile(%q) = %q, want native key %q", input, got, want)
+		}
+	}
+}
+
+func TestHandoffVariantTruncationTracksSelectedPayload(t *testing.T) {
+	artifact := &handoff.Artifact{
+		Prefix: handoff.PrefixSnapshot{Hubs: []handoff.HubSummary{{Path: "hub.go"}}},
+		Delta:  handoff.DeltaSnapshot{Changed: make([]handoff.FileStub, maxStructuredItems+1)},
+	}
+	if output := newHandoffOutput("prefix", artifact); output.Truncated || output.OmittedCount != 0 {
+		t.Fatalf("prefix metadata counted omitted delta fields: %#v", output)
+	}
+	artifact.Prefix.Hubs = make([]handoff.HubSummary, maxStructuredItems+1)
+	artifact.Delta.Changed = []handoff.FileStub{{Path: "main.go"}}
+	if output := newHandoffOutput("delta", artifact); output.Truncated || output.OmittedCount != 0 {
+		t.Fatalf("delta metadata counted omitted prefix fields: %#v", output)
+	}
+}
+
+func TestHandoffJSONPreservesLegacyPayloadAndBoundsStructuredContent(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "pkg"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "go.mod"), []byte("module example.com/handoffbound\n\ngo 1.22\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "pkg", "target.go"), []byte("package pkg\n\ntype Target struct{}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	changed := make([]handoff.FileStub, maxStructuredItems+3)
+	for index := range changed {
+		changed[index] = handoff.FileStub{Path: fmt.Sprintf("file-%03d.go", index)}
+	}
+	changed[0].Path = "pkg/target.go"
+	artifact := &handoff.Artifact{SchemaVersion: handoff.SchemaVersion, Root: root, Delta: handoff.DeltaSnapshot{Changed: changed}}
+	if err := handoff.WriteLatest(root, artifact); err != nil {
+		t.Fatal(err)
+	}
+
+	result, structured, err := handleGetHandoff(context.Background(), nil, HandoffInput{Path: root, Latest: true, JSON: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var payload handoff.Artifact
+	if err := json.Unmarshal([]byte(resultText(t, result)), &payload); err != nil {
+		t.Fatal(err)
+	}
+	if len(payload.Delta.Changed) != len(changed) {
+		t.Fatalf("legacy JSON artifact changed files = %d, want %d", len(payload.Delta.Changed), len(changed))
+	}
+	// The artifact includes both the delta and its legacy top-level mirror.
+	output := structured.(HandoffOutput)
+	if len(output.Artifact.Delta.Changed) != maxStructuredItems || !output.Truncated || output.OmittedCount != 3 {
+		t.Fatalf("bounded structured artifact = %#v", output)
+	}
+
+	events := make([]handoff.EventSummary, maxStructuredItems+3)
+	for index := range events {
+		events[index].Path = "pkg/target.go"
+	}
+	artifact.Delta.RecentEvents = events
+	if err := handoff.WriteLatest(root, artifact); err != nil {
+		t.Fatal(err)
+	}
+	result, structured, err = handleGetHandoff(context.Background(), nil, HandoffInput{Path: root, Latest: true, File: "pkg/target.go", JSON: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var detail handoff.FileDetail
+	if err := json.Unmarshal([]byte(resultText(t, result)), &detail); err != nil {
+		t.Fatal(err)
+	}
+	detailOutput := structured.(HandoffOutput)
+	if len(detail.RecentEvents) != len(events) || len(detailOutput.FileDetail.RecentEvents) != maxStructuredItems || detailOutput.OmittedCount != 3 {
+		t.Fatalf("legacy detail events = %d; bounded structured detail = %#v", len(detail.RecentEvents), detailOutput)
+	}
+}
+
+func TestStructuredCollectionsAreBounded(t *testing.T) {
+	values := make([]string, maxStructuredItems+3)
+	bounded, omitted := boundedSlice(values)
+	if len(bounded) != maxStructuredItems || omitted != 3 {
+		t.Fatalf("bounded collection = %d items, %d omitted", len(bounded), omitted)
+	}
+	if bounded == nil {
+		t.Fatal("bounded empty-compatible collections must serialize as arrays")
+	}
+}
+
+func structuredParityMap(t *testing.T, value any) map[string]any {
+	t.Helper()
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(encoded, &payload); err != nil {
+		t.Fatal(err)
+	}
+	return payload
+}
+
+func writeParityRepository(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	for path, body := range map[string]string{
+		"go.mod":             "module example.com/parity\n\ngo 1.22\n",
+		"main.go":            "package main\n\nimport \"example.com/parity/pkg/types\"\n\nfunc main() { _ = types.Item{} }\n",
+		"pkg/types/types.go": "package types\n\ntype Item struct{}\n",
+	} {
+		full := filepath.Join(root, path)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	runGitMCPTestCmd(t, root, "init", "-b", "main")
+	runGitMCPTestCmd(t, root, "add", ".")
+	runGitMCPTestCmd(t, root, "-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "-m", "fixture")
+	if err := os.WriteFile(filepath.Join(root, "pkg/types/types.go"), []byte("package types\n\ntype Item struct{ Name string }\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGitMCPTestCmd(t, root, "add", ".")
+	runGitMCPTestCmd(t, root, "-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "-m", "change")
+	return root
+}


### PR DESCRIPTION
# feat(mcp): Add structured analysis results

## What does this PR do?

Adds bounded structured results for structure, diff, importer, and handoff MCP tools while preserving existing text and complete JSON responses.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] New language support
- [ ] Documentation
- [ ] Other (describe below)

## Checklist

- [x] I've tested this locally with `go build && ./codemap .`
- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) (for new language support)
- [x] I've updated documentation if needed

## Additional notes

Verification: `go test ./... -count=1`.

Developed with carefully directed, manually reviewed AI assistance.

Co-Authored-By: GPT-5.6 Sol <codex@openai.com>
