### PR TITLE
fix: Address Copilot review comments on #100 and #102

### DIFF
--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -289,8 +289,8 @@ type doctorScope struct {
 // Agents merge user-level configuration into every project, so a hook or MCP
 // server defined in the user scope genuinely applies to this project. Reporting
 // it MISS because the project file does not repeat it describes the file layout
-// rather than the effective configuration. When every scope fails, the first
-// scope's failure is reported, since that is the one the user is expected to fix.
+// rather than the effective configuration. When every scope fails, the failure
+// reported is chosen by the rule described below rather than by scope order.
 func checkScopedFile(label string, scopes []doctorScope, validate func(string) error, failures *int) {
 	// When every scope fails, prefer reporting one that exists but is wired up
 	// wrong over one whose file is simply absent: the former is the user's
@@ -327,7 +327,7 @@ func checkScopedFile(label string, scopes []doctorScope, validate func(string) e
 		return
 	}
 
-	*failures++
+	(*failures)++
 	switch {
 	case misconfigured != nil:
 		fmt.Printf("MISS %s: %s (%v)\n", label, misconfigured.path, misconfiguredErr)

--- a/watch/control_events_test.go
+++ b/watch/control_events_test.go
@@ -58,8 +58,10 @@ func TestControlEventBurstTriggersOneRefresh(t *testing.T) {
 	}
 
 	waitForWatchCondition(t, 5*time.Second, func() bool { return refreshes.Load() >= 1 })
-	// Let any further coalesced refreshes land before counting.
-	time.Sleep(500 * time.Millisecond)
+	// Let any further refresh land before counting. Derived from the coalescing
+	// window so this stays correct if the window changes; several multiples so a
+	// slow CI machine does not read a late second refresh as a pass.
+	time.Sleep(5 * controlRefreshWindow)
 
 	if got := refreshes.Load(); got != 1 {
 		t.Fatalf("control event burst caused %d refreshes, want 1", got)


### PR DESCRIPTION
Follow-up to the Copilot review comments that arrived on #100 and #102 as those merged. Two are real; one is a false positive that I've changed anyway for readability.

## 1. Stale doc comment on `checkScopedFile` (#100) — valid

The function comment still said:

> When every scope fails, the first scope's failure is reported, since that is the one the user is expected to fix.

That described the first implementation. It was later changed to prefer a scope that exists but is **misconfigured** over one that is merely **absent**, so the doc contradicted the code immediately below it. Rewritten to defer to the rule the body documents.

## 2. Hard-coded sleep in the coalescing test (#102) — valid

`TestControlEventBurstTriggersOneRefresh` slept a fixed `500 * time.Millisecond` waiting for any further coalesced refreshes. That's disconnected from `controlRefreshWindow`: if the window ever grew past 500ms the test would stop testing anything and silently pass. Now derived from the window:

```go
time.Sleep(5 * controlRefreshWindow)
```

Several multiples, so a slow CI machine doesn't read a late second refresh as a pass.

## 3. `*failures++` (#100) — not a defect, changed for clarity

Copilot reported this as incrementing the pointer and not compiling. Neither is the case. Go has no pointer arithmetic, and `++` is a statement applied to the whole `*failures` expression — which is why #100 built and passed on three platforms across Go 1.24/1.25/1.26. Verified independently:

```go
n := 5
p := &n
*p++
// n == 6
```

`(*failures)++` is clearer and matches the form the surrounding code already used, so I've made the change — but on style grounds, not correctness, and no behavior changes.

## Type of change

- [x] Bug fix — documentation accuracy and test robustness
- [ ] New feature
- [ ] New language support
- [ ] Documentation
- [ ] Other

## Checklist

- [x] I've tested this locally with `go build && ./codemap .`
- [x] I've read `CONTRIBUTING.md`; this does not add a new language.
- [x] Documentation unchanged beyond the corrected code comment.

## Verification

`go test ./...`, plus `-count=3` on `./cmd` and `./watch` to confirm the retimed sleep didn't introduce flake. `go vet`, `staticcheck`, `gofmt` clean; `go vet` clean cross-compiled for windows/amd64 and linux/amd64.