### PR TITLE
fix(scanner): Resolve Rust `dev` dependencies in source targets

### DIFF
--- a/scanner/rustcargo_test.go
+++ b/scanner/rustcargo_test.go
@@ -219,9 +219,13 @@ func TestCargoMetadataScopesDependenciesByCallerAndTargetKind(t *testing.T) {
 	files := map[string]string{
 		"Cargo.toml":               "[workspace]\nmembers = [\"app\"]\n",
 		"app/Cargo.toml":           cargoTestManifest("app"),
-		"app/src/lib.rs":           "pub fn call() {}\n",
+		"app/src/lib.rs":           "#[cfg(test)] mod unit_tests;\npub fn call() {}\n",
+		"app/src/main.rs":          "fn main() {}\n",
+		"app/src/unit_tests.rs":    "#[test] fn unit() {}\n",
 		"app/build.rs":             "fn main() {}\n",
 		"app/tests/integration.rs": "fn test() {}\n",
+		"app/examples/demo.rs":     "fn main() {}\n",
+		"app/benches/measure.rs":   "fn main() {}\n",
 		"normal/Cargo.toml":        "[package]\nname = \"normal\"\nversion = \"0.1.0\"\n",
 		"normal/src/lib.rs":        "pub mod api;\n",
 		"normal/src/api.rs":        "pub fn run() {}\n",
@@ -241,8 +245,11 @@ func TestCargoMetadataScopesDependenciesByCallerAndTargetKind(t *testing.T) {
 	packages := []map[string]any{
 		cargoPackageWithTargets(root, "app", "app", []map[string]any{
 			cargoTargetJSON(root, "app/src/lib.rs", "app", rustTargetLib),
+			cargoTargetJSON(root, "app/src/main.rs", "app-bin", rustTargetBin),
 			cargoTargetJSON(root, "app/build.rs", "build-script-build", rustTargetCustomBuild),
 			cargoTargetJSON(root, "app/tests/integration.rs", "integration", rustTargetTest),
+			cargoTargetJSON(root, "app/examples/demo.rs", "demo", rustTargetExample),
+			cargoTargetJSON(root, "app/benches/measure.rs", "measure", rustTargetBench),
 		}, dependencies),
 		cargoPackage(root, "normal", "normal", "normal", nil),
 		cargoPackage(root, "build-dep", "build-dep", "build_dep", nil),
@@ -255,18 +262,26 @@ func TestCargoMetadataScopesDependenciesByCallerAndTargetKind(t *testing.T) {
 		{Path: "dev_dep::api::run", Kind: "rust-path"},
 	}
 	analyses := []FileAnalysis{
-		{Path: "app/src/lib.rs", Language: "rust", References: refs},
+		{Path: "app/src/lib.rs", Language: "rust", References: append([]ImportReference{{Path: "unit_tests", Kind: "rust-module"}}, refs...)},
+		{Path: "app/src/main.rs", Language: "rust", References: refs},
+		{Path: "app/src/unit_tests.rs", Language: "rust", References: refs},
 		{Path: "app/build.rs", Language: "rust", References: refs},
 		{Path: "app/tests/integration.rs", Language: "rust", References: refs},
+		{Path: "app/examples/demo.rs", Language: "rust", References: refs},
+		{Path: "app/benches/measure.rs", Language: "rust", References: refs},
 	}
 	graph, err := buildFileGraphFromAnalysesWithCargoMetadata(context.Background(), root, analyses, func(context.Context, string) ([]byte, error) { return metadata, nil })
 	if err != nil {
 		t.Fatal(err)
 	}
 	for from, want := range map[string][]string{
-		"app/src/lib.rs":           {"normal/src/api.rs"},
+		"app/src/lib.rs":           {"app/src/unit_tests.rs", "dev-dep/src/api.rs", "normal/src/api.rs"},
+		"app/src/main.rs":          {"dev-dep/src/api.rs", "normal/src/api.rs"},
+		"app/src/unit_tests.rs":    {"dev-dep/src/api.rs", "normal/src/api.rs"},
 		"app/build.rs":             {"build-dep/src/api.rs"},
 		"app/tests/integration.rs": {"dev-dep/src/api.rs", "normal/src/api.rs"},
+		"app/examples/demo.rs":     {"dev-dep/src/api.rs", "normal/src/api.rs"},
+		"app/benches/measure.rs":   {"dev-dep/src/api.rs", "normal/src/api.rs"},
 	} {
 		got := append([]string(nil), graph.Imports[from]...)
 		sort.Strings(got)

--- a/scanner/rustgraph.go
+++ b/scanner/rustgraph.go
@@ -11,7 +11,7 @@ import (
 
 const (
 	rustCoverageStatus = "partial"
-	rustCoverageNote   = "Rust macro-generated, cfg-gated dev-dependency, string-routed, and #[path] module edges may be unresolved"
+	rustCoverageNote   = "Rust macro-generated, string-routed, and #[path] module edges may be unresolved"
 
 	rustTargetLib         = "lib"
 	rustTargetBin         = "bin"
@@ -431,8 +431,6 @@ func rustDependencyEligible(dependencyKind, targetKind string) bool {
 	switch dependencyKind {
 	case "build":
 		return targetKind == rustTargetCustomBuild
-	case "dev":
-		return targetKind == rustTargetTest || targetKind == rustTargetExample || targetKind == rustTargetBench
 	default:
 		return targetKind != rustTargetCustomBuild
 	}


### PR DESCRIPTION
## What does this PR do?

Normal dependencies already resolve from every non-build target, and build dependencies remain scoped to custom-build targets.
This closes the remaining gap: `dev` dependencies now resolve from library, binary, example, test, and benchmark sources.

This lets a sandboxed coding agent run `codemap --deps ../rust-worktree` and see target-correct local dependency edges throughout the workspace.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] New language support
- [ ] Documentation
- [ ] Other (describe below)

## Checklist

- [x] I've tested this locally with `go build && ./codemap .`
- [x] I've read `CONTRIBUTING.md`; this does not add a new language.
- [x] Documentation is unchanged because this corrects existing Rust scanning.

## Additional notes

Focused Cargo-target tests cover library, binary, unit, integration, example, benchmark, and custom-build targets.
Full verification is recorded at the publication tip.

Developed with carefully directed, manually reviewed AI assistance.

Co-Authored-By: GPT-5.6 Sol <codex@openai.com>