### PR TITLE
fix(doctor): Report effective agent config, not file layout

### DIFF
--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -273,15 +273,6 @@ func doctorAnyConfigured(firstPath string, firstErr error, secondPath string, se
 	return false
 }
 
-func checkResolvedFile(label, path string, pathErr error, validate func(string) error, check func(string, string, func(string) error), failures *int) {
-	if pathErr != nil {
-		fmt.Printf("MISS %s: could not resolve path (%v)\n", label, pathErr)
-		(*failures)++
-		return
-	}
-	check(label, path, validate)
-}
-
 // doctorScope is one configuration location a check may be satisfied from.
 // validate overrides the check's default validator when a scope stores the
 // same setting in a different format, as the Codex plugin manifest does.

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -105,11 +105,13 @@ func RunDoctor(args []string, defaultRoot string) int {
 	claudeMCP, claudeMCPErr := claudeMCPPath(root, *global)
 	codexHooks, codexHooksErr := codexHooksPath(root, *global)
 	codexMCP, codexMCPErr := codexConfigPath(root, *global)
-	validateEffectiveCodexMCP := validateCodexMCP
-	if !*global && codexMCPErr == nil && !codexProjectMCPOverridesPlugin(codexMCP) {
+	// An active Codex plugin manifest supersedes the project config, but never
+	// the user config, which remains the fallback scope below.
+	codexMCPScopes := doctorScopesFor(root, *global, codexConfigPath)
+	if !*global && codexMCPScopes[0].err == nil && !codexProjectMCPOverridesPlugin(codexMCPScopes[0].path) {
 		if pluginMCP, ok := activeCodexPluginMCPPath(); ok {
 			codexMCP = pluginMCP
-			validateEffectiveCodexMCP = validateCodexPluginMCP
+			codexMCPScopes[0] = doctorScope{name: "plugin", path: pluginMCP, validate: validateCodexPluginMCP}
 		}
 	}
 	claudeConfigured := doctorAnyConfigured(claudeSettings, claudeSettingsErr, claudeMCP, claudeMCPErr)
@@ -133,15 +135,15 @@ func RunDoctor(args []string, defaultRoot string) int {
 	}
 
 	if selected == "claude" || (selected == "" && (claudeConfigured || (!anyConfigured && claudeAvailable))) {
-		checkResolvedFile("Claude hooks", claudeSettings, claudeSettingsErr, func(path string) error {
+		checkScopedFile("Claude hooks", doctorScopesFor(root, *global, claudeSettingsPath), func(path string) error {
 			return validateHooks(path, recommendedClaudeHooks)
-		}, checkFile, &failures)
-		checkResolvedFile("Claude MCP", claudeMCP, claudeMCPErr, validateClaudeMCP, checkFile, &failures)
+		}, &failures)
+		checkScopedFile("Claude MCP", claudeMCPScopes(root, *global), validateClaudeMCP, &failures)
 	}
 	if selected == "codex" || (selected == "" && (codexConfigured || (!anyConfigured && (codexAvailable || codexDesktopAvailable)))) {
-		checkResolvedFile("Codex hooks", codexHooks, codexHooksErr, func(path string) error {
+		checkScopedFile("Codex hooks", doctorScopesFor(root, *global, codexHooksPath), func(path string) error {
 			return validateHooks(path, recommendedCodexHooks)
-		}, checkFile, &failures)
+		}, &failures)
 		if codexAvailable && codexHooksErr == nil && validateHooks(codexHooks, recommendedCodexHooks) == nil {
 			if err := validateCodexHookTrust(root); err != nil {
 				fmt.Printf("MISS Codex hook trust: %v\n", err)
@@ -150,7 +152,7 @@ func RunDoctor(args []string, defaultRoot string) int {
 				fmt.Println("OK   Codex hook trust: all Codemap hooks are enabled and runnable")
 			}
 		}
-		checkResolvedFile("Codex MCP", codexMCP, codexMCPErr, validateEffectiveCodexMCP, checkFile, &failures)
+		checkScopedFile("Codex MCP", codexMCPScopes, validateCodexMCP, &failures)
 	}
 
 	if failures > 0 {
@@ -280,6 +282,99 @@ func checkResolvedFile(label, path string, pathErr error, validate func(string) 
 	check(label, path, validate)
 }
 
+// doctorScope is one configuration location a check may be satisfied from.
+// validate overrides the check's default validator when a scope stores the
+// same setting in a different format, as the Codex plugin manifest does.
+type doctorScope struct {
+	name     string
+	path     string
+	err      error
+	validate func(string) error
+}
+
+// checkScopedFile validates a check against each scope in order and reports the
+// first that satisfies it, naming the scope that did.
+//
+// Agents merge user-level configuration into every project, so a hook or MCP
+// server defined in the user scope genuinely applies to this project. Reporting
+// it MISS because the project file does not repeat it describes the file layout
+// rather than the effective configuration. When every scope fails, the first
+// scope's failure is reported, since that is the one the user is expected to fix.
+func checkScopedFile(label string, scopes []doctorScope, validate func(string) error, failures *int) {
+	// When every scope fails, prefer reporting one that exists but is wired up
+	// wrong over one whose file is simply absent: the former is the user's
+	// actual problem, the latter is the normal state of an unused scope.
+	var misconfigured, absent *doctorScope
+	var misconfiguredErr, absentErr error
+	remember := func(scope *doctorScope, err error) {
+		if errors.Is(err, os.ErrNotExist) {
+			if absent == nil {
+				absent, absentErr = scope, err
+			}
+			return
+		}
+		if misconfigured == nil {
+			misconfigured, misconfiguredErr = scope, err
+		}
+	}
+
+	for index := range scopes {
+		scope := scopes[index]
+		if scope.err != nil {
+			remember(&scopes[index], fmt.Errorf("could not resolve path (%w)", scope.err))
+			continue
+		}
+		validateScope := validate
+		if scope.validate != nil {
+			validateScope = scope.validate
+		}
+		if err := validateScope(scope.path); err != nil {
+			remember(&scopes[index], err)
+			continue
+		}
+		fmt.Printf("OK   %s: %s (%s scope)\n", label, scope.path, scope.name)
+		return
+	}
+
+	*failures++
+	switch {
+	case misconfigured != nil:
+		fmt.Printf("MISS %s: %s (%v)\n", label, misconfigured.path, misconfiguredErr)
+	case absent != nil:
+		fmt.Printf("MISS %s: %s (%v)\n", label, absent.path, absentErr)
+	default:
+		fmt.Printf("MISS %s: no configuration scope available\n", label)
+	}
+}
+
+// claudeMCPScopes returns the three places Claude Code loads MCP servers from,
+// in the order it resolves them: the committed project .mcp.json, the local
+// per-project entry inside the user-level ~/.claude.json (what `claude mcp add`
+// writes by default), and that file's top-level user-wide servers.
+func claudeMCPScopes(root string, global bool) []doctorScope {
+	scopes := doctorScopesFor(root, global, claudeMCPPath)
+	if global {
+		return scopes
+	}
+	userPath, userErr := claudeMCPPath(root, true)
+	local := doctorScope{name: "local", path: userPath, err: userErr, validate: validateClaudeLocalMCP(root)}
+	return []doctorScope{scopes[0], local, scopes[1]}
+}
+
+// doctorScopesFor returns the scopes a check should consult. With --global the
+// user scope is the explicit subject of the check, so project files must not
+// satisfy it; otherwise the project scope is preferred and the user scope acts
+// as the fallback that reflects what the agent actually loads.
+func doctorScopesFor(root string, global bool, resolve func(string, bool) (string, error)) []doctorScope {
+	userPath, userErr := resolve(root, true)
+	userScope := doctorScope{name: "user", path: userPath, err: userErr}
+	if global {
+		return []doctorScope{userScope}
+	}
+	projectPath, projectErr := resolve(root, false)
+	return []doctorScope{{name: "project", path: projectPath, err: projectErr}, userScope}
+}
+
 func validateJSONFile(path string) error {
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -314,11 +409,88 @@ func validateHooks(path string, specs []claudeHookSpec) error {
 		return fmt.Errorf("invalid hooks: %w", err)
 	}
 	for _, spec := range specs {
-		if !hasHookSpec(hooks[spec.Event], spec) {
+		if !hookSpecSatisfied(hooks[spec.Event], spec) {
 			return fmt.Errorf("missing %s hook %q", spec.Event, spec.Command)
 		}
 	}
 	return nil
+}
+
+// hookSpecSatisfied reports whether entries already run the codemap subcommand
+// that spec describes.
+//
+// This deliberately differs from hasHookSpec, which demands byte-identity
+// because setup uses it to decide which entries it owns and may rewrite. Doctor
+// answers a weaker question — "is this hook wired up?" — so it accepts any
+// spelling that runs the same thing: PATH-resolved or absolute executable,
+// quoted or bare, with or without the --integration ownership tag. Requiring
+// the canonical spelling here reports working installations as broken.
+func hookSpecSatisfied(entries []claudeHookEntry, spec claudeHookSpec) bool {
+	requiredMatcher := strings.TrimSpace(spec.Matcher)
+	for _, entry := range entries {
+		if requiredMatcher != "" && !strings.EqualFold(strings.TrimSpace(entry.Matcher), requiredMatcher) {
+			continue
+		}
+		for _, hook := range entry.Hooks {
+			if !strings.EqualFold(strings.TrimSpace(hook.Type), "command") {
+				continue
+			}
+			if hookCommandSatisfies(hook.Command, spec.Command) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// hookCommandSatisfies reports whether existing invokes the same codemap
+// subcommand as target.
+func hookCommandSatisfies(existing, target string) bool {
+	existingExecutable, existingArgs, ok := splitHookCommand(existing)
+	if !ok {
+		return false
+	}
+	_, targetArgs, ok := splitHookCommand(target)
+	if !ok {
+		return false
+	}
+	return existingArgs == targetArgs && hookExecutableIsCodemap(existingExecutable)
+}
+
+// splitHookCommand separates a hook command into its executable and the codemap
+// argument list beginning at "hook", with the --integration tag removed.
+//
+// Dropping --integration is safe because it never changes behavior: main.go
+// parses it, checks it agrees with the agent, then discards it. --agent does
+// change behavior and is preserved, so a Claude hook cannot satisfy a Codex spec.
+func splitHookCommand(command string) (executable, args string, ok bool) {
+	command = strings.TrimSpace(command)
+	index := strings.Index(command, " hook ")
+	if index < 0 {
+		return "", "", false
+	}
+	executable, ok = unquoteHookExecutable(strings.TrimSpace(command[:index]))
+	if !ok {
+		return "", "", false
+	}
+	fields := strings.Fields(command[index:])
+	kept := fields[:0]
+	for _, field := range fields {
+		if strings.HasPrefix(field, "--integration=") {
+			continue
+		}
+		kept = append(kept, field)
+	}
+	return executable, strings.Join(kept, " "), true
+}
+
+// hookExecutableIsCodemap reports whether a hook executable names a codemap
+// binary, accepting POSIX and Windows path separators, drive-letter paths, and
+// the .exe suffix.
+func hookExecutableIsCodemap(path string) bool {
+	normalized := strings.ReplaceAll(path, `\`, "/")
+	name := strings.ToLower(normalized[strings.LastIndex(normalized, "/")+1:])
+	return name == "codemap" || name == "codemap.exe"
 }
 
 func validateClaudeMCP(path string) error {
@@ -339,6 +511,40 @@ func validateClaudeMCP(path string) error {
 		return fmt.Errorf("missing codemap MCP server; repair with `codemap setup --agent claude`")
 	}
 	return validateDoctorMCPServer(server, "claude")
+}
+
+// validateClaudeLocalMCP validates the server registered for one project inside
+// the user-level ~/.claude.json, which is where `claude mcp add` writes by
+// default. The entry lives under projects[<root>].mcpServers rather than the
+// top-level mcpServers object that validateClaudeMCP reads.
+func validateClaudeLocalMCP(projectRoot string) func(string) error {
+	return func(path string) error {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		payload := map[string]any{}
+		if err := json.Unmarshal(data, &payload); err != nil {
+			return fmt.Errorf("invalid JSON: %w", err)
+		}
+		projects, ok := payload["projects"].(map[string]any)
+		if !ok {
+			return fmt.Errorf("no project-scoped MCP servers registered")
+		}
+		project, ok := projects[projectRoot].(map[string]any)
+		if !ok {
+			return fmt.Errorf("no MCP servers registered for %s", projectRoot)
+		}
+		servers, ok := project["mcpServers"].(map[string]any)
+		if !ok {
+			return fmt.Errorf("no MCP servers registered for %s", projectRoot)
+		}
+		server, ok := servers["codemap"]
+		if !ok {
+			return fmt.Errorf("missing codemap MCP server; repair with `codemap setup --agent claude`")
+		}
+		return validateDoctorMCPServer(server, "claude")
+	}
 }
 
 func validateCodexMCP(path string) error {

--- a/cmd/doctor_scope_test.go
+++ b/cmd/doctor_scope_test.go
@@ -1,0 +1,346 @@
+package cmd
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func runtimeIsWindows() bool { return runtime.GOOS == "windows" }
+
+// hookSettingsJSON renders a Claude settings file whose hook commands are
+// derived from specs via transform. It lets tests express "the same hooks,
+// written a different but equivalent way".
+func hookSettingsJSON(t *testing.T, specs []claudeHookSpec, transform func(claudeHookSpec) string) string {
+	t.Helper()
+	hooks := map[string][]claudeHookEntry{}
+	for _, spec := range specs {
+		hooks[spec.Event] = append(hooks[spec.Event], claudeHookEntry{
+			Matcher: spec.Matcher,
+			Hooks:   []claudeHookCommand{{Type: "command", Command: transform(spec)}},
+		})
+	}
+	data, err := json.Marshal(map[string]any{"hooks": hooks})
+	if err != nil {
+		t.Fatalf("marshal settings: %v", err)
+	}
+	return string(data)
+}
+
+func writeHookSettings(t *testing.T, path, contents string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+// stripIntegrationTag removes the trailing --integration=<value> token that
+// codemap adds purely as an ownership marker.
+func stripIntegrationTag(command string) string {
+	marker := " --integration="
+	index := strings.LastIndex(command, marker)
+	if index < 0 {
+		return command
+	}
+	rest := command[index+len(marker):]
+	if space := strings.Index(rest, " "); space >= 0 {
+		return command[:index] + rest[space:]
+	}
+	return command[:index]
+}
+
+// TestValidateHooksAcceptsEquivalentCommands pins the rule that doctor reports
+// a hook as present when it invokes the same codemap subcommand, regardless of
+// whether the executable is PATH-resolved or absolute and whether the
+// ownership tag is present. setup already treats the bare form as codemap-owned
+// (migrateOwnedHookCommand), so doctor must not call it missing.
+func TestValidateHooksAcceptsEquivalentCommands(t *testing.T) {
+	specs := generatedClaudeHooks("/usr/local/bin/codemap")
+
+	for _, tt := range []struct {
+		name      string
+		transform func(claudeHookSpec) string
+		wantErr   bool
+	}{
+		{
+			name:      "canonical quoted absolute with tag",
+			transform: func(s claudeHookSpec) string { return s.Command },
+		},
+		{
+			name: "PATH-resolved bare executable without tag",
+			transform: func(s claudeHookSpec) string {
+				return stripIntegrationTag(strings.Replace(s.Command, "'/usr/local/bin/codemap'", "codemap", 1))
+			},
+		},
+		{
+			name: "unquoted absolute path without tag",
+			transform: func(s claudeHookSpec) string {
+				return stripIntegrationTag(strings.Replace(s.Command, "'/usr/local/bin/codemap'", "/usr/local/bin/codemap", 1))
+			},
+		},
+		{
+			name: "windows quoted exe with tag",
+			transform: func(s claudeHookSpec) string {
+				return strings.Replace(s.Command, "'/usr/local/bin/codemap'", `"C:\Tools\codemap.exe"`, 1)
+			},
+		},
+		{
+			name: "different subcommand is not a match",
+			transform: func(s claudeHookSpec) string {
+				return strings.Replace(s.Command, " hook ", " hook not-a-real-", 1)
+			},
+			wantErr: true,
+		},
+		{
+			name: "foreign executable is not a match",
+			transform: func(s claudeHookSpec) string {
+				return stripIntegrationTag(strings.Replace(s.Command, "'/usr/local/bin/codemap'", "othertool", 1))
+			},
+			wantErr: true,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "settings.json")
+			writeHookSettings(t, path, hookSettingsJSON(t, specs, tt.transform))
+
+			err := validateHooks(path, specs)
+			if tt.wantErr && err == nil {
+				t.Fatalf("validateHooks() = nil, want error")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("validateHooks() = %v, want nil", err)
+			}
+		})
+	}
+}
+
+// TestValidateHooksKeepsAgentDistinct guards against the relaxation being too
+// loose: a Claude hook command must not satisfy the Codex spec, because
+// --agent=codex changes hook behavior (unlike --integration, which does not).
+func TestValidateHooksKeepsAgentDistinct(t *testing.T) {
+	claudeSpecs := generatedClaudeHooks("/usr/local/bin/codemap")
+	codexSpecs := generatedCodexHooks("/usr/local/bin/codemap")
+
+	path := filepath.Join(t.TempDir(), "settings.json")
+	writeHookSettings(t, path, hookSettingsJSON(t, claudeSpecs, func(s claudeHookSpec) string {
+		return stripIntegrationTag(s.Command)
+	}))
+
+	if err := validateHooks(path, codexSpecs); err == nil {
+		t.Fatal("validateHooks() accepted Claude hooks for the Codex spec, want error")
+	}
+}
+
+// TestHasHookSpecStaysExact protects setup's ownership decision. Rewriting a
+// hook entry in place requires byte-identity; only doctor's "is it present"
+// question is allowed to be semantic.
+func TestHasHookSpecStaysExact(t *testing.T) {
+	spec := generatedClaudeHooks("/usr/local/bin/codemap")[0]
+	entries := []claudeHookEntry{{
+		Hooks: []claudeHookCommand{{Type: "command", Command: stripIntegrationTag(spec.Command)}},
+	}}
+
+	if hasHookSpec(entries, spec) {
+		t.Fatal("hasHookSpec() matched a non-identical command; setup would skip migrating it")
+	}
+}
+
+// TestRunDoctorFallsBackToUserScopeHooks covers the scope half: Claude Code
+// merges user settings into every project, so hooks configured in
+// ~/.claude/settings.json genuinely apply here and must not be reported MISS.
+func TestRunDoctorFallsBackToUserScopeHooks(t *testing.T) {
+	home := t.TempDir()
+	root := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	originalLook := doctorLookPath
+	originalRecommended := recommendedClaudeHooks
+	t.Cleanup(func() {
+		doctorLookPath = originalLook
+		recommendedClaudeHooks = originalRecommended
+	})
+	doctorLookPath = func(name string) (string, error) {
+		if name == "claude" {
+			return "/usr/local/bin/claude", nil
+		}
+		return "", os.ErrNotExist
+	}
+	recommendedClaudeHooks = generatedClaudeHooks("/usr/local/bin/codemap")
+
+	// Project scope has settings but no hooks; user scope has them.
+	writeHookSettings(t, filepath.Join(root, ".claude", "settings.local.json"), `{"permissions":{}}`)
+	writeHookSettings(t, filepath.Join(home, ".claude", "settings.json"),
+		hookSettingsJSON(t, recommendedClaudeHooks, func(s claudeHookSpec) string { return s.Command }))
+
+	out := captureOutput(func() { RunDoctor([]string{"--agent", "claude", root}, ".") })
+
+	if strings.Contains(out, "MISS Claude hooks") {
+		t.Fatalf("doctor reported Claude hooks missing despite user-scope configuration:\n%s", out)
+	}
+	if !strings.Contains(out, "OK   Claude hooks") {
+		t.Fatalf("doctor did not report Claude hooks OK:\n%s", out)
+	}
+	if !strings.Contains(out, "user scope") {
+		t.Fatalf("doctor did not disclose which scope satisfied the check:\n%s", out)
+	}
+}
+
+// TestRunDoctorFindsLocalScopedClaudeMCP covers Claude Code's third MCP
+// location: `claude mcp add` with the default local scope writes the server
+// into ~/.claude.json under projects[<root>].mcpServers, not the top-level
+// mcpServers object. A server registered that way is live for this project, so
+// doctor must not report it missing.
+func TestRunDoctorFindsLocalScopedClaudeMCP(t *testing.T) {
+	home := t.TempDir()
+	root := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	originalLook := doctorLookPath
+	originalVersionProbe := doctorVersionProbe
+	originalMCPProbe := doctorMCPProbe
+	t.Cleanup(func() {
+		doctorLookPath = originalLook
+		doctorVersionProbe = originalVersionProbe
+		doctorMCPProbe = originalMCPProbe
+	})
+	doctorLookPath = func(name string) (string, error) {
+		if name == "claude" {
+			return "/usr/local/bin/claude", nil
+		}
+		return "", os.ErrNotExist
+	}
+	// The scope lookup is what is under test, not the launch probes.
+	doctorVersionProbe = func(doctorManagedLaunch) error { return nil }
+	doctorMCPProbe = func(doctorManagedLaunch) error { return nil }
+
+	binary := filepath.Join(home, "codemap")
+	if runtimeIsWindows() {
+		binary += ".exe"
+	}
+	if err := os.WriteFile(binary, []byte("stub"), 0o755); err != nil {
+		t.Fatalf("write stub binary: %v", err)
+	}
+	server := map[string]any{
+		"command": binary,
+		"args":    managedMCPArgs("1.0.0", "claude-setup"),
+	}
+	payload := map[string]any{
+		"mcpServers": map[string]any{},
+		"projects": map[string]any{
+			root: map[string]any{"mcpServers": map[string]any{"codemap": server}},
+		},
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal claude.json: %v", err)
+	}
+	writeHookSettings(t, filepath.Join(home, ".claude.json"), string(data))
+
+	out := captureOutput(func() { RunDoctor([]string{"--agent", "claude", root}, ".") })
+
+	if strings.Contains(out, "MISS Claude MCP") {
+		t.Fatalf("doctor reported Claude MCP missing despite local-scope registration:\n%s", out)
+	}
+	if !strings.Contains(out, "OK   Claude MCP") || !strings.Contains(out, "local scope") {
+		t.Fatalf("doctor did not report Claude MCP OK in local scope:\n%s", out)
+	}
+}
+
+// TestRunDoctorReportsMisconfiguredScopeOverAbsentOne keeps the failure message
+// actionable. When several scopes fail, a scope that exists but is wired up
+// wrong is the user's real problem; a scope whose file simply does not exist is
+// expected and says nothing. Reporting the absent one buries the diagnosis.
+func TestRunDoctorReportsMisconfiguredScopeOverAbsentOne(t *testing.T) {
+	home := t.TempDir()
+	root := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	originalLook := doctorLookPath
+	t.Cleanup(func() { doctorLookPath = originalLook })
+	doctorLookPath = func(name string) (string, error) {
+		if name == "claude" {
+			return "/usr/local/bin/claude", nil
+		}
+		return "", os.ErrNotExist
+	}
+
+	// No project .mcp.json at all; the local scope exists but is hand-wired
+	// rather than codemap-managed.
+	payload := map[string]any{
+		"projects": map[string]any{
+			root: map[string]any{"mcpServers": map[string]any{
+				"codemap": map[string]any{"command": "/somewhere/codemap-mcp", "args": []string{}},
+			}},
+		},
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal claude.json: %v", err)
+	}
+	claudeJSON := filepath.Join(home, ".claude.json")
+	writeHookSettings(t, claudeJSON, string(data))
+
+	out := captureOutput(func() { RunDoctor([]string{"--agent", "claude", root}, ".") })
+
+	line := doctorLineFor(t, out, "MISS Claude MCP")
+	if !strings.Contains(line, claudeJSON) {
+		t.Fatalf("failure did not name the misconfigured scope %s:\n%s", claudeJSON, line)
+	}
+	if strings.Contains(line, "no such file") {
+		t.Fatalf("failure reported an absent scope instead of the misconfigured one:\n%s", line)
+	}
+}
+
+// doctorLineFor returns the single doctor report line beginning with prefix.
+func doctorLineFor(t *testing.T, out, prefix string) string {
+	t.Helper()
+	for _, line := range strings.Split(out, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), prefix) {
+			return line
+		}
+	}
+	t.Fatalf("no %q line in doctor output:\n%s", prefix, out)
+	return ""
+}
+
+// TestRunDoctorGlobalFlagChecksOnlyUserScope keeps --global meaning "check the
+// user-scoped configuration", so it must not be satisfied by project files.
+func TestRunDoctorGlobalFlagChecksOnlyUserScope(t *testing.T) {
+	home := t.TempDir()
+	root := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	originalLook := doctorLookPath
+	originalRecommended := recommendedClaudeHooks
+	t.Cleanup(func() {
+		doctorLookPath = originalLook
+		recommendedClaudeHooks = originalRecommended
+	})
+	doctorLookPath = func(name string) (string, error) {
+		if name == "claude" {
+			return "/usr/local/bin/claude", nil
+		}
+		return "", os.ErrNotExist
+	}
+	recommendedClaudeHooks = generatedClaudeHooks("/usr/local/bin/codemap")
+
+	// Only project scope is configured.
+	writeHookSettings(t, filepath.Join(root, ".claude", "settings.local.json"),
+		hookSettingsJSON(t, recommendedClaudeHooks, func(s claudeHookSpec) string { return s.Command }))
+
+	out := captureOutput(func() { RunDoctor([]string{"--global", "--agent", "claude", root}, ".") })
+
+	if !strings.Contains(out, "MISS Claude hooks") {
+		t.Fatalf("--global was satisfied by project-scope hooks:\n%s", out)
+	}
+}


### PR DESCRIPTION
## What does this PR do?

`codemap doctor` reported a fully working installation as broken. Three independent bugs, each making doctor describe **where files sit** instead of **what the agent actually loads**.

On a real machine with working hooks and a live MCP connection, doctor said:

```
MISS Claude hooks: <project>/.claude/settings.local.json (missing hooks object)
MISS Claude MCP:   <project>/.mcp.json (no such file or directory)
```

Both were false. After this change:

```
OK   Claude hooks: ~/.claude/settings.json (user scope)
MISS Claude MCP:   ~/.claude.json (unrecognized codemap MCP arguments; repair with `codemap setup --agent claude`)
```

That remaining MISS is real and now actionable — it names a hand-wired local-scope entry pointing at a stale binary, instead of blaming an absent `.mcp.json`.

### 1. Hook matching required byte-identity

`hasHookSpec` compared commands with `==`, so this was reported missing:

| | |
|---|---|
| configured | `codemap hook session-start` |
| demanded | `'/opt/homebrew/bin/codemap' hook session-start --integration=claude-setup` |

Same binary, same subcommand. And `--integration` is inert — `main.go` parses it, validates it agrees with the agent, then discards it. It exists only as an ownership marker.

The clincher: setup's own `migrateOwnedHookCommand` **already** treats the bare form as codemap-owned. Setup knew the hook was ours while doctor called it missing.

Matching is now semantic: same codemap executable (PATH-resolved or absolute, quoted or bare, `.exe` or not) invoking the same subcommand.

### 2. Project scope ignored user scope

Agents merge user-level config into every project, so a hook in `~/.claude/settings.json` genuinely applies. Doctor only read `.claude/settings.local.json`, and `--global` *replaced* the project paths rather than adding to them — so no invocation of doctor could report a user-scoped hook as present.

Checks now consult project then user scope and disclose which one satisfied them. `--global` still checks only the user scope.

### 3. Claude MCP has three locations; doctor knew two

`claude mcp add` writes to the **local** scope by default: `~/.claude.json` under `projects[<root>].mcpServers` — not that file's top-level `mcpServers`. A server registered that way is live for the project and was invisible to doctor. All three scopes are now checked in the order Claude resolves them.

### 4. Failure reporting (introduced by the above)

With multiple scopes, reporting the *first* failure blamed an absent file over a misconfigured one. It now prefers the scope that exists but is wrong.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] New language support
- [ ] Documentation
- [ ] Other

## Checklist

- [x] I've tested this locally with `go build && ./codemap .`
- [x] I've read `CONTRIBUTING.md`; this does not add a new language.
- [x] Documentation unchanged — this corrects existing doctor behavior.

## Guards against over-relaxing

Written test-first; three of the seven tests exist to keep the relaxation honest:

- `--agent=codex` still distinguishes Claude from Codex specs (unlike `--integration`, it changes behavior).
- `hasHookSpec` stays byte-exact — setup uses it to decide which entries it owns and may rewrite, where identity is the point.
- `--global` still cannot be satisfied by project-scope files.

Windows is covered by `"C:\Tools\codemap.exe"` quoting plus case-insensitive `.exe` basename matching; `go vet` is clean cross-compiled for windows/amd64 and linux/amd64, and the full suite passes.

## Additional notes

**Draft on purpose** — holding this until @reneleonhardt's open PRs (#93 #94 #95 #96 #97 #99) are resolved and merged, so his queue lands first. This touches only `cmd/doctor.go` and adds one test file; none of those PRs touch `cmd/doctor.go`, `cmd/setup.go`, or `cmd/integration_command.go`, and no symbol names collide with the `cmd/root.go` that #94 adds to the same package. Expected to rebase cleanly.