### PR TITLE
fix(handoff): Honor configured file counts

### DIFF
--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -138,5 +138,6 @@ Surface behavior note:
 
 Output and budget notes:
 - text responses are byte-budgeted and line-truncated to protect context
+- prefix file counts and size-based handoff budgets honor the active `.codemap/config.json` filters
 - handoff payload includes deterministic hashes (`prefix_hash`, `delta_hash`, `combined_hash`)
 - handoff payload includes cache metrics (`reuse_ratio`, `unchanged_bytes`, etc.)

--- a/handoff/build.go
+++ b/handoff/build.go
@@ -68,7 +68,7 @@ func Build(root string, opts BuildOptions) (*Artifact, error) {
 		state = watch.ReadState(absRoot)
 	}
 
-	fileCount := resolveRepoFileCount(absRoot, state)
+	fileCount := resolveRepoFileCount(absRoot)
 	opts = normalizeOptions(opts, fileCount)
 
 	branch, err := gitCurrentBranch(absRoot)
@@ -595,13 +595,9 @@ func gitCurrentBranch(root string) (string, error) {
 	return strings.TrimSpace(string(out)), nil
 }
 
-func resolveRepoFileCount(root string, state *watch.State) int {
-	if state != nil && state.FileCount > 0 {
-		return state.FileCount
-	}
-
+func resolveRepoFileCount(root string) int {
 	gitCache := scanner.NewGitIgnoreCache(root)
-	files, err := scanner.ScanFiles(root, gitCache, nil, nil)
+	files, err := scanner.ScanConfiguredFiles(root, gitCache)
 	if err != nil {
 		return 0
 	}
@@ -613,7 +609,7 @@ func dependencyImportersForHandoff(root string, state *watch.State, fileCount in
 		return state.Importers
 	}
 
-	// Reuse daemon file count when available to avoid an extra scan.
+	// Skip fallback graph construction for configured large repositories.
 	if fileCount > limits.LargeRepoFileCount {
 		return nil
 	}

--- a/handoff/config_filter_test.go
+++ b/handoff/config_filter_test.go
@@ -1,0 +1,53 @@
+package handoff
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"codemap/limits"
+	"codemap/watch"
+)
+
+func TestConfiguredFileCountControlsHandoffBudgetsAndDependencies(t *testing.T) {
+	root := t.TempDir()
+	write := func(path, content string) {
+		path = filepath.Join(root, path)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	runCmd(t, root, "git", "init")
+	write("go.mod", "module example\n\ngo 1.25\n")
+	write("notes.md", "not configured source\n")
+	runCmd(t, root, "git", "add", ".")
+	runCmd(t, root, "git", "-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "-m", "init")
+	write(".codemap/config.json", `{"only":["go"]}`)
+	write("lib/lib.go", "package lib\n")
+	write("cmd/main.go", "package main\n\nimport _ \"example/lib\"\n")
+	for i := 0; i < 28; i++ {
+		write(fmt.Sprintf("file%02d.go", i), "package example\n")
+	}
+
+	state := &watch.State{FileCount: limits.LargeRepoFileCount + 1}
+	artifact, err := Build(root, BuildOptions{BaseRef: "HEAD", State: state})
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+	if artifact.Prefix.FileCount != 30 {
+		t.Fatalf("configured file count = %d, want 30", artifact.Prefix.FileCount)
+	}
+	if len(artifact.Delta.Changed) != 30 {
+		t.Fatalf("configured small-repo budget kept %d changed files, want 30", len(artifact.Delta.Changed))
+	}
+
+	importers, _ := dependencyContextForFile(root, state, "lib/lib.go")
+	if len(importers) != 1 || importers[0] != "cmd/main.go" {
+		t.Fatalf("configured dependency importers = %v, want [cmd/main.go]", importers)
+	}
+}

--- a/handoff/detail.go
+++ b/handoff/detail.go
@@ -70,7 +70,7 @@ func dependencyContextForFile(root string, state *watch.State, path string) ([]s
 		return append([]string{}, state.Importers[path]...), append([]string{}, state.Imports[path]...)
 	}
 
-	if state != nil && state.FileCount > limits.LargeRepoFileCount {
+	if resolveRepoFileCount(root) > limits.LargeRepoFileCount {
 		return nil, nil
 	}
 

--- a/skills/builtin/handoff.md
+++ b/skills/builtin/handoff.md
@@ -12,13 +12,13 @@ keywords: ["handoff", "agent", "switch", "continue", "resume", "context"]
 ```bash
 codemap handoff .                 # Build + save full artifact
 codemap handoff --json .          # Machine-readable for other tools
-codemap handoff --prefix .        # Stable context only (hub summaries, file count)
+codemap handoff --prefix .        # Stable context only (hubs, configured file count)
 codemap handoff --delta .         # Recent work only (changed files, risk, events)
 ```
 
 ## What's in a handoff
 
-- **Prefix** (stable): project file count, hub summaries — changes rarely
+- **Prefix** (stable): configured project file count, hub summaries — changes rarely
 - **Delta** (dynamic): changed files, risk files, recent edit events, next steps
 - **Hashes**: deterministic hashes for cache validation across agents
 
@@ -30,6 +30,8 @@ codemap handoff --detail file.go . # Lazy-load full context for one file
 ```
 
 The MCP tool `get_handoff` provides the same capabilities for tool-based consumption.
+The prefix file count and size-based handoff budgets honor the active
+`.codemap/config.json` filters even when watch state tracks a broader working set.
 
 ## When to handoff
 


### PR DESCRIPTION
## What does this PR do?

Uses configured file counts for handoff budgets and fallback dependency gates instead of unfiltered watch-state counts.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] New language support
- [ ] Documentation
- [ ] Other (describe below)

## Checklist

- [x] I've tested this locally with `go build && ./codemap .`
- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) (for new language support)
- [x] I've updated documentation if needed

## Additional notes

Verification: `go test ./handoff ./cmd -count=1`.

Developed with carefully directed, manually reviewed AI assistance.

Co-Authored-By: GPT-5.6 Sol <codex@openai.com>