### PR TITLE
chore: Ignore local agent artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,16 @@ coverage.out
 
 # Local settings
 .claude/settings.local.json
+
+# Local agent artifacts. Machine-specific or generated, never authored here:
+# .codex/config.toml pins absolute paths for one machine (mirrors how
+# .claude/settings.local.json is ignored while .claude/ is not, so project-scoped
+# .codex/hooks.json can still be committed); .agents/skills/ is populated by
+# `codemap plugin install` while .agents/plugins/marketplace.json stays tracked;
+# AGENTS.md is produced by agent tooling from CLAUDE.md.
+.codex/config.toml
+.agents/skills/
+/AGENTS.md
+
+# Rust prototype build output
+/codemapd/


### PR DESCRIPTION
## What does this PR do?

Four untracked paths were showing up in every `git status` and in `codemap --diff`. None are authored in this repo:

| Path | What it is |
|---|---|
| `.codex/config.toml` | Pins an absolute path for one machine (`command = "/Users/…/codemap-mcp"`) |
| `.agents/skills/` | Populated by `codemap plugin install` |
| `AGENTS.md` | Produced by agent tooling from `CLAUDE.md` |
| `codemapd/` | Rust build output left over from the sockd prototype (#66) |

Two deliberate scoping choices:

- **`.codex/config.toml`, not `.codex/`** — mirrors how `.claude/settings.local.json` is ignored while `.claude/` is not. A project-scoped `.codex/hooks.json` is something a team may well want committed, and doctor checks for it, so the directory stays available.
- **`.agents/skills/`, not `.agents/`** — `.agents/plugins/marketplace.json` **is tracked**. A directory-wide rule would shadow a committed file. Verified with `git ls-files -i -c --exclude-standard`, which now returns empty.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] New language support
- [ ] Documentation
- [x] Other — repository hygiene

## Checklist

- [x] I've tested this locally with `go build && ./codemap .`
- [x] I've read `CONTRIBUTING.md`; this does not add a new language.
- [x] Documentation is unchanged.

## Note on AGENTS.md

Ignoring it rather than committing it, because the copy on disk is generated and contains a bad substitution — it says `.Codex/settings.local.json`, which is wrong twice over: capitalised, and `settings.local.json` is a Claude concept (Codex uses `.codex/hooks.json`). It reads like a naive `claude` → `Codex` replace over `CLAUDE.md`. Nothing in the Go source writes it, so it came from agent tooling rather than codemap itself. Committing a file with a wrong path in it seemed worse than ignoring it; happy to author a real one separately if you'd rather ship Codex instructions.