### PR TITLE
fix(scanner): Consolidate scanner, MCP, and analysis behavior

### DIFF
--- a/analysis/contracts.go
+++ b/analysis/contracts.go
@@ -1,0 +1,77 @@
+package analysis
+
+import (
+	"slices"
+	"sort"
+)
+
+const SchemaVersion = "codemap.analysis/v1"
+
+type CoverageStatus string
+
+const (
+	CoverageComplete    CoverageStatus = "complete"
+	CoveragePartial     CoverageStatus = "partial"
+	CoverageUnavailable CoverageStatus = "unavailable"
+)
+
+type SourceStatus string
+
+const (
+	SourceAuthoritative SourceStatus = "authoritative"
+	SourceMixed         SourceStatus = "mixed"
+	SourceFallback      SourceStatus = "fallback"
+	SourceTimeout       SourceStatus = "timeout"
+	SourceUnavailable   SourceStatus = "unavailable"
+	SourceFailed        SourceStatus = "failed"
+)
+
+type Source struct {
+	Name   string       `json:"name"`
+	Status SourceStatus `json:"status"`
+	Detail string       `json:"detail,omitempty"`
+}
+
+type Issue struct {
+	Code       string   `json:"code"`
+	Severity   string   `json:"severity,omitempty"`
+	Path       string   `json:"path,omitempty"`
+	Line       int      `json:"line,omitempty"`
+	Message    string   `json:"message"`
+	Candidates []string `json:"candidates,omitempty"`
+}
+
+type Coverage struct {
+	Status  CoverageStatus `json:"status"`
+	Sources []Source       `json:"sources"`
+	Issues  []Issue        `json:"issues"`
+}
+
+func NormalizeCoverage(coverage Coverage) Coverage {
+	coverage.Sources = slices.Clone(coverage.Sources)
+	coverage.Issues = slices.Clone(coverage.Issues)
+	if coverage.Sources == nil {
+		coverage.Sources = []Source{}
+	}
+	if coverage.Issues == nil {
+		coverage.Issues = []Issue{}
+	}
+	sort.Slice(coverage.Sources, func(i, j int) bool {
+		left, right := coverage.Sources[i], coverage.Sources[j]
+		if left.Name != right.Name {
+			return left.Name < right.Name
+		}
+		if left.Status != right.Status {
+			return left.Status < right.Status
+		}
+		return left.Detail < right.Detail
+	})
+	for index := range coverage.Issues {
+		coverage.Issues[index].Candidates = slices.Clone(coverage.Issues[index].Candidates)
+		if coverage.Issues[index].Candidates == nil {
+			coverage.Issues[index].Candidates = []string{}
+		}
+		sort.Strings(coverage.Issues[index].Candidates)
+	}
+	return coverage
+}

--- a/analysis/contracts_test.go
+++ b/analysis/contracts_test.go
@@ -1,0 +1,45 @@
+package analysis
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+func TestNormalizeCoverageProducesDeterministicNonNilCollections(t *testing.T) {
+	coverage := NormalizeCoverage(Coverage{
+		Status: CoveragePartial,
+		Sources: []Source{
+			{Name: "zeta", Status: SourceFallback},
+			{Name: "alpha", Status: SourceAuthoritative},
+		},
+		Issues: []Issue{{Code: "ambiguous", Message: "choose", Candidates: []string{"z", "a"}}},
+	})
+	if got, want := []string{coverage.Sources[0].Name, coverage.Sources[1].Name}, []string{"alpha", "zeta"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("source order = %v, want %v", got, want)
+	}
+	if got, want := coverage.Issues[0].Candidates, []string{"a", "z"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("candidates = %v, want %v", got, want)
+	}
+	encoded, err := json.Marshal(NormalizeCoverage(Coverage{}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(encoded) == "" || string(encoded) == `{"status":"","sources":null,"issues":null}` {
+		t.Fatalf("coverage must encode non-null collections: %s", encoded)
+	}
+}
+
+func TestNormalizeCoveragePreservesIssueOrderAndSortsRepeatedFields(t *testing.T) {
+	input := Coverage{
+		Sources: []Source{{Name: "same", Status: SourceFallback}, {Name: "same", Status: SourceAuthoritative}},
+		Issues:  []Issue{{Code: "z", Candidates: []string{"b", "a"}}, {Code: "a"}},
+	}
+	got := NormalizeCoverage(input)
+	if got.Sources[0].Status != SourceAuthoritative {
+		t.Fatalf("source tie order = %#v", got.Sources)
+	}
+	if got.Issues[0].Code != "z" || !reflect.DeepEqual(got.Issues[0].Candidates, []string{"a", "b"}) || got.Issues[1].Code != "a" {
+		t.Fatalf("issue order = %#v", got.Issues)
+	}
+}

--- a/blast_radius.go
+++ b/blast_radius.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"unicode/utf8"
 
+	"codemap/analysis"
 	"codemap/config"
 	"codemap/render"
 	"codemap/scanner"
@@ -68,6 +69,8 @@ type blastRadiusDeps struct {
 	ExternalDeps      map[string][]string    `json:"external_deps"`
 	DiffRef           string                 `json:"diff_ref,omitempty"`
 	ChangedFilesTotal int                    `json:"changed_files_total"`
+	CoverageStatus    string                 `json:"coverage_status,omitempty"`
+	CoverageNotes     []string               `json:"coverage_notes,omitempty"`
 }
 
 type blastRadiusImporters struct {
@@ -497,12 +500,16 @@ func buildBlastRadiusBundle(absRoot, ref string, limits blastRadiusLimits) (blas
 			return blastRadiusBundle{}, err
 		}
 		depsTotal = len(depsProject.Files)
-		depsCapped = capBlastRadiusDepsProject(depsProject, limits.MaxChangedFiles)
 
 		fg, err := scanner.BuildFileGraphFromOutcome(context.Background(), absRoot, scanOutcome, filters)
 		if err != nil {
 			return blastRadiusBundle{}, err
 		}
+
+		// Carry scan provenance into the deps project so a fail-closed scan
+		// never reads as an empty, complete dependency graph.
+		depsProject.Coverage = scanner.CoverageFromSources(fg.Coverage.Sources)
+		depsCapped = capBlastRadiusDepsProject(depsProject, limits.MaxChangedFiles)
 
 		// Analyze the FULL changed set; capping only limits what is displayed,
 		// it must not shrink blast-radius analysis or the summary stats.
@@ -549,6 +556,8 @@ func buildBlastRadiusBundle(absRoot, ref string, limits blastRadiusLimits) (blas
 			ExternalDeps:      depsCapped.ExternalDeps,
 			DiffRef:           depsCapped.DiffRef,
 			ChangedFilesTotal: depsTotal,
+			CoverageStatus:    string(depsCapped.Coverage.Status),
+			CoverageNotes:     coverageNotesFromSources(depsCapped.Coverage.Sources),
 		},
 		Importers:                    jsonReports,
 		Limits:                       limits,
@@ -601,6 +610,18 @@ func capBlastRadiusDepsProject(project scanner.DepsProject, max int) scanner.Dep
 	}
 	project.Files = append([]scanner.FileAnalysis(nil), project.Files[:max]...)
 	return project
+}
+
+// coverageNotesFromSources flattens source-level detail into coverage notes,
+// mirroring how the graph records blind-spot details for importers.
+func coverageNotesFromSources(sources []analysis.Source) []string {
+	var notes []string
+	for _, source := range sources {
+		if source.Detail != "" {
+			notes = append(notes, source.Detail)
+		}
+	}
+	return notes
 }
 
 func capBlastRadiusImportersReport(report scanner.ImportersReport, max int) blastRadiusImporters {
@@ -1277,7 +1298,7 @@ func renderDiffProject(project scanner.Project) string {
 
 func renderDepsProject(project scanner.DepsProject) string {
 	var buf bytes.Buffer
-	render.Depgraph(&buf, project)
+	render.Depgraph(context.Background(), &buf, project)
 	return stripANSI(buf.String())
 }
 

--- a/blast_radius.go
+++ b/blast_radius.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -427,7 +428,7 @@ func resolveBlastRadiusRoot(root string) (string, func(), error) {
 }
 
 func buildBlastRadiusBundle(absRoot, ref string, limits blastRadiusLimits) (blastRadiusBundle, error) {
-	diffInfo, err := scanner.GitDiffInfo(absRoot, ref)
+	diffInfo, err := scanner.GitDiffInfo(context.Background(), absRoot, ref)
 	if err != nil {
 		return blastRadiusBundle{}, &blastRadiusDiffError{ref: ref, err: err}
 	}
@@ -435,7 +436,7 @@ func buildBlastRadiusBundle(absRoot, ref string, limits blastRadiusLimits) (blas
 	cfg := config.Load(absRoot)
 	filters := scanner.Filters{Only: cfg.Only, Exclude: cfg.Exclude}
 	gitCache := scanner.NewGitIgnoreCache(absRoot)
-	allFiles, err := scanner.ScanFiles(absRoot, gitCache, filters.Only, filters.Exclude)
+	allFiles, err := scanner.ScanFiles(context.Background(), absRoot, gitCache, filters.Only, filters.Exclude)
 	if err != nil {
 		return blastRadiusBundle{}, err
 	}
@@ -450,13 +451,14 @@ func buildBlastRadiusBundle(absRoot, ref string, limits blastRadiusLimits) (blas
 	// Single ast-grep scan shared by impact analysis, the deps project, and the
 	// file graph below. Previously each of those triggered its own full-repo
 	// ScanForDeps, tripling latency on large repositories.
-	var analyses []scanner.FileAnalysis
+	var scanOutcome scanner.ScanOutcome
 	if diffTotal > 0 {
-		analyses, err = scanForDepsWithHint(absRoot, filters)
+		scanOutcome, err = scanForDepsOutcomeWithHint(absRoot, filters)
 		if err != nil {
 			return blastRadiusBundle{}, err
 		}
 	}
+	analyses := scanOutcome.Analyses
 
 	diffProject := scanner.Project{
 		Root:    absRoot,
@@ -485,16 +487,19 @@ func buildBlastRadiusBundle(absRoot, ref string, limits blastRadiusLimits) (blas
 	var rawImpacted []blastRadiusRelation
 	var impacted []blastRadiusRelation
 	var rawContext []blastRadiusRelation
-	var context []blastRadiusRelation
+	var ctxRelations []blastRadiusRelation
 	var snippets []blastRadiusSnippet
 
 	if diffTotal > 0 {
 		depsProject.Files = scanner.FilterAnalysisToChanged(analyses, changedSet)
-		depsProject.ExternalDeps = scanner.ReadExternalDeps(absRoot)
+		depsProject.ExternalDeps, err = scanner.ReadExternalDeps(context.Background(), absRoot, 0)
+		if err != nil {
+			return blastRadiusBundle{}, err
+		}
 		depsTotal = len(depsProject.Files)
 		depsCapped = capBlastRadiusDepsProject(depsProject, limits.MaxChangedFiles)
 
-		fg, err := scanner.BuildFileGraphFromFilteredAnalyses(absRoot, analyses, filters)
+		fg, err := scanner.BuildFileGraphFromOutcome(context.Background(), absRoot, scanOutcome, filters)
 		if err != nil {
 			return blastRadiusBundle{}, err
 		}
@@ -515,11 +520,11 @@ func buildBlastRadiusBundle(absRoot, ref string, limits blastRadiusLimits) (blas
 		rawImpacted = collectBlastRadiusImpacted(allReports, changedSet)
 		rawContext = collectBlastRadiusContext(allReports, changedSet)
 		impacted = capBlastRadiusRelations(rawImpacted, limits.MaxAffected)
-		context = capBlastRadiusRelations(rawContext, limits.MaxContext)
-		snippets = buildBlastRadiusSnippets(absRoot, changedFiles, depsProject.Files, impacted, context, limits)
+		ctxRelations = capBlastRadiusRelations(rawContext, limits.MaxContext)
+		snippets = buildBlastRadiusSnippets(absRoot, changedFiles, depsProject.Files, impacted, ctxRelations, limits)
 	}
 
-	summary := buildBlastRadiusSummary(diffCapped.Files, diffTotal, impacted, rawImpacted, context, rawContext, allReports)
+	summary := buildBlastRadiusSummary(diffCapped.Files, diffTotal, impacted, rawImpacted, ctxRelations, rawContext, allReports)
 
 	bundle := blastRadiusBundle{
 		Root:    absRoot,
@@ -548,7 +553,7 @@ func buildBlastRadiusBundle(absRoot, ref string, limits blastRadiusLimits) (blas
 		Importers:                    jsonReports,
 		Limits:                       limits,
 		ImpactedOutsideDiff:          impacted,
-		DependencyContextOutsideDiff: context,
+		DependencyContextOutsideDiff: ctxRelations,
 		Snippets:                     snippets,
 	}
 	bundle.Rendered = buildBlastRadiusRendered(diffCapped, depsCapped, shownReports, diffTotal, limits)

--- a/blast_radius.go
+++ b/blast_radius.go
@@ -1363,7 +1363,7 @@ func buildImportersReportFromGraph(root, file string, fg *scanner.FileGraph) sca
 		Imports:        imports,
 		ImporterCount:  len(importers),
 		IsHub:          fg.IsHub(file),
-		CoverageStatus: fg.Coverage.Status,
+		CoverageStatus: string(fg.Coverage.Status),
 		CoverageNotes:  append([]string(nil), fg.Coverage.Notes...),
 	}
 

--- a/blast_radius_fixes_test.go
+++ b/blast_radius_fixes_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"codemap/analysis"
 	"codemap/config"
 	"codemap/scanner"
 )
@@ -380,5 +381,35 @@ func TestBlastOutputBuilderClosesFenceOnTruncation(t *testing.T) {
 	out := b.String()
 	if strings.Count(out, "```")%2 != 0 {
 		t.Fatalf("unbalanced fences after truncation:\n%q", out)
+	}
+}
+
+// Regression for PR #105: blast-radius deps output must carry scan provenance
+// so a fail-closed scan never reads as an empty, complete dependency graph.
+func TestCapBlastRadiusDepsProjectCarriesCoverage(t *testing.T) {
+	capped := capBlastRadiusDepsProject(scanner.DepsProject{
+		Files: []scanner.FileAnalysis{{Path: "a.go"}, {Path: "b.go"}},
+		Coverage: analysis.Coverage{
+			Status:  analysis.CoverageUnavailable,
+			Sources: []analysis.Source{{Name: "ast-grep", Status: analysis.SourceFailed, Detail: "scanner failed"}},
+		},
+	}, 1)
+	if capped.Coverage.Status != analysis.CoverageUnavailable {
+		t.Fatalf("capped deps coverage = %q, want unavailable", capped.Coverage.Status)
+	}
+	if len(capped.Files) != 1 {
+		t.Fatalf("capped deps files = %d, want 1", len(capped.Files))
+	}
+}
+
+func TestCoverageNotesFromSources(t *testing.T) {
+	notes := coverageNotesFromSources([]analysis.Source{
+		{Name: "ast-grep", Status: analysis.SourceFailed, Detail: "scanner failed"},
+		{Name: "cargo-metadata", Status: analysis.SourceAuthoritative},
+		{Name: "rust-cargo", Status: analysis.SourceMixed, Detail: "partial Rust"},
+	})
+	want := []string{"scanner failed", "partial Rust"}
+	if !reflect.DeepEqual(notes, want) {
+		t.Fatalf("coverageNotesFromSources() = %#v, want %#v", notes, want)
 	}
 }

--- a/blast_radius_fixes_test.go
+++ b/blast_radius_fixes_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"os"
 	"os/exec"
@@ -300,8 +301,8 @@ func TestBlastRadiusOmitsEmptyImporterSections(t *testing.T) {
 	}
 }
 
-// Finding #10: BuildFileGraphFromAnalyses / AnalyzeImpactFromAnalyses must match
-// the scanning wrappers so the single-scan refactor is behavior-preserving.
+// Finding #10: injected scan outcomes must match the scanning wrappers so the
+// single-scan refactor preserves both graph results and provenance.
 func TestBlastRadiusSingleScanParity(t *testing.T) {
 	requireBlastRadiusTools(t)
 	root := makeBlastRadiusHubRepo(t)
@@ -314,27 +315,33 @@ func TestBlastRadiusSingleScanParity(t *testing.T) {
 	cfg := config.Load(root)
 	filters := scanner.Filters{Only: cfg.Only, Exclude: cfg.Exclude}
 
-	analyses, err := scanner.ScanForDepsWithFilters(root, filters)
+	outcome, err := scanner.ScanForDeps(context.Background(), root, filters)
 	if err != nil {
-		t.Fatalf("ScanForDepsWithFilters: %v", err)
+		t.Fatalf("ScanForDeps: %v", err)
 	}
 
-	fgWrap, err := scanner.BuildFileGraph(root)
+	fgWrap, err := scanner.BuildFileGraph(context.Background(), root, filters)
 	if err != nil {
 		t.Fatalf("BuildFileGraph: %v", err)
 	}
-	fgInjected, err := scanner.BuildFileGraphFromFilteredAnalyses(root, analyses, filters)
+	fgInjected, err := scanner.BuildFileGraphFromOutcome(context.Background(), root, outcome, filters)
 	if err != nil {
-		t.Fatalf("BuildFileGraphFromFilteredAnalyses: %v", err)
+		t.Fatalf("BuildFileGraphFromOutcome: %v", err)
 	}
 	if len(fgWrap.Importers["pkg/hub/hub.go"]) != len(fgInjected.Importers["pkg/hub/hub.go"]) {
 		t.Fatalf("file graph importer parity mismatch: %v vs %v",
 			fgWrap.Importers["pkg/hub/hub.go"], fgInjected.Importers["pkg/hub/hub.go"])
 	}
+	if !reflect.DeepEqual(fgWrap.Coverage.Sources, fgInjected.Coverage.Sources) {
+		t.Fatalf("file graph provenance mismatch: %#v vs %#v", fgWrap.Coverage.Sources, fgInjected.Coverage.Sources)
+	}
 
 	changed := []scanner.FileInfo{{Path: "pkg/hub/hub.go"}}
-	impWrap := scanner.AnalyzeImpact(root, changed)
-	impInjected := scanner.AnalyzeImpactFromAnalyses(changed, analyses)
+	impWrap, err := scanner.AnalyzeImpact(context.Background(), root, changed)
+	if err != nil {
+		t.Fatalf("AnalyzeImpact: %v", err)
+	}
+	impInjected := scanner.AnalyzeImpactFromAnalyses(changed, outcome.Analyses)
 	if len(impWrap) != len(impInjected) {
 		t.Fatalf("impact parity mismatch: %v vs %v", impWrap, impInjected)
 	}

--- a/blast_radius_test.go
+++ b/blast_radius_test.go
@@ -126,6 +126,11 @@ func TestBlastRadiusSubcommandMarkdownAndJSON(t *testing.T) {
 	if bundle.Snippets[0].MatchedTerm != "ComputeTotal" {
 		t.Fatalf("expected snippet match to target ComputeTotal, got %+v", bundle.Snippets[0])
 	}
+	// PR #105: blast-radius deps output carries scan provenance, so a healthy
+	// repo reports complete coverage rather than an empty, silent graph.
+	if bundle.Deps.CoverageStatus != "complete" {
+		t.Fatalf("expected deps coverage complete, got %q (notes %#v)", bundle.Deps.CoverageStatus, bundle.Deps.CoverageNotes)
+	}
 }
 
 func TestBlastRadiusSubcommandNoChanges(t *testing.T) {

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -99,7 +100,7 @@ func initProjectConfig(root string) (configInitResult, error) {
 	}
 
 	gitCache := scanner.NewGitIgnoreCache(root)
-	files, err := scanner.ScanFiles(root, gitCache, nil, nil)
+	files, err := scanner.ScanFiles(context.Background(), root, gitCache, nil, nil)
 	if err != nil {
 		return result, fmt.Errorf("scan files: %w", err)
 	}

--- a/cmd/context.go
+++ b/cmd/context.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -314,7 +315,7 @@ func detectLanguagesFromFiles(root string) map[string]bool {
 
 	// Include subdirectory source files. Reuse the scan result for countSourceFiles too.
 	gitCache := scanner.NewGitIgnoreCache(root)
-	if files, err := scanner.ScanConfiguredFiles(root, gitCache); err == nil {
+	if files, err := scanner.ScanConfiguredFiles(context.Background(), root, gitCache); err == nil {
 		for _, f := range files {
 			addLang(scanner.DetectLanguage(f.Path))
 		}
@@ -360,7 +361,7 @@ func countSourceFiles(root string) int {
 		return count
 	}
 	gitCache := scanner.NewGitIgnoreCache(root)
-	files, err := scanner.ScanConfiguredFiles(root, gitCache)
+	files, err := scanner.ScanConfiguredFiles(context.Background(), root, gitCache)
 	if err != nil {
 		return 0
 	}

--- a/cmd/hooks.go
+++ b/cmd/hooks.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bufio"
+	"context"
 	"crypto/sha256"
 	"encoding/json"
 	"errors"
@@ -137,7 +138,7 @@ func getHubInfoWithFallback(root string, allowFallback bool) *hubInfo {
 	}
 
 	// Fall back to fresh scan only when daemon is not running.
-	fg, err := scanner.BuildFileGraph(root)
+	fg, err := scanner.BuildFileGraph(context.Background(), root, scanner.ConfiguredFilters(root))
 	if err != nil {
 		return nil
 	}
@@ -486,7 +487,7 @@ func configuredStateFileCount(root string, state *watch.State) (int, bool) {
 	if state == nil {
 		return 0, false
 	}
-	files, err := scanner.ScanConfiguredFiles(root, scanner.NewGitIgnoreCache(root))
+	files, err := scanner.ScanConfiguredFiles(context.Background(), root, scanner.NewGitIgnoreCache(root))
 	if err != nil {
 		return 0, false
 	}

--- a/cmd/intent.go
+++ b/cmd/intent.go
@@ -117,7 +117,7 @@ func classifyIntent(prompt string, files []string, info *hubInfo, cfg config.Pro
 		Scope:     "single-file",
 	}
 	if info != nil {
-		intent.DependencyCoverage = info.Coverage.Status
+		intent.DependencyCoverage = string(info.Coverage.Status)
 		intent.CoverageNotes = append([]string(nil), info.Coverage.Notes...)
 	}
 

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -138,6 +138,12 @@ Surface behavior note:
 
 Output and budget notes:
 - text responses are byte-budgeted and line-truncated to protect context
+- project discovery reads bounded batches, returns at most 50 sorted projects, examines at most 200 parent entries, and reports truncation separately from cancellation; when the examination cap is exceeded it returns only the truncation notice rather than a filesystem-order-dependent partial list
+- MCP dependency discovery skips individual manifests larger than 1 MiB; CLI dependency and blast-radius callers retain their legacy unbounded manifest behavior
 - prefix file counts and size-based handoff budgets honor the active `.codemap/config.json` filters
 - handoff payload includes deterministic hashes (`prefix_hash`, `delta_hash`, `combined_hash`)
 - handoff payload includes cache metrics (`reuse_ratio`, `unchanged_bytes`, etc.)
+
+Cancellation notes:
+- project scans, dependency graphs, ast-grep, Git diff/impact work, project discovery, and generated handoff/detail work stop with the MCP request context
+- with `save=true`, cancellation observed after generation but before persistence prevents `WriteLatest`; once persistence begins, the existing multi-file write completes or reports its existing error without rollback

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.24.0
 require (
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/fsnotify/fsnotify v1.9.0
+	github.com/google/jsonschema-go v0.3.0
 	github.com/modelcontextprotocol/go-sdk v1.1.0
 	github.com/pelletier/go-toml/v2 v2.2.4
 	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06
@@ -20,7 +21,6 @@ require (
 	github.com/charmbracelet/x/cellbuf v0.0.13-0.20250311204145-2c3ea96c31dd // indirect
 	github.com/charmbracelet/x/term v0.2.1 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
-	github.com/google/jsonschema-go v0.3.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-localereader v0.0.1 // indirect

--- a/handoff/build.go
+++ b/handoff/build.go
@@ -2,6 +2,7 @@ package handoff
 
 import (
 	"bytes"
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -58,6 +59,15 @@ func normalizeOptions(opts BuildOptions, fileCount int) BuildOptions {
 
 // Build creates a multi-agent handoff artifact from git + daemon state.
 func Build(root string, opts BuildOptions) (*Artifact, error) {
+	return BuildContext(context.Background(), root, opts)
+}
+
+// BuildContext creates a handoff artifact while honoring caller cancellation
+// across filesystem scans, dependency analysis, and Git subprocesses.
+func BuildContext(ctx context.Context, root string, opts BuildOptions) (*Artifact, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	absRoot, err := filepath.Abs(root)
 	if err != nil {
 		return nil, err
@@ -67,16 +77,22 @@ func Build(root string, opts BuildOptions) (*Artifact, error) {
 	if state == nil {
 		state = watch.ReadState(absRoot)
 	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 
-	fileCount := resolveRepoFileCount(absRoot)
+	fileCount, err := resolveRepoFileCountContext(ctx, absRoot)
+	if err != nil {
+		return nil, err
+	}
 	opts = normalizeOptions(opts, fileCount)
 
-	branch, err := gitCurrentBranch(absRoot)
+	branch, err := gitCurrentBranchContext(ctx, absRoot)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read git branch: %w", err)
 	}
 
-	entries, diffErr := collectChangedEntries(absRoot, opts.BaseRef)
+	entries, diffErr := collectChangedEntriesContext(ctx, absRoot, opts.BaseRef)
 	if diffErr != nil {
 		return nil, diffErr
 	}
@@ -92,12 +108,18 @@ func Build(root string, opts BuildOptions) (*Artifact, error) {
 		}
 	}
 
-	importers := dependencyImportersForHandoff(absRoot, state, fileCount)
+	importers, err := dependencyImportersForHandoffContext(ctx, absRoot, state, fileCount)
+	if err != nil {
+		return nil, err
+	}
 	riskFiles := summarizeRiskFiles(changedAll, importers, opts.MaxRisk)
 	selectedPaths := prioritizeChangedPaths(changedAll, riskFiles, opts.MaxChanged)
 	entries = selectEntries(entries, selectedPaths)
 
-	changedStubs := buildFileStubs(absRoot, entries)
+	changedStubs, err := buildFileStubsContext(ctx, absRoot, entries)
+	if err != nil {
+		return nil, err
+	}
 	hubs := summarizeHubs(importers, opts.MaxHubs)
 
 	nextSteps, openQuestions := deriveGuidance(selectedPaths, riskFiles, recentEvents, opts.BaseRef, state != nil, len(importers) > 0)
@@ -128,6 +150,9 @@ func Build(root string, opts BuildOptions) (*Artifact, error) {
 	if previous == nil {
 		previous, _ = ReadLatest(absRoot)
 	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	metrics := buildCacheMetrics(previous, prefixHash, deltaHash, prefixBytes, deltaBytes)
 	generatedAt := time.Now()
 	if previous != nil && previous.PrefixHash == prefixHash && previous.DeltaHash == deltaHash && !previous.GeneratedAt.IsZero() {
@@ -157,25 +182,37 @@ func Build(root string, opts BuildOptions) (*Artifact, error) {
 	}, nil
 }
 
-func collectChangedEntries(root, baseRef string) ([]changedEntry, error) {
+func collectChangedEntriesContext(ctx context.Context, root, baseRef string) ([]changedEntry, error) {
 	changed := make(map[string]changedEntry)
 
-	branchLines, branchErr := runGitLines(root, "diff", "--name-only", baseRef+"...HEAD")
+	branchLines, branchErr := runGitLinesContext(ctx, root, "diff", "--name-only", baseRef+"...HEAD")
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	for _, line := range branchLines {
 		addChangedEntry(changed, root, line, "branch")
 	}
 
-	workingLines, _ := runGitLines(root, "diff", "--name-only")
+	workingLines, _ := runGitLinesContext(ctx, root, "diff", "--name-only")
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	for _, line := range workingLines {
 		addChangedEntry(changed, root, line, "modified")
 	}
 
-	stagedLines, _ := runGitLines(root, "diff", "--name-only", "--cached")
+	stagedLines, _ := runGitLinesContext(ctx, root, "diff", "--name-only", "--cached")
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	for _, line := range stagedLines {
 		addChangedEntry(changed, root, line, "staged")
 	}
 
-	untrackedLines, _ := runGitLines(root, "ls-files", "--others", "--exclude-standard")
+	untrackedLines, _ := runGitLinesContext(ctx, root, "ls-files", "--others", "--exclude-standard")
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	for _, line := range untrackedLines {
 		addChangedEntry(changed, root, line, "untracked")
 	}
@@ -254,13 +291,16 @@ func isLikelyBinary(root, relPath string) bool {
 	return bytes.IndexByte(buf[:n], 0) >= 0
 }
 
-func buildFileStubs(root string, changed []changedEntry) []FileStub {
+func buildFileStubsContext(ctx context.Context, root string, changed []changedEntry) ([]FileStub, error) {
 	if len(changed) == 0 {
-		return []FileStub{}
+		return []FileStub{}, ctx.Err()
 	}
 
 	stubs := make([]FileStub, 0, len(changed))
 	for _, entry := range changed {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		stub := FileStub{
 			Path:   entry.Path,
 			Status: entry.Status,
@@ -270,25 +310,49 @@ func buildFileStubs(root string, changed []changedEntry) []FileStub {
 		info, err := os.Stat(absPath)
 		if err == nil && !info.IsDir() {
 			stub.Size = info.Size()
-			stub.Hash = fileSHA256(absPath)
+			stub.Hash, err = fileSHA256Context(ctx, absPath)
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return nil, ctxErr
+			}
+			if err != nil {
+				stub.Hash = ""
+			}
 		}
 		stubs = append(stubs, stub)
 	}
-	return stubs
+	return stubs, ctx.Err()
 }
 
-func fileSHA256(path string) string {
+func fileSHA256Context(ctx context.Context, path string) (string, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
 	f, err := os.Open(path)
 	if err != nil {
-		return ""
+		return "", err
 	}
 	defer f.Close()
 
 	h := sha256.New()
-	if _, err := io.Copy(h, f); err != nil {
-		return ""
+	buf := make([]byte, 32*1024)
+	for {
+		if err := ctx.Err(); err != nil {
+			return "", err
+		}
+		n, readErr := f.Read(buf)
+		if n > 0 {
+			if _, err := h.Write(buf[:n]); err != nil {
+				return "", err
+			}
+		}
+		if readErr == io.EOF {
+			break
+		}
+		if readErr != nil {
+			return "", readErr
+		}
 	}
-	return hex.EncodeToString(h.Sum(nil))
+	return hex.EncodeToString(h.Sum(nil)), ctx.Err()
 }
 
 func summarizeHubs(importersByFile map[string][]string, maxHubs int) []HubSummary {
@@ -562,11 +626,18 @@ func buildCacheMetrics(previous *Artifact, prefixHash, deltaHash string, prefixB
 	return metrics
 }
 
-func runGitLines(root string, args ...string) ([]string, error) {
-	cmd := exec.Command("git", args...)
+func runGitLinesContext(ctx context.Context, root string, args ...string) ([]string, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd.WaitDelay = 100 * time.Millisecond
 	cmd.Dir = root
 	out, err := cmd.Output()
 	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, ctxErr
+		}
 		return nil, err
 	}
 
@@ -585,40 +656,56 @@ func runGitLines(root string, args ...string) ([]string, error) {
 	return lines, nil
 }
 
-func gitCurrentBranch(root string) (string, error) {
-	cmd := exec.Command("git", "rev-parse", "--abbrev-ref", "HEAD")
+func gitCurrentBranchContext(ctx context.Context, root string) (string, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+	cmd := exec.CommandContext(ctx, "git", "rev-parse", "--abbrev-ref", "HEAD")
+	cmd.WaitDelay = 100 * time.Millisecond
 	cmd.Dir = root
 	out, err := cmd.Output()
 	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return "", ctxErr
+		}
 		return "", err
 	}
 	return strings.TrimSpace(string(out)), nil
 }
 
-func resolveRepoFileCount(root string) int {
+func resolveRepoFileCountContext(ctx context.Context, root string) (int, error) {
 	gitCache := scanner.NewGitIgnoreCache(root)
-	files, err := scanner.ScanConfiguredFiles(root, gitCache)
+	files, err := scanner.ScanConfiguredFiles(ctx, root, gitCache)
 	if err != nil {
-		return 0
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return 0, ctxErr
+		}
+		return 0, nil
 	}
-	return len(files)
+	return len(files), ctx.Err()
 }
 
-func dependencyImportersForHandoff(root string, state *watch.State, fileCount int) map[string][]string {
+func dependencyImportersForHandoffContext(ctx context.Context, root string, state *watch.State, fileCount int) (map[string][]string, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	if state != nil && len(state.Importers) > 0 {
-		return state.Importers
+		return state.Importers, nil
 	}
 
 	// Skip fallback graph construction for configured large repositories.
 	if fileCount > limits.LargeRepoFileCount {
-		return nil
+		return nil, nil
 	}
 
-	fg, err := scanner.BuildFileGraph(root)
+	fg, err := scanner.BuildFileGraph(ctx, root, scanner.ConfiguredFilters(root))
 	if err != nil {
-		return nil
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, ctxErr
+		}
+		return nil, nil
 	}
-	return fg.Importers
+	return fg.Importers, ctx.Err()
 }
 
 func nonNilStrings(items []string) []string {

--- a/handoff/build_more_test.go
+++ b/handoff/build_more_test.go
@@ -1,8 +1,12 @@
 package handoff
 
 import (
+	"context"
 	"reflect"
 	"testing"
+	"time"
+
+	"codemap/watch"
 )
 
 func TestChangedFromEventsDedupesAndSorts(t *testing.T) {
@@ -54,5 +58,92 @@ func TestBuildCacheMetricsTracksReuseAccounting(t *testing.T) {
 	}
 	if got.PreviousCombinedHash != "combined" {
 		t.Fatalf("previous combined hash = %q, want combined", got.PreviousCombinedHash)
+	}
+}
+
+func TestSummarizeEventsFiltersSortsAndCaps(t *testing.T) {
+	now := time.Now()
+	old := now.Add(-3 * time.Hour)
+	stale := now.Add(-2 * time.Hour)
+	fresh := now.Add(-5 * time.Minute)
+
+	tests := []struct {
+		name      string
+		state     *watch.State
+		since     time.Duration
+		maxEvents int
+		wantPaths []string
+	}{
+		{
+			name:  "nil state yields empty",
+			state: nil,
+			since: time.Hour, maxEvents: 10,
+			wantPaths: nil,
+		},
+		{
+			name: "drops stale and orders by time then path",
+			state: &watch.State{RecentEvents: []watch.Event{
+				{Time: old, Op: "WRITE", Path: "z.go"},
+				{Time: fresh, Op: "WRITE", Path: "b.go"},
+				{Time: fresh, Op: "WRITE", Path: "a.go"},
+				{Time: stale, Op: "DELETE", Path: "skip.go"},
+			}},
+			since: time.Hour, maxEvents: 10,
+			wantPaths: []string{"a.go", "b.go"},
+		},
+		{
+			name: "caps to newest events",
+			state: &watch.State{RecentEvents: []watch.Event{
+				{Time: now.Add(-3 * time.Minute), Op: "WRITE", Path: "1.go"},
+				{Time: now.Add(-2 * time.Minute), Op: "WRITE", Path: "2.go"},
+				{Time: now.Add(-time.Minute), Op: "WRITE", Path: "3.go"},
+			}},
+			since: time.Hour, maxEvents: 2,
+			wantPaths: []string{"2.go", "3.go"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := summarizeEvents(tt.state, tt.since, tt.maxEvents)
+			var paths []string
+			for _, e := range got {
+				paths = append(paths, e.Path)
+			}
+			if !reflect.DeepEqual(paths, tt.wantPaths) {
+				t.Fatalf("summarizeEvents paths = %v, want %v", paths, tt.wantPaths)
+			}
+		})
+	}
+}
+
+func TestSummarizeHubsFiltersSortsAndCaps(t *testing.T) {
+	importers := map[string][]string{
+		"a.go": {"1.go", "2.go", "3.go", "4.go"},
+		"b.go": {"1.go", "2.go", "3.go"},
+		"c.go": {"1.go", "2.go"},
+		"d.go": {"1.go"},
+	}
+	got := summarizeHubs(importers, 0)
+	want := []HubSummary{{Path: "a.go", Importers: 4}, {Path: "b.go", Importers: 3}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("summarizeHubs = %v, want %v", got, want)
+	}
+	capped := summarizeHubs(importers, 1)
+	if len(capped) != 1 || capped[0].Path != "a.go" {
+		t.Fatalf("capped hubs = %v, want only a.go", capped)
+	}
+	if got := summarizeHubs(nil, 0); len(got) != 0 {
+		t.Fatalf("nil importers = %v, want empty", got)
+	}
+}
+
+func TestGitCurrentBranchContextErrors(t *testing.T) {
+	if _, err := gitCurrentBranchContext(context.Background(), t.TempDir()); err == nil {
+		t.Fatal("expected error outside a git repository")
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := gitCurrentBranchContext(ctx, t.TempDir()); err == nil {
+		t.Fatal("expected error for cancelled context")
 	}
 }

--- a/handoff/context_test.go
+++ b/handoff/context_test.go
@@ -1,0 +1,179 @@
+package handoff
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"codemap/scanner"
+)
+
+type cancelAfterHandoffChecks struct {
+	context.Context
+	remaining int
+}
+
+func (c *cancelAfterHandoffChecks) Err() error {
+	if c.remaining <= 0 {
+		return context.Canceled
+	}
+	c.remaining--
+	return nil
+}
+
+func TestBuildContextPreCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := BuildContext(ctx, t.TempDir(), BuildOptions{}); !errors.Is(err, context.Canceled) {
+		t.Fatalf("BuildContext error = %v, want context.Canceled", err)
+	}
+}
+
+func TestBuildContextTerminatesGitSubprocess(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("requires shell script execution")
+	}
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "main.go"), []byte("package main\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	binDir := t.TempDir()
+	marker := filepath.Join(t.TempDir(), "started")
+	fakeGit := filepath.Join(binDir, "git")
+	script := `#!/bin/sh
+if [ "$1" = "rev-parse" ]; then
+  echo feature/test
+  exit 0
+fi
+printf '%s\n' "$$" > "$CODEMAP_HANDOFF_GIT_MARKER"
+exec sleep 10
+`
+	if err := os.WriteFile(fakeGit, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CODEMAP_HANDOFF_GIT_MARKER", marker)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		_, err := BuildContext(ctx, root, BuildOptions{BaseRef: "main"})
+		done <- err
+	}()
+	var blockerPID string
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		if data, err := os.ReadFile(marker); err == nil && len(data) > 0 {
+			blockerPID = strings.TrimSpace(string(data))
+			break
+		}
+		select {
+		case err := <-done:
+			t.Fatalf("BuildContext exited before fake handoff git subprocess started: %v", err)
+		default:
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("fake handoff git subprocess did not start")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	cancel()
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("BuildContext error = %v, want context.Canceled", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("BuildContext did not terminate cancelled git subprocess")
+	}
+	if err := exec.Command("/bin/kill", "-0", blockerPID).Run(); err == nil {
+		t.Fatalf("cancelled fake handoff git left blocker process %s running", blockerPID)
+	}
+}
+
+func TestBuildFileDetailContextPreCancellation(t *testing.T) {
+	artifact := &Artifact{Delta: DeltaSnapshot{Changed: []FileStub{{Path: "main.go"}}}}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := BuildFileDetailContext(ctx, t.TempDir(), artifact, "main.go", nil); !errors.Is(err, context.Canceled) {
+		t.Fatalf("BuildFileDetailContext error = %v, want context.Canceled", err)
+	}
+
+	inFlight := &cancelAfterHandoffChecks{Context: context.Background(), remaining: 1}
+	if _, err := BuildFileDetailContext(inFlight, t.TempDir(), artifact, "main.go", nil); !errors.Is(err, context.Canceled) {
+		t.Fatalf("in-flight BuildFileDetailContext error = %v, want context.Canceled", err)
+	}
+}
+
+func TestFileSHA256ContextInFlightCancellation(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "large.go")
+	if err := os.WriteFile(path, make([]byte, 2<<20), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ctx := &cancelAfterHandoffChecks{Context: context.Background(), remaining: 1}
+	if _, err := fileSHA256Context(ctx, path); !errors.Is(err, context.Canceled) {
+		t.Fatalf("fileSHA256Context error = %v, want context.Canceled", err)
+	}
+}
+
+func TestBuildAndFileDetailPreserveBestEffortScanFailures(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("permission fixture and shell script are Unix-specific")
+	}
+
+	root := t.TempDir()
+	blocked := filepath.Join(root, "blocked")
+	if err := os.MkdirAll(blocked, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(blocked, "main.go"), []byte("package blocked\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(blocked, 0); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(blocked, 0o755) })
+	if _, err := scanner.ScanConfiguredFiles(context.Background(), root, scanner.NewGitIgnoreCache(root)); err == nil {
+		t.Skip("fixture did not produce a scanner failure")
+	}
+
+	binDir := t.TempDir()
+	fakeGit := filepath.Join(binDir, "git")
+	script := `#!/bin/sh
+if [ "$1" = "rev-parse" ]; then
+  echo feature/test
+fi
+exit 0
+`
+	if err := os.WriteFile(fakeGit, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir)
+
+	t.Run("Build", func(t *testing.T) {
+		artifact, err := BuildContext(context.Background(), root, BuildOptions{BaseRef: "HEAD"})
+		if err != nil {
+			t.Fatalf("ordinary scanner failure escaped BuildContext: %v", err)
+		}
+		if artifact == nil || artifact.Prefix.FileCount != 0 {
+			t.Fatalf("BuildContext artifact = %#v, want zero-count best-effort artifact", artifact)
+		}
+	})
+
+	t.Run("BuildFileDetail", func(t *testing.T) {
+		artifact := &Artifact{Delta: DeltaSnapshot{Changed: []FileStub{{Path: "blocked/main.go"}}}}
+		detail, err := BuildFileDetailContext(context.Background(), root, artifact, "blocked/main.go", nil)
+		if err != nil {
+			t.Fatalf("ordinary scanner failure escaped BuildFileDetailContext: %v", err)
+		}
+		if detail == nil || len(detail.Importers) != 0 || len(detail.Imports) != 0 {
+			t.Fatalf("BuildFileDetailContext detail = %#v, want empty best-effort dependency context", detail)
+		}
+	})
+}

--- a/handoff/detail.go
+++ b/handoff/detail.go
@@ -1,6 +1,7 @@
 package handoff
 
 import (
+	"context"
 	"fmt"
 	"path/filepath"
 	"sort"
@@ -13,6 +14,14 @@ import (
 
 // BuildFileDetail resolves detailed context for one changed file stub.
 func BuildFileDetail(root string, artifact *Artifact, targetPath string, state *watch.State) (*FileDetail, error) {
+	return BuildFileDetailContext(context.Background(), root, artifact, targetPath, state)
+}
+
+// BuildFileDetailContext resolves detailed context while honoring caller cancellation.
+func BuildFileDetailContext(ctx context.Context, root string, artifact *Artifact, targetPath string, state *watch.State) (*FileDetail, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	if artifact == nil {
 		return nil, fmt.Errorf("handoff artifact is nil")
 	}
@@ -25,6 +34,9 @@ func BuildFileDetail(root string, artifact *Artifact, targetPath string, state *
 
 	var selected *FileStub
 	for i := range artifact.Delta.Changed {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		if artifact.Delta.Changed[i].Path == target {
 			selected = &artifact.Delta.Changed[i]
 			break
@@ -41,13 +53,22 @@ func BuildFileDetail(root string, artifact *Artifact, targetPath string, state *
 	if state == nil {
 		state = watch.ReadState(absRoot)
 	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 
-	importers, imports := dependencyContextForFile(absRoot, state, target)
+	importers, imports, err := dependencyContextForFileContext(ctx, absRoot, state, target)
+	if err != nil {
+		return nil, err
+	}
 	importers = uniqueSorted(importers)
 	imports = uniqueSorted(imports)
 
 	events := make([]EventSummary, 0, len(artifact.Delta.RecentEvents))
 	for _, event := range artifact.Delta.RecentEvents {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		if event.Path == target {
 			events = append(events, event)
 		}
@@ -66,19 +87,34 @@ func BuildFileDetail(root string, artifact *Artifact, targetPath string, state *
 }
 
 func dependencyContextForFile(root string, state *watch.State, path string) ([]string, []string) {
+	importers, imports, _ := dependencyContextForFileContext(context.Background(), root, state, path)
+	return importers, imports
+}
+
+func dependencyContextForFileContext(ctx context.Context, root string, state *watch.State, path string) ([]string, []string, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, nil, err
+	}
 	if state != nil && (len(state.Importers) > 0 || len(state.Imports) > 0) {
-		return append([]string{}, state.Importers[path]...), append([]string{}, state.Imports[path]...)
+		return append([]string{}, state.Importers[path]...), append([]string{}, state.Imports[path]...), nil
 	}
 
-	if resolveRepoFileCount(root) > limits.LargeRepoFileCount {
-		return nil, nil
-	}
-
-	fg, err := scanner.BuildFileGraph(root)
+	fileCount, err := resolveRepoFileCountContext(ctx, root)
 	if err != nil {
-		return nil, nil
+		return nil, nil, err
 	}
-	return append([]string{}, fg.Importers[path]...), append([]string{}, fg.Imports[path]...)
+	if fileCount > limits.LargeRepoFileCount {
+		return nil, nil, nil
+	}
+
+	fg, err := scanner.BuildFileGraph(ctx, root, scanner.ConfiguredFilters(root))
+	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, nil, ctxErr
+		}
+		return nil, nil, nil
+	}
+	return append([]string{}, fg.Importers[path]...), append([]string{}, fg.Imports[path]...), ctx.Err()
 }
 
 func uniqueSorted(items []string) []string {

--- a/main.go
+++ b/main.go
@@ -457,6 +457,21 @@ type stdinManifest struct {
 	} `json:"files"`
 }
 
+// safeStdinManifestPath validates a --stdin manifest file path and returns a
+// cleaned, slash-normalized path that stays inside the manifest root. Absolute
+// paths and any ".." traversal are rejected so a hostile manifest cannot write
+// outside the private temp directory.
+func safeStdinManifestPath(rel string) (string, bool) {
+	if rel == "" || filepath.IsAbs(rel) {
+		return "", false
+	}
+	cleaned := filepath.Clean(filepath.FromSlash(rel))
+	if cleaned == ".." || strings.HasPrefix(cleaned, ".."+string(filepath.Separator)) || filepath.IsAbs(cleaned) {
+		return "", false
+	}
+	return cleaned, true
+}
+
 func runDepsMode(absRoot, root string, jsonMode bool, diffRef string, changedFiles map[string]bool, stdinMode bool, filters scanner.Filters) {
 	var outcome scanner.ScanOutcome
 	var externalDeps map[string][]string
@@ -545,7 +560,11 @@ func runDepsFromStdin(filters scanner.Filters) (scanner.ScanOutcome, map[string]
 	defer os.RemoveAll(tempDir)
 
 	for _, f := range manifest.Files {
-		dest := filepath.Join(tempDir, f.Path)
+		rel, ok := safeStdinManifestPath(f.Path)
+		if !ok {
+			return scanner.ScanOutcome{}, nil, nil, fmt.Errorf("invalid manifest path %q: must be a relative path inside the manifest root", f.Path)
+		}
+		dest := filepath.Join(tempDir, rel)
 		if err := os.MkdirAll(filepath.Dir(dest), 0755); err != nil {
 			return scanner.ScanOutcome{}, nil, nil, fmt.Errorf("mkdir %s: %w", filepath.Dir(dest), err)
 		}

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -368,7 +369,7 @@ func main() {
 	var diffInfo *scanner.DiffInfo
 	if *diffMode {
 		var err error
-		diffInfo, err = scanner.GitDiffInfo(absRoot, *diffRef)
+		diffInfo, err = scanner.GitDiffInfo(context.Background(), absRoot, *diffRef)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error getting git diff: %v\n", err)
 			fmt.Fprintf(os.Stderr, "Make sure '%s' is a valid branch/ref\n", *diffRef)
@@ -404,7 +405,7 @@ func main() {
 	}
 
 	// Scan files
-	files, err := scanner.ScanFiles(root, gitCache, only, exclude)
+	files, err := scanner.ScanFiles(context.Background(), root, gitCache, only, exclude)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error walking tree: %v\n", err)
 		os.Exit(1)
@@ -415,7 +416,11 @@ func main() {
 	var activeDiffRef string
 	if diffInfo != nil {
 		files = scanner.FilterToChangedWithInfo(files, diffInfo)
-		impact = scanner.AnalyzeImpact(absRoot, files)
+		impact, err = scanner.AnalyzeImpact(context.Background(), absRoot, files)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error analyzing impact: %v\n", err)
+			os.Exit(1)
+		}
 		activeDiffRef = *diffRef
 	}
 
@@ -453,22 +458,22 @@ type stdinManifest struct {
 }
 
 func runDepsMode(absRoot, root string, jsonMode bool, diffRef string, changedFiles map[string]bool, stdinMode bool, filters scanner.Filters) {
-	var analyses []FileAnalysis
+	var outcome scanner.ScanOutcome
 	var externalDeps map[string][]string
+	var graph *scanner.FileGraph
 	var err error
 
 	if stdinMode {
-		analyses, externalDeps, err = runDepsFromStdin(filters)
+		outcome, externalDeps, graph, err = runDepsFromStdin(filters)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error reading stdin manifest: %v\n", err)
 			os.Exit(1)
 		}
-		// Use the manifest root as absRoot if provided
 		if externalDeps == nil {
 			externalDeps = make(map[string][]string)
 		}
 	} else {
-		analyses, err = scanForDepsWithHint(root, filters)
+		outcome, err = scanForDepsOutcomeWithHint(root, filters)
 		if err != nil {
 			if errors.Is(err, scanner.ErrAstGrepNotFound) {
 				printAstGrepInstallHint(os.Stderr, err)
@@ -477,21 +482,23 @@ func runDepsMode(absRoot, root string, jsonMode bool, diffRef string, changedFil
 			}
 			os.Exit(1)
 		}
-		externalDeps = scanner.ReadExternalDeps(absRoot)
+		externalDeps, err = scanner.ReadExternalDeps(context.Background(), absRoot, 0)
+		if err != nil {
+			externalDeps = make(map[string][]string)
+		}
+		graph, err = scanner.BuildFileGraphFromOutcome(context.Background(), absRoot, outcome, filters)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error building dependency graph: %v\n", err)
+			os.Exit(1)
+		}
 	}
 
 	// Filter to changed files if --diff specified
 	if changedFiles != nil {
-		analyses = scanner.FilterAnalysisToChanged(analyses, changedFiles)
+		outcome.Analyses = scanner.FilterAnalysisToChanged(outcome.Analyses, changedFiles)
 	}
 
-	depsProject := scanner.DepsProject{
-		Root:         absRoot,
-		Mode:         "deps",
-		Files:        analyses,
-		ExternalDeps: externalDeps,
-		DiffRef:      diffRef,
-	}
+	depsProject := scanner.NewDepsProjectWithCoverage(absRoot, outcome.Analyses, externalDeps, diffRef, scanner.CoverageFromSources(graph.Coverage.Sources))
 
 	// Render or output JSON
 	if jsonMode {
@@ -501,51 +508,60 @@ func runDepsMode(absRoot, root string, jsonMode bool, diffRef string, changedFil
 	}
 }
 
-// scanForDepsWithHint wraps scanner.ScanForDepsWithFilters (extracted for testability).
-func scanForDepsWithHint(root string, filters scanner.Filters) ([]FileAnalysis, error) {
-	return scanner.ScanForDepsWithFilters(root, filters)
+// scanForDepsOutcomeWithHint wraps scanner.ScanForDeps (extracted for testability).
+func scanForDepsOutcomeWithHint(root string, filters scanner.Filters) (scanner.ScanOutcome, error) {
+	return scanner.ScanForDeps(context.Background(), root, filters)
 }
 
 // runDepsFromStdin reads a JSON manifest from stdin, writes files to a temp
 // directory, runs ast-grep on it, and returns the results with paths matching
 // the original manifest.
-func runDepsFromStdin(filters scanner.Filters) ([]FileAnalysis, map[string][]string, error) {
+func runDepsFromStdin(filters scanner.Filters) (scanner.ScanOutcome, map[string][]string, *scanner.FileGraph, error) {
 	var manifest stdinManifest
 	if err := json.NewDecoder(os.Stdin).Decode(&manifest); err != nil {
-		return nil, nil, fmt.Errorf("invalid JSON: %w", err)
+		return scanner.ScanOutcome{}, nil, nil, fmt.Errorf("invalid JSON: %w", err)
 	}
 
 	if len(manifest.Files) == 0 {
-		return nil, nil, nil
+		return scanner.ScanOutcome{}, nil, nil, nil
 	}
 
 	// Create temp directory and write manifest files
 	tempDir, err := os.MkdirTemp("", "codemap-stdin-*")
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to create temp dir: %w", err)
+		return scanner.ScanOutcome{}, nil, nil, fmt.Errorf("failed to create temp dir: %w", err)
 	}
 	defer os.RemoveAll(tempDir)
 
 	for _, f := range manifest.Files {
 		dest := filepath.Join(tempDir, f.Path)
 		if err := os.MkdirAll(filepath.Dir(dest), 0755); err != nil {
-			return nil, nil, fmt.Errorf("mkdir %s: %w", filepath.Dir(dest), err)
+			return scanner.ScanOutcome{}, nil, nil, fmt.Errorf("mkdir %s: %w", filepath.Dir(dest), err)
 		}
 		if err := os.WriteFile(dest, []byte(f.Content), 0644); err != nil {
-			return nil, nil, fmt.Errorf("write %s: %w", f.Path, err)
+			return scanner.ScanOutcome{}, nil, nil, fmt.Errorf("write %s: %w", f.Path, err)
 		}
 	}
 
 	// Run ast-grep on temp directory
-	analyses, err := scanner.ScanForDepsWithFilters(tempDir, filters)
+	outcome, err := scanner.ScanForDeps(context.Background(), tempDir, filters)
 	if err != nil {
-		return nil, nil, err
+		return scanner.ScanOutcome{}, nil, nil, err
 	}
 
 	// Read external deps from temp directory (manifest may include go.mod etc.)
-	externalDeps := scanner.ReadExternalDeps(tempDir)
+	externalDeps, err := scanner.ReadExternalDeps(context.Background(), tempDir, 0)
+	if err != nil {
+		return scanner.ScanOutcome{}, nil, nil, err
+	}
 
-	return analyses, externalDeps, nil
+	// Build the graph in the temp directory so coverage provenance is honest.
+	graph, err := scanner.BuildFileGraphFromOutcome(context.Background(), tempDir, outcome, filters)
+	if err != nil {
+		return scanner.ScanOutcome{}, nil, nil, err
+	}
+
+	return outcome, externalDeps, graph, nil
 }
 
 // FileAnalysis is a type alias for use in main package.
@@ -591,7 +607,7 @@ func runWatchMode(root string, verbose bool) {
 }
 
 func buildImportersReport(root, file string, filters scanner.Filters) (scanner.ImportersReport, error) {
-	fg, err := scanner.BuildFileGraphWithFilters(root, filters)
+	fg, err := scanner.BuildFileGraph(context.Background(), root, filters)
 	if err != nil {
 		return scanner.ImportersReport{}, err
 	}

--- a/main.go
+++ b/main.go
@@ -486,10 +486,12 @@ func runDepsMode(absRoot, root string, jsonMode bool, diffRef string, changedFil
 		if err != nil {
 			externalDeps = make(map[string][]string)
 		}
-		graph, err = scanner.BuildFileGraphFromOutcome(context.Background(), absRoot, outcome, filters)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error building dependency graph: %v\n", err)
-			os.Exit(1)
+		// Build the graph from the scan outcome. The graph is best-effort: a
+		// fail-closed scan or a non-fatal graph build problem must not turn
+		// --deps into a hard error. Coverage falls back to the scan outcome's
+		// own sources when no graph is available.
+		if built, graphErr := scanner.BuildFileGraphFromOutcome(context.Background(), absRoot, outcome, filters); graphErr == nil {
+			graph = built
 		}
 	}
 
@@ -498,13 +500,20 @@ func runDepsMode(absRoot, root string, jsonMode bool, diffRef string, changedFil
 		outcome.Analyses = scanner.FilterAnalysisToChanged(outcome.Analyses, changedFiles)
 	}
 
-	depsProject := scanner.NewDepsProjectWithCoverage(absRoot, outcome.Analyses, externalDeps, diffRef, scanner.CoverageFromSources(graph.Coverage.Sources))
+	// Derive coverage from the graph's provenance when one was built; otherwise
+	// fall back to the scan outcome's sources (nil graph = empty stdin manifest
+	// or best-effort graph failure).
+	coverageSources := outcome.Sources
+	if graph != nil {
+		coverageSources = graph.Coverage.Sources
+	}
+	depsProject := scanner.NewDepsProjectWithCoverage(absRoot, outcome.Analyses, externalDeps, diffRef, scanner.CoverageFromSources(coverageSources))
 
 	// Render or output JSON
 	if jsonMode {
 		json.NewEncoder(os.Stdout).Encode(depsProject)
 	} else {
-		render.Depgraph(os.Stdout, depsProject)
+		render.Depgraph(context.Background(), os.Stdout, depsProject)
 	}
 }
 
@@ -523,7 +532,9 @@ func runDepsFromStdin(filters scanner.Filters) (scanner.ScanOutcome, map[string]
 	}
 
 	if len(manifest.Files) == 0 {
-		return scanner.ScanOutcome{}, nil, nil, nil
+		// Return a valid empty graph/outcome so callers never dereference a nil
+		// graph when deriving coverage; an empty manifest is an empty answer.
+		return scanner.ScanOutcome{}, nil, &scanner.FileGraph{}, nil
 	}
 
 	// Create temp directory and write manifest files

--- a/main_more_test.go
+++ b/main_more_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"codemap/analysis"
 	"codemap/config"
 	"codemap/handoff"
 	"codemap/scanner"
@@ -352,6 +353,9 @@ func TestRunDepsModeJSONAndMainDispatchesDepsAndImporters(t *testing.T) {
 
 	root := t.TempDir()
 	writeImportersFixture(t, root)
+	if err := os.WriteFile(filepath.Join(root, "lib.rs"), []byte("pub struct Value;\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	stdout, _ := captureMainStreams(t, func() {
 		runDepsMode(root, root, true, "main", map[string]bool{"a/a.go": true}, false, scanner.Filters{})
@@ -375,7 +379,7 @@ func TestRunDepsModeJSONAndMainDispatchesDepsAndImporters(t *testing.T) {
 	if err := json.Unmarshal([]byte(stdout), &depsProject); err != nil {
 		t.Fatalf("expected main deps JSON output, got error %v with body:\n%s", err, stdout)
 	}
-	if depsProject.Mode != "deps" || len(depsProject.Files) == 0 {
+	if depsProject.Mode != "deps" || len(depsProject.Files) == 0 || depsProject.Coverage.Status != analysis.CoveragePartial {
 		t.Fatalf("expected deps project output, got %+v", depsProject)
 	}
 

--- a/main_more_test.go
+++ b/main_more_test.go
@@ -936,3 +936,47 @@ func TestRunWatchSubcommandStopForeignPID(t *testing.T) {
 		t.Fatalf("should not claim the daemon was stopped for a foreign PID:\n%s", stdout)
 	}
 }
+
+// Regression for PR #105: an empty stdin manifest must produce an empty deps
+// answer instead of panicking on a nil graph's coverage.
+func TestRunDepsModeEmptyStdinManifestDoesNotPanic(t *testing.T) {
+	for _, jsonMode := range []bool{true, false} {
+		name := "text"
+		if jsonMode {
+			name = "json"
+		}
+		t.Run(name, func(t *testing.T) {
+			reader, writer, err := os.Pipe()
+			if err != nil {
+				t.Fatal(err)
+			}
+			oldStdin := os.Stdin
+			os.Stdin = reader
+			t.Cleanup(func() {
+				os.Stdin = oldStdin
+				_ = reader.Close()
+			})
+			if _, err := writer.WriteString(`{"root":"stdin-root","files":[]}`); err != nil {
+				t.Fatal(err)
+			}
+			if err := writer.Close(); err != nil {
+				t.Fatal(err)
+			}
+
+			stdout, _ := captureMainStreams(t, func() {
+				runDepsMode("stdin-root", "stdin-root", jsonMode, "main", nil, true, scanner.Filters{})
+			})
+			if jsonMode {
+				var project scanner.DepsProject
+				if err := json.Unmarshal([]byte(stdout), &project); err != nil {
+					t.Fatalf("decode empty stdin deps JSON: %v\n%s", err, stdout)
+				}
+				if project.Mode != "deps" || len(project.Files) != 0 {
+					t.Fatalf("expected empty deps project, got %+v", project)
+				}
+			} else if !strings.Contains(stdout, "No source files found.") {
+				t.Fatalf("expected empty rendered deps, got:\n%s", stdout)
+			}
+		})
+	}
+}

--- a/main_more_test.go
+++ b/main_more_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -976,6 +977,53 @@ func TestRunDepsModeEmptyStdinManifestDoesNotPanic(t *testing.T) {
 				}
 			} else if !strings.Contains(stdout, "No source files found.") {
 				t.Fatalf("expected empty rendered deps, got:\n%s", stdout)
+			}
+		})
+	}
+}
+
+func TestSafeStdinManifestPath(t *testing.T) {
+	for _, accepted := range []string{"go.mod", "src/main.go", "a/b/c.ts", "./go.mod", "a/../b/x.go"} {
+		got, ok := safeStdinManifestPath(accepted)
+		if !ok {
+			t.Fatalf("safeStdinManifestPath(%q) rejected, want accept", accepted)
+		}
+		if got == "" {
+			t.Fatalf("safeStdinManifestPath(%q) = empty path", accepted)
+		}
+	}
+	for _, rejected := range []string{"", "../x", "a/../../x", "/abs/path", ".."} {
+		if _, ok := safeStdinManifestPath(rejected); ok {
+			t.Fatalf("safeStdinManifestPath(%q) accepted, want reject", rejected)
+		}
+	}
+}
+
+// A --stdin manifest must never write outside the private temp directory:
+// parent traversal and absolute paths are rejected before any file is written,
+// so a hostile manifest cannot touch arbitrary paths on disk.
+func TestRunDepsFromStdinRejectsEscapingPaths(t *testing.T) {
+	for _, path := range []string{"../outside.go", "a/../../outside.go", "/etc/outside.go", ".."} {
+		t.Run(path, func(t *testing.T) {
+			reader, writer, err := os.Pipe()
+			if err != nil {
+				t.Fatal(err)
+			}
+			oldStdin := os.Stdin
+			os.Stdin = reader
+			t.Cleanup(func() {
+				os.Stdin = oldStdin
+				_ = reader.Close()
+			})
+			manifest := fmt.Sprintf(`{"root":"stdin-root","files":[{"path":%q,"content":"package main\n"},{"path":"go.mod","content":"module example.com/stdin\n"}]}`, path)
+			if _, err := writer.WriteString(manifest); err != nil {
+				t.Fatal(err)
+			}
+			if err := writer.Close(); err != nil {
+				t.Fatal(err)
+			}
+			if _, _, _, err := runDepsFromStdin(scanner.Filters{}); err == nil {
+				t.Fatalf("expected error for manifest path %q", path)
 			}
 		})
 	}

--- a/mcp/analysis_output.go
+++ b/mcp/analysis_output.go
@@ -89,7 +89,7 @@ func newImportersOutput(root, file string, graph *scanner.FileGraph) ImportersOu
 		Kind: kind, Root: root, Mode: "importers", File: file,
 		Importers: boundedImporters, Imports: boundedImports, HubImports: boundedHubs,
 		ImporterCount: len(importers), IsHub: graph.IsHub(file),
-		CoverageStatus: graph.Coverage.Status, CoverageNotes: nonNilCopy(graph.Coverage.Notes),
+		CoverageStatus: string(graph.Coverage.Status), CoverageNotes: nonNilCopy(graph.Coverage.Notes),
 		Truncated: omittedCount > 0, OmittedCount: omittedCount,
 	}
 }

--- a/mcp/analysis_output_test.go
+++ b/mcp/analysis_output_test.go
@@ -1,0 +1,68 @@
+package codemapmcp
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"codemap/analysis"
+	"codemap/scanner"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+func TestGetDependenciesReturnsTextAndStructuredContent(t *testing.T) {
+	if !scanner.NewAstGrepAnalyzer().Available() {
+		t.Skip("ast-grep not available")
+	}
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "main.go"), []byte("package main\n\nfunc main() {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "lib.rs"), []byte("pub struct Value;\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	serverTransport, clientTransport := mcp.NewInMemoryTransports()
+	if _, err := NewServer(RuntimeOptions{}).Connect(ctx, serverTransport, nil); err != nil {
+		t.Fatal(err)
+	}
+	client := mcp.NewClient(&mcp.Implementation{Name: "structured-output-test", Version: "1"}, nil)
+	session, err := client.Connect(ctx, clientTransport, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer session.Close()
+	tools, err := session.ListTools(ctx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, tool := range tools.Tools {
+		if tool.Name == "get_dependencies" && tool.OutputSchema == nil {
+			t.Fatal("get_dependencies does not advertise an output schema")
+		}
+	}
+	result, err := session.CallTool(ctx, &mcp.CallToolParams{Name: "get_dependencies", Arguments: map[string]any{"path": root}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.IsError || !strings.Contains(resultText(t, result), "Dependency Flow") || result.StructuredContent == nil {
+		t.Fatalf("structured dependency result = %#v", result)
+	}
+	encoded, err := json.Marshal(result.StructuredContent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var output scanner.DepsProject
+	if err := json.Unmarshal(encoded, &output); err != nil {
+		t.Fatal(err)
+	}
+	if output.SchemaVersion != analysis.SchemaVersion || output.Coverage.Status != analysis.CoveragePartial {
+		t.Fatalf("structured output = %#v", output)
+	}
+}

--- a/mcp/cancellation_test.go
+++ b/mcp/cancellation_test.go
@@ -1,0 +1,496 @@
+package codemapmcp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"codemap/handoff"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+type cancelAfterMCPChecks struct {
+	context.Context
+	remaining int
+}
+
+type scriptedProjectDirReader struct {
+	entries []os.DirEntry
+	offset  int
+}
+
+func (r *scriptedProjectDirReader) ReadDir(n int) ([]os.DirEntry, error) {
+	if r.offset >= len(r.entries) {
+		return nil, io.EOF
+	}
+	end := min(r.offset+n, len(r.entries))
+	batch := r.entries[r.offset:end]
+	r.offset = end
+	return batch, nil
+}
+
+type namedProjectDirEntry string
+
+func (e namedProjectDirEntry) Name() string               { return string(e) }
+func (e namedProjectDirEntry) IsDir() bool                { return true }
+func (e namedProjectDirEntry) Type() fs.FileMode          { return fs.ModeDir }
+func (e namedProjectDirEntry) Info() (fs.FileInfo, error) { return nil, errors.New("unused") }
+
+func (c *cancelAfterMCPChecks) Err() error {
+	if c.remaining <= 0 {
+		return context.Canceled
+	}
+	c.remaining--
+	return nil
+}
+
+func TestMCPTraversalHandlersReportPreCancellation(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "main.go"), []byte("package main\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name string
+		call func(context.Context) (bool, string, error)
+	}{
+		{"structure", func(ctx context.Context) (bool, string, error) {
+			r, _, e := handleGetStructure(ctx, nil, StructureInput{Path: root})
+			return resultState(t, r, e)
+		}},
+		{"dependencies", func(ctx context.Context) (bool, string, error) {
+			r, _, e := handleGetDependencies(ctx, nil, PathInput{Path: root})
+			return resultState(t, r, e)
+		}},
+		{"diff", func(ctx context.Context) (bool, string, error) {
+			r, _, e := handleGetDiff(ctx, nil, DiffInput{Path: root, Ref: "HEAD"})
+			return resultState(t, r, e)
+		}},
+		{"find", func(ctx context.Context) (bool, string, error) {
+			r, _, e := handleFindFile(ctx, nil, FindInput{Path: root, Pattern: "main"})
+			return resultState(t, r, e)
+		}},
+		{"importers", func(ctx context.Context) (bool, string, error) {
+			r, _, e := handleGetImporters(ctx, nil, ImportersInput{Path: root, File: "main.go"})
+			return resultState(t, r, e)
+		}},
+		{"hubs", func(ctx context.Context) (bool, string, error) {
+			r, _, e := handleGetHubs(ctx, nil, PathInput{Path: root})
+			return resultState(t, r, e)
+		}},
+		{"file context", func(ctx context.Context) (bool, string, error) {
+			r, _, e := handleGetFileContext(ctx, nil, ImportersInput{Path: root, File: "main.go"})
+			return resultState(t, r, e)
+		}},
+		{"handoff", func(ctx context.Context) (bool, string, error) {
+			r, _, e := handleGetHandoff(ctx, nil, HandoffInput{Path: root})
+			return resultState(t, r, e)
+		}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
+			isError, text, err := tt.call(ctx)
+			if err != nil {
+				t.Fatalf("handler returned transport error instead of explicit result: %v", err)
+			}
+			if !isError || !strings.Contains(strings.ToLower(text), "cancel") {
+				t.Fatalf("cancelled handler result: IsError=%v text=%q", isError, text)
+			}
+		})
+	}
+}
+
+func TestMCPTraversalHandlersReportInFlightCancellation(t *testing.T) {
+	root := t.TempDir()
+	for i := 0; i < 20; i++ {
+		if err := os.WriteFile(filepath.Join(root, fmt.Sprintf("file-%02d.go", i)), []byte("package fixture\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	tests := []struct {
+		name string
+		call func(context.Context) (bool, string, error)
+	}{
+		{"structure", func(ctx context.Context) (bool, string, error) {
+			r, _, e := handleGetStructure(ctx, nil, StructureInput{Path: root})
+			return resultState(t, r, e)
+		}},
+		{"dependencies", func(ctx context.Context) (bool, string, error) {
+			r, _, e := handleGetDependencies(ctx, nil, PathInput{Path: root})
+			return resultState(t, r, e)
+		}},
+		{"diff", func(ctx context.Context) (bool, string, error) {
+			r, _, e := handleGetDiff(ctx, nil, DiffInput{Path: root, Ref: "HEAD"})
+			return resultState(t, r, e)
+		}},
+		{"find", func(ctx context.Context) (bool, string, error) {
+			r, _, e := handleFindFile(ctx, nil, FindInput{Path: root, Pattern: "file"})
+			return resultState(t, r, e)
+		}},
+		{"importers", func(ctx context.Context) (bool, string, error) {
+			r, _, e := handleGetImporters(ctx, nil, ImportersInput{Path: root, File: "file-00.go"})
+			return resultState(t, r, e)
+		}},
+		{"hubs", func(ctx context.Context) (bool, string, error) {
+			r, _, e := handleGetHubs(ctx, nil, PathInput{Path: root})
+			return resultState(t, r, e)
+		}},
+		{"file context", func(ctx context.Context) (bool, string, error) {
+			r, _, e := handleGetFileContext(ctx, nil, ImportersInput{Path: root, File: "file-00.go"})
+			return resultState(t, r, e)
+		}},
+		{"handoff", func(ctx context.Context) (bool, string, error) {
+			r, _, e := handleGetHandoff(ctx, nil, HandoffInput{Path: root})
+			return resultState(t, r, e)
+		}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := &cancelAfterMCPChecks{Context: context.Background(), remaining: 1}
+			isError, text, err := tt.call(ctx)
+			if err != nil {
+				t.Fatalf("handler returned transport error instead of explicit result: %v", err)
+			}
+			if !isError || !strings.Contains(strings.ToLower(text), "cancel") {
+				t.Fatalf("cancelled handler result: IsError=%v text=%q", isError, text)
+			}
+		})
+	}
+}
+
+func resultState(t *testing.T, result interface{}, err error) (bool, string, error) {
+	t.Helper()
+	if err != nil {
+		return false, "", err
+	}
+	if result == nil {
+		return false, "", errors.New("nil MCP result")
+	}
+	r, ok := result.(*mcp.CallToolResult)
+	if !ok {
+		return false, "", fmt.Errorf("unexpected MCP result type %T", result)
+	}
+	return r.IsError, resultText(t, r), nil
+}
+
+func TestListProjectsUsesSeparateExaminedAndResultCaps(t *testing.T) {
+	t.Run("exact result cap is complete", func(t *testing.T) {
+		parent := t.TempDir()
+		createProjectDirs(t, parent, 50, "project")
+		result, _, err := handleListProjects(context.Background(), nil, ListProjectsInput{Path: parent})
+		if err != nil {
+			t.Fatal(err)
+		}
+		out := resultText(t, result)
+		if result.IsError || strings.Contains(out, "truncated") || strings.Count(out, "project-") != 50 {
+			t.Fatalf("exact-cap result: IsError=%v count=%d output=%q", result.IsError, strings.Count(out, "project-"), out)
+		}
+	})
+
+	t.Run("over result cap truncates", func(t *testing.T) {
+		parent := t.TempDir()
+		createProjectDirs(t, parent, 51, "project")
+		result, _, err := handleListProjects(context.Background(), nil, ListProjectsInput{Path: parent})
+		if err != nil {
+			t.Fatal(err)
+		}
+		out := resultText(t, result)
+		if result.IsError || strings.Count(out, "project-") != 50 || !strings.Contains(out, "truncated") {
+			t.Fatalf("over-cap result: IsError=%v count=%d output=%q", result.IsError, strings.Count(out, "project-"), out)
+		}
+	})
+
+	t.Run("examined cap bounds nonmatches", func(t *testing.T) {
+		parent := t.TempDir()
+		createProjectDirs(t, parent, 240, "nonmatch")
+		result, _, err := handleListProjects(context.Background(), nil, ListProjectsInput{Path: parent, Pattern: "wanted"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		out := resultText(t, result)
+		want := fmt.Sprintf("Project discovery matching 'wanted' in %s was truncated after examining 200 entries; results are unavailable because the directory exceeds the examination cap.", parent)
+		if result.IsError || out != want {
+			t.Fatalf("patterned examined-cap result: IsError=%v output=%q, want %q", result.IsError, out, want)
+		}
+		if strings.Contains(out, "No projects matching") {
+			t.Fatalf("patterned examined-cap result made a false exhaustive claim: %q", out)
+		}
+	})
+
+	t.Run("examined cap does not claim parent has no projects", func(t *testing.T) {
+		parent := t.TempDir()
+		createProjectDirs(t, parent, 201, "project")
+		result, _, err := handleListProjects(context.Background(), nil, ListProjectsInput{Path: parent})
+		if err != nil {
+			t.Fatal(err)
+		}
+		out := resultText(t, result)
+		want := fmt.Sprintf("Project discovery in %s was truncated after examining 200 entries; results are unavailable because the directory exceeds the examination cap.", parent)
+		if result.IsError || out != want {
+			t.Fatalf("unpatterned examined-cap result: IsError=%v output=%q, want %q", result.IsError, out, want)
+		}
+		if strings.Contains(out, "No project directories found") {
+			t.Fatalf("unpatterned examined-cap result made a false exhaustive claim: %q", out)
+		}
+	})
+}
+
+func TestSelectProjectCandidatesSortsAcrossBatchesAndCapsDeterministically(t *testing.T) {
+	makeEntries := func(count int) []os.DirEntry {
+		entries := make([]os.DirEntry, 0, count)
+		for i := count - 1; i >= 0; i-- {
+			entries = append(entries, namedProjectDirEntry(fmt.Sprintf("project-%03d", i)))
+		}
+		return entries
+	}
+
+	tests := []struct {
+		name               string
+		count              int
+		wantCount          int
+		wantExamined       int
+		wantResultCap      bool
+		wantExaminationCap bool
+	}{
+		{name: "exact result cap", count: 50, wantCount: 50, wantExamined: 50},
+		{name: "over result cap", count: 51, wantCount: 50, wantExamined: 51, wantResultCap: true},
+		{name: "over examination cap", count: 201, wantCount: 0, wantExamined: 200, wantExaminationCap: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reader := &scriptedProjectDirReader{entries: makeEntries(tt.count)}
+			candidates, examined, byResults, byExamined, err := selectProjectCandidates(context.Background(), reader, "")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(candidates) != tt.wantCount || examined != tt.wantExamined || byResults != tt.wantResultCap || byExamined != tt.wantExaminationCap {
+				t.Fatalf("selection = count %d, examined %d, result cap %v, examination cap %v", len(candidates), examined, byResults, byExamined)
+			}
+			for i, candidate := range candidates {
+				want := fmt.Sprintf("project-%03d", tt.count-tt.wantExamined+i)
+				if candidate != want {
+					t.Fatalf("candidate[%d] = %q, want %q; selection was not sorted across batches", i, candidate, want)
+				}
+			}
+		})
+	}
+}
+
+func TestSelectProjectCandidatesAboveExamCapIsIndependentOfEnumerationOrder(t *testing.T) {
+	forward := make([]os.DirEntry, 0, maxExaminedProjectEntries+1)
+	reverse := make([]os.DirEntry, 0, maxExaminedProjectEntries+1)
+	for i := 0; i <= maxExaminedProjectEntries; i++ {
+		forward = append(forward, namedProjectDirEntry(fmt.Sprintf("project-%03d", i)))
+	}
+	for i := maxExaminedProjectEntries; i >= 0; i-- {
+		reverse = append(reverse, namedProjectDirEntry(fmt.Sprintf("project-%03d", i)))
+	}
+
+	for name, entries := range map[string][]os.DirEntry{"forward": forward, "reverse": reverse} {
+		t.Run(name, func(t *testing.T) {
+			candidates, examined, byResults, byExamined, err := selectProjectCandidates(context.Background(), &scriptedProjectDirReader{entries: entries}, "")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(candidates) != 0 || examined != maxExaminedProjectEntries || byResults || !byExamined {
+				t.Fatalf("oversized selection leaked filesystem order: candidates=%v examined=%d result cap=%v examination cap=%v", candidates, examined, byResults, byExamined)
+			}
+		})
+	}
+}
+
+func TestListProjectsCancellationIsNotTruncation(t *testing.T) {
+	parent := t.TempDir()
+	createProjectDirs(t, parent, 80, "project")
+	ctx := &cancelAfterMCPChecks{Context: context.Background(), remaining: 1}
+	result, _, err := handleListProjects(ctx, nil, ListProjectsInput{Path: parent})
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := resultText(t, result)
+	if !result.IsError || !strings.Contains(strings.ToLower(out), "cancel") || strings.Contains(strings.ToLower(out), "truncated") {
+		t.Fatalf("cancelled discovery result: IsError=%v output=%q", result.IsError, out)
+	}
+}
+
+func TestListProjectsPreservesPerChildScanErrors(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("permission fixture is Unix-specific")
+	}
+	parent := t.TempDir()
+	project := filepath.Join(parent, "restricted")
+	blocked := filepath.Join(project, "blocked")
+	if err := os.MkdirAll(blocked, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(blocked, 0); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(blocked, 0o755) })
+
+	result, _, err := handleListProjects(context.Background(), nil, ListProjectsInput{Path: parent})
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := resultText(t, result)
+	if result.IsError || !strings.Contains(out, "restricted/") || !strings.Contains(out, "(error scanning)") {
+		t.Fatalf("per-child scan failure was not preserved: IsError=%v output=%q", result.IsError, out)
+	}
+}
+
+func TestTraversalRootsFailClosed(t *testing.T) {
+	notDir := filepath.Join(t.TempDir(), "not-a-directory")
+	if err := os.WriteFile(notDir, []byte("not a project"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	tests := []struct {
+		name string
+		call func() (bool, string, error)
+	}{
+		{"structure", func() (bool, string, error) {
+			r, _, e := handleGetStructure(context.Background(), nil, StructureInput{Path: notDir})
+			return resultState(t, r, e)
+		}},
+		{"dependencies", func() (bool, string, error) {
+			r, _, e := handleGetDependencies(context.Background(), nil, PathInput{Path: notDir})
+			return resultState(t, r, e)
+		}},
+		{"diff", func() (bool, string, error) {
+			r, _, e := handleGetDiff(context.Background(), nil, DiffInput{Path: notDir, Ref: "HEAD"})
+			return resultState(t, r, e)
+		}},
+		{"find", func() (bool, string, error) {
+			r, _, e := handleFindFile(context.Background(), nil, FindInput{Path: notDir, Pattern: "x"})
+			return resultState(t, r, e)
+		}},
+		{"importers", func() (bool, string, error) {
+			r, _, e := handleGetImporters(context.Background(), nil, ImportersInput{Path: notDir, File: "x.go"})
+			return resultState(t, r, e)
+		}},
+		{"hubs", func() (bool, string, error) {
+			r, _, e := handleGetHubs(context.Background(), nil, PathInput{Path: notDir})
+			return resultState(t, r, e)
+		}},
+		{"file context", func() (bool, string, error) {
+			r, _, e := handleGetFileContext(context.Background(), nil, ImportersInput{Path: notDir, File: "x.go"})
+			return resultState(t, r, e)
+		}},
+		{"handoff", func() (bool, string, error) {
+			r, _, e := handleGetHandoff(context.Background(), nil, HandoffInput{Path: notDir})
+			return resultState(t, r, e)
+		}},
+		{"list projects", func() (bool, string, error) {
+			r, _, e := handleListProjects(context.Background(), nil, ListProjectsInput{Path: notDir})
+			return resultState(t, r, e)
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			isError, text, err := tt.call()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !isError || text == "" {
+				t.Fatalf("invalid explicit root did not fail closed: IsError=%v text=%q", isError, text)
+			}
+		})
+	}
+
+	result, _, err := handleListProjects(context.Background(), nil, ListProjectsInput{Path: string([]byte{'b', 'a', 'd', 0, 'p', 'a', 't', 'h'})})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.IsError {
+		t.Fatalf("malformed root did not fail closed: %q", resultText(t, result))
+	}
+}
+
+func TestHandoffCancellationBeforePersistenceCommitPoint(t *testing.T) {
+	oldBuild := buildHandoffForMCP
+	oldWrite := writeLatestForMCP
+	t.Cleanup(func() {
+		buildHandoffForMCP = oldBuild
+		writeLatestForMCP = oldWrite
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	buildHandoffForMCP = func(context.Context, string, handoff.BuildOptions) (*handoff.Artifact, error) {
+		cancel()
+		return &handoff.Artifact{}, nil
+	}
+	writeCalled := false
+	writeLatestForMCP = func(string, *handoff.Artifact) error {
+		writeCalled = true
+		return nil
+	}
+
+	result, _, err := handleGetHandoff(ctx, nil, HandoffInput{Path: t.TempDir(), Save: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if writeCalled {
+		t.Fatal("WriteLatest began after cancellation was observed before persistence commit point")
+	}
+	if !result.IsError || !strings.Contains(strings.ToLower(resultText(t, result)), "cancel") {
+		t.Fatalf("pre-persistence cancellation result: IsError=%v text=%q", result.IsError, resultText(t, result))
+	}
+}
+
+func TestGetDiffPreservesBestEffortUnavailableImpactScan(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake Git script is Unix-specific")
+	}
+
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "main.go"), []byte("package main\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	binDir := t.TempDir()
+	fakeGit := filepath.Join(binDir, "git")
+	script := `#!/bin/sh
+if [ "$1" = "diff" ] && [ "$2" = "--numstat" ]; then
+  printf '1\t0\tmain.go\n'
+fi
+exit 0
+`
+	if err := os.WriteFile(fakeGit, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Keep Git available while making ast-grep unavailable.
+	t.Setenv("PATH", binDir)
+
+	result, _, err := handleGetDiff(context.Background(), nil, DiffInput{Path: root, Ref: "HEAD"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.IsError || !strings.Contains(resultText(t, result), "main.go") {
+		t.Fatalf("ordinary impact scan failure escaped get_diff: IsError=%v output=%q", result.IsError, resultText(t, result))
+	}
+}
+
+func createProjectDirs(t *testing.T, parent string, count int, prefix string) {
+	t.Helper()
+	for i := 0; i < count; i++ {
+		root := filepath.Join(parent, fmt.Sprintf("%s-%03d", prefix, i))
+		if err := os.Mkdir(root, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(root, "main.go"), []byte("package main\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+}

--- a/mcp/main.go
+++ b/mcp/main.go
@@ -844,9 +844,9 @@ func mcpCoverageText(fg *scanner.FileGraph) string {
 		return ""
 	}
 	if len(fg.Coverage.Notes) == 0 {
-		return "\n\nCoverage: " + fg.Coverage.Status
+		return "\n\nCoverage: " + string(fg.Coverage.Status)
 	}
-	return "\n\nCoverage: " + fg.Coverage.Status + " — " + strings.Join(fg.Coverage.Notes, "; ")
+	return "\n\nCoverage: " + string(fg.Coverage.Status) + " — " + strings.Join(fg.Coverage.Notes, "; ")
 }
 
 func handleGetHandoff(ctx context.Context, req *mcp.CallToolRequest, input HandoffInput) (*mcp.CallToolResult, any, error) {

--- a/mcp/main.go
+++ b/mcp/main.go
@@ -33,6 +33,10 @@ import (
 var (
 	watchers   = make(map[string]*watch.Daemon)
 	watchersMu sync.RWMutex
+
+	buildHandoffForMCP    = handoff.BuildContext
+	buildHandoffDetailMCP = handoff.BuildFileDetailContext
+	writeLatestForMCP     = handoff.WriteLatest
 )
 
 const (
@@ -172,10 +176,12 @@ func NewServer(options RuntimeOptions) *mcp.Server {
 	}, handleGetStructure)
 
 	// Tool: get_dependencies - Get dependency graph
-	mcp.AddTool(server, &mcp.Tool{
-		Name:        "get_dependencies",
-		Description: "Get the dependency flow of a project. Shows external dependencies by language, internal import chains between files, hub files (most-imported), and function counts. Use this to understand how code connects and which files are most critical.",
-	}, handleGetDependencies)
+	dependenciesTool := &mcp.Tool{
+		Name:         "get_dependencies",
+		Description:  "Get the dependency flow of a project. Shows external dependencies by language, internal import chains between files, hub files (most-imported), and function counts. Use this to understand how code connects and which files are most critical.",
+		OutputSchema: mustSchemaFor[scanner.DepsProject](),
+	}
+	mcp.AddTool(server, dependenciesTool, handleGetDependencies)
 
 	// Tool: get_diff - Get changed files with impact analysis
 	mcp.AddTool(server, &mcp.Tool{
@@ -302,15 +308,40 @@ func mustSchemaFor[T any]() *jsonschema.Schema {
 	return schema
 }
 
-func handleGetStructure(ctx context.Context, req *mcp.CallToolRequest, input StructureInput) (*mcp.CallToolResult, any, error) {
-	absRoot, err := filepath.Abs(input.Path)
+func traversalRoot(path string) (string, *mcp.CallToolResult) {
+	absRoot, err := filepath.Abs(path)
 	if err != nil {
-		return errorResult("Invalid path: " + err.Error()), nil, nil
+		return "", errorResult("Invalid path: " + err.Error())
+	}
+	info, err := os.Stat(absRoot)
+	if err != nil || !info.IsDir() {
+		return "", errorResult("Invalid project path: path is not an accessible directory")
+	}
+	return absRoot, nil
+}
+
+func cancellationResult(ctx context.Context, operation string) *mcp.CallToolResult {
+	if err := ctx.Err(); err != nil {
+		return errorResult(operation + " cancelled: " + err.Error())
+	}
+	return nil
+}
+
+func handleGetStructure(ctx context.Context, req *mcp.CallToolRequest, input StructureInput) (*mcp.CallToolResult, any, error) {
+	if cancelled := cancellationResult(ctx, "Structure scan"); cancelled != nil {
+		return cancelled, nil, nil
+	}
+	absRoot, invalid := traversalRoot(input.Path)
+	if invalid != nil {
+		return invalid, nil, nil
 	}
 
-	gitCache := scanner.NewGitIgnoreCache(input.Path)
-	files, err := scanner.ScanConfiguredFiles(input.Path, gitCache)
+	gitCache := scanner.NewGitIgnoreCache(absRoot)
+	files, err := scanner.ScanConfiguredFiles(ctx, absRoot, gitCache)
 	if err != nil {
+		if cancelled := cancellationResult(ctx, "Structure scan"); cancelled != nil {
+			return cancelled, nil, nil
+		}
 		return errorResult("Scan error: " + err.Error()), nil, nil
 	}
 	fileCount := len(files)
@@ -350,7 +381,10 @@ func handleGetStructure(ctx context.Context, req *mcp.CallToolRequest, input Str
 		hubs = append(hubs, state.Hubs...)
 		importers = state.Importers
 	} else if fileCount <= limits.LargeRepoFileCount {
-		fg, err := scanner.BuildFileGraph(absRoot)
+		fg, err := scanner.BuildFileGraph(ctx, absRoot, scanner.ConfiguredFilters(absRoot))
+		if cancelled := cancellationResult(ctx, "Structure graph analysis"); cancelled != nil {
+			return cancelled, nil, nil
+		}
 		if err == nil {
 			hubs = fg.HubFiles()
 			importers = fg.Importers
@@ -377,43 +411,66 @@ func handleGetStructure(ctx context.Context, req *mcp.CallToolRequest, input Str
 }
 
 func handleGetDependencies(ctx context.Context, req *mcp.CallToolRequest, input PathInput) (*mcp.CallToolResult, any, error) {
-	absRoot, err := filepath.Abs(input.Path)
-	if err != nil {
-		return errorResult("Invalid path: " + err.Error()), nil, nil
+	if cancelled := cancellationResult(ctx, "Dependency scan"); cancelled != nil {
+		return cancelled, nil, nil
+	}
+	absRoot, invalid := traversalRoot(input.Path)
+	if invalid != nil {
+		return invalid, nil, nil
 	}
 
-	analyses, err := scanner.ScanForDeps(input.Path)
+	filters := scanner.ConfiguredFilters(absRoot)
+	outcome, err := scanner.ScanForDeps(ctx, absRoot, filters)
 	if err != nil {
+		if cancelled := cancellationResult(ctx, "Dependency scan"); cancelled != nil {
+			return cancelled, nil, nil
+		}
 		return errorResult("Scan error: " + err.Error()), nil, nil
 	}
-
-	depsProject := scanner.DepsProject{
-		Root:         absRoot,
-		Mode:         "deps",
-		Files:        analyses,
-		ExternalDeps: scanner.ReadExternalDeps(absRoot),
+	externalDeps, err := scanner.ReadExternalDeps(ctx, absRoot, scanner.MCPManifestByteBudget)
+	if err != nil {
+		if cancelled := cancellationResult(ctx, "External dependency scan"); cancelled != nil {
+			return cancelled, nil, nil
+		}
+		return errorResult("External dependency scan error: " + err.Error()), nil, nil
 	}
+
+	graph, graphErr := scanner.BuildFileGraphFromOutcome(ctx, absRoot, outcome, filters)
+	if graphErr != nil {
+		if cancelled := cancellationResult(ctx, "Dependency graph"); cancelled != nil {
+			return cancelled, nil, nil
+		}
+		return errorResult("Dependency graph error: " + graphErr.Error()), nil, nil
+	}
+	coverage := scanner.CoverageFromSources(graph.Coverage.Sources)
+	depsProject := scanner.NewDepsProjectWithCoverage(absRoot, outcome.Analyses, externalDeps, "", coverage)
 
 	var buf bytes.Buffer
 	render.Depgraph(&buf, depsProject)
 	output := buf.String()
 
-	return textResult(output), nil, nil
+	return textResult(output), depsProject, nil
 }
 
 func handleGetDiff(ctx context.Context, req *mcp.CallToolRequest, input DiffInput) (*mcp.CallToolResult, any, error) {
+	if cancelled := cancellationResult(ctx, "Diff analysis"); cancelled != nil {
+		return cancelled, nil, nil
+	}
 	ref := input.Ref
 	if ref == "" {
 		ref = "main"
 	}
 
-	absRoot, err := filepath.Abs(input.Path)
-	if err != nil {
-		return errorResult("Invalid path: " + err.Error()), nil, nil
+	absRoot, invalid := traversalRoot(input.Path)
+	if invalid != nil {
+		return invalid, nil, nil
 	}
 
-	diffInfo, err := scanner.GitDiffInfo(absRoot, ref)
+	diffInfo, err := scanner.GitDiffInfo(ctx, absRoot, ref)
 	if err != nil {
+		if cancelled := cancellationResult(ctx, "Diff analysis"); cancelled != nil {
+			return cancelled, nil, nil
+		}
 		return errorResult("Git diff error: " + err.Error() + "\nMake sure '" + ref + "' is a valid branch/ref"), nil, nil
 	}
 
@@ -421,14 +478,23 @@ func handleGetDiff(ctx context.Context, req *mcp.CallToolRequest, input DiffInpu
 		return textResult("No files changed vs " + ref), newDiffOutput("empty", ref, scanner.Project{Root: absRoot, Mode: "tree", DiffRef: ref}), nil
 	}
 
-	gitCache := scanner.NewGitIgnoreCache(input.Path)
-	files, err := scanner.ScanConfiguredFiles(input.Path, gitCache)
+	gitCache := scanner.NewGitIgnoreCache(absRoot)
+	files, err := scanner.ScanConfiguredFiles(ctx, absRoot, gitCache)
 	if err != nil {
+		if cancelled := cancellationResult(ctx, "Diff scan"); cancelled != nil {
+			return cancelled, nil, nil
+		}
 		return errorResult("Scan error: " + err.Error()), nil, nil
 	}
 
 	files = scanner.FilterToChangedWithInfo(files, diffInfo)
-	impact := scanner.AnalyzeImpact(absRoot, files)
+	impact, err := scanner.AnalyzeImpact(ctx, absRoot, files)
+	if err != nil {
+		if cancelled := cancellationResult(ctx, "Impact analysis"); cancelled != nil {
+			return cancelled, nil, nil
+		}
+		return errorResult("Impact scan error: " + err.Error()), nil, nil
+	}
 
 	project := scanner.Project{
 		Root:    absRoot,
@@ -446,14 +512,24 @@ func handleGetDiff(ctx context.Context, req *mcp.CallToolRequest, input DiffInpu
 }
 
 func handleFindFile(ctx context.Context, req *mcp.CallToolRequest, input FindInput) (*mcp.CallToolResult, any, error) {
-	gitCache := scanner.NewGitIgnoreCache(input.Path)
-	files, err := scanner.ScanFiles(input.Path, gitCache, nil, nil)
+	if cancelled := cancellationResult(ctx, "File search"); cancelled != nil {
+		return cancelled, nil, nil
+	}
+	absRoot, invalid := traversalRoot(input.Path)
+	if invalid != nil {
+		return invalid, nil, nil
+	}
+	gitCache := scanner.NewGitIgnoreCache(absRoot)
+	files, err := scanner.ScanFiles(ctx, absRoot, gitCache, nil, nil)
 	if err != nil {
+		if cancelled := cancellationResult(ctx, "File search"); cancelled != nil {
+			return cancelled, nil, nil
+		}
 		return errorResult("Scan error: " + err.Error()), nil, nil
 	}
 
 	// Filter files matching pattern (case-insensitive)
-	matches, filteredMatches, hintsEnabled := findConfiguredMatches(input.Path, input.Pattern, files)
+	matches, filteredMatches, hintsEnabled := findConfiguredMatches(absRoot, input.Pattern, files)
 
 	if len(matches) == 0 {
 		if hintsEnabled && len(filteredMatches) > 0 {
@@ -523,6 +599,9 @@ func statusHandler(guidance string) func(context.Context, *mcp.CallToolRequest, 
 }
 
 func handleListProjects(ctx context.Context, req *mcp.CallToolRequest, input ListProjectsInput) (*mcp.CallToolResult, any, error) {
+	if cancelled := cancellationResult(ctx, "Project discovery"); cancelled != nil {
+		return cancelled, nil, nil
+	}
 	// Expand ~ to home directory
 	path := input.Path
 	if strings.HasPrefix(path, "~/") {
@@ -530,47 +609,51 @@ func handleListProjects(ctx context.Context, req *mcp.CallToolRequest, input Lis
 		path = filepath.Join(home, path[2:])
 	}
 
-	absPath, err := filepath.Abs(path)
-	if err != nil {
-		return errorResult("Invalid path: " + err.Error()), nil, nil
+	absPath, invalid := traversalRoot(path)
+	if invalid != nil {
+		return invalid, nil, nil
 	}
 
-	entries, err := os.ReadDir(absPath)
+	dir, err := os.Open(absPath)
 	if err != nil {
 		return errorResult("Cannot read directory: " + err.Error()), nil, nil
 	}
+	defer dir.Close()
 
 	pattern := strings.ToLower(input.Pattern)
-	var projects []string
-
-	for _, entry := range entries {
-		if !entry.IsDir() {
-			continue
+	candidates, examined, truncatedByResults, truncatedByExamined, err := selectProjectCandidates(ctx, dir, pattern)
+	if err != nil {
+		if cancelled := cancellationResult(ctx, "Project discovery"); cancelled != nil {
+			return cancelled, nil, nil
 		}
-		name := entry.Name()
+		return errorResult("Cannot read directory: " + err.Error()), nil, nil
+	}
 
-		// Skip hidden directories and common non-project dirs
-		if strings.HasPrefix(name, ".") {
-			continue
+	projects := make([]string, 0, len(candidates))
+	for _, name := range candidates {
+		if cancelled := cancellationResult(ctx, "Project discovery"); cancelled != nil {
+			return cancelled, nil, nil
 		}
-
-		// Filter by pattern if provided
-		if pattern != "" && !strings.Contains(strings.ToLower(name), pattern) {
-			continue
-		}
-
-		// Get project stats
 		projectPath := filepath.Join(absPath, name)
-		stats := getProjectStats(projectPath)
-
+		stats, scanErr := getProjectStatsContext(ctx, projectPath)
+		if scanErr != nil {
+			if cancelled := cancellationResult(ctx, "Project discovery"); cancelled != nil {
+				return cancelled, nil, nil
+			}
+			stats = "(error scanning)"
+		}
 		projects = append(projects, fmt.Sprintf("%-30s %s", name+"/", stats))
 	}
 
+	if truncatedByExamined && len(candidates) == 0 {
+		return textResult(projectDiscoveryExaminationCap(input.Pattern, absPath, examined)), nil, nil
+	}
 	if len(projects) == 0 {
+		truncation := projectDiscoveryTruncation(truncatedByResults, truncatedByExamined, examined)
 		if pattern != "" {
-			return textResult(fmt.Sprintf("No projects matching '%s' in %s", input.Pattern, absPath)), nil, nil
+			return textResult(fmt.Sprintf("No projects matching '%s' in %s%s", input.Pattern, absPath, truncation)), nil, nil
 		}
-		return textResult("No project directories found in " + absPath), nil, nil
+		return textResult("No project directories found in " + absPath + truncation), nil, nil
 	}
 
 	header := fmt.Sprintf("Projects in %s", absPath)
@@ -578,21 +661,114 @@ func handleListProjects(ctx context.Context, req *mcp.CallToolRequest, input Lis
 		header = fmt.Sprintf("Projects matching '%s' in %s", input.Pattern, absPath)
 	}
 
-	return textResult(fmt.Sprintf("%s:\n\n%s", header, strings.Join(projects, "\n"))), nil, nil
+	output := fmt.Sprintf("%s:\n\n%s", header, strings.Join(projects, "\n"))
+	output += projectDiscoveryTruncation(truncatedByResults, truncatedByExamined, examined)
+	return textResult(output), nil, nil
+}
+
+func projectDiscoveryExaminationCap(pattern, path string, examined int) string {
+	if pattern != "" {
+		return fmt.Sprintf("Project discovery matching '%s' in %s was truncated after examining %d entries; results are unavailable because the directory exceeds the examination cap.", pattern, path, examined)
+	}
+	return fmt.Sprintf("Project discovery in %s was truncated after examining %d entries; results are unavailable because the directory exceeds the examination cap.", path, examined)
+}
+
+const (
+	maxListedProjects         = 50
+	maxExaminedProjectEntries = 200
+	projectDiscoveryBatchSize = 32
+)
+
+type projectDirectoryReader interface {
+	ReadDir(int) ([]os.DirEntry, error)
+}
+
+// selectProjectCandidates deterministically selects the lexicographically
+// first result-cap entries within the bounded examination window.
+func selectProjectCandidates(ctx context.Context, dir projectDirectoryReader, pattern string) ([]string, int, bool, bool, error) {
+	candidates := make([]string, 0, maxListedProjects+1)
+	examined := 0
+	truncatedByExamined := false
+	discoveryDone := false
+
+	for !discoveryDone {
+		if err := ctx.Err(); err != nil {
+			return nil, examined, false, truncatedByExamined, err
+		}
+		entries, readErr := dir.ReadDir(projectDiscoveryBatchSize)
+		for _, entry := range entries {
+			if examined >= maxExaminedProjectEntries {
+				truncatedByExamined = true
+				discoveryDone = true
+				break
+			}
+			examined++
+			if !entry.IsDir() {
+				continue
+			}
+			name := entry.Name()
+			if strings.HasPrefix(name, ".") {
+				continue
+			}
+			if pattern != "" && !strings.Contains(strings.ToLower(name), pattern) {
+				continue
+			}
+			candidates = append(candidates, name)
+		}
+		if readErr == io.EOF {
+			discoveryDone = true
+		} else if readErr != nil {
+			return nil, examined, false, truncatedByExamined, readErr
+		}
+	}
+
+	if truncatedByExamined {
+		// The bounded prefix is filesystem-order dependent. Do not emit a
+		// partial selection when the examination cap prevents observing the
+		// complete directory; only the stable truncation notice is returned.
+		return []string{}, examined, false, true, ctx.Err()
+	}
+	sort.Strings(candidates)
+	truncatedByResults := len(candidates) > maxListedProjects
+	if truncatedByResults {
+		candidates = candidates[:maxListedProjects]
+	}
+	return candidates, examined, truncatedByResults, truncatedByExamined, ctx.Err()
+}
+
+func projectDiscoveryTruncation(byResults, byExamined bool, examined int) string {
+	switch {
+	case byResults && byExamined:
+		return fmt.Sprintf("\n... truncated after %d projects and examining %d entries", maxListedProjects, examined)
+	case byResults:
+		return fmt.Sprintf("\n... truncated after %d projects", maxListedProjects)
+	case byExamined:
+		return fmt.Sprintf("\n... truncated after examining %d entries", examined)
+	default:
+		return ""
+	}
 }
 
 // getProjectStats returns a brief summary of a project directory
 // Uses the same scanner logic as the main codemap command (respects nested .gitignore files)
 func getProjectStats(path string) string {
+	stats, _ := getProjectStatsContext(context.Background(), path)
+	return stats
+}
+
+func getProjectStatsContext(ctx context.Context, path string) (string, error) {
 	gitCache := scanner.NewGitIgnoreCache(path)
-	files, err := scanner.ScanConfiguredFiles(path, gitCache)
+	files, err := scanner.ScanConfiguredFiles(ctx, path, gitCache)
 	if err != nil {
-		return "(error scanning)"
+		return "(error scanning)", err
 	}
 
 	// Count files by language
 	langCounts := make(map[string]int)
 	for _, f := range files {
+		if err := ctx.Err(); err != nil {
+			return "(error scanning)", err
+		}
 		lang := scanner.DetectLanguage(f.Path)
 		if lang != "" {
 			langCounts[lang]++
@@ -616,18 +792,24 @@ func getProjectStats(path string) string {
 	}
 
 	if lang, ok := scanner.LangDisplay[primaryLang]; ok {
-		return fmt.Sprintf("(%d files, %s%s)", len(files), lang, isGit)
+		return fmt.Sprintf("(%d files, %s%s)", len(files), lang, isGit), nil
 	}
-	return fmt.Sprintf("(%d files%s)", len(files), isGit)
+	return fmt.Sprintf("(%d files%s)", len(files), isGit), ctx.Err()
 }
 
 func handleGetImporters(ctx context.Context, req *mcp.CallToolRequest, input ImportersInput) (*mcp.CallToolResult, any, error) {
-	absRoot, err := filepath.Abs(input.Path)
-	if err != nil {
-		return errorResult("Invalid path: " + err.Error()), nil, nil
+	if cancelled := cancellationResult(ctx, "Importer analysis"); cancelled != nil {
+		return cancelled, nil, nil
 	}
-	fg, err := scanner.BuildFileGraph(absRoot)
+	absRoot, invalid := traversalRoot(input.Path)
+	if invalid != nil {
+		return invalid, nil, nil
+	}
+	fg, err := scanner.BuildFileGraph(ctx, absRoot, scanner.ConfiguredFilters(absRoot))
 	if err != nil {
+		if cancelled := cancellationResult(ctx, "Importer analysis"); cancelled != nil {
+			return cancelled, nil, nil
+		}
 		return errorResult("Failed to build file graph: " + err.Error()), nil, nil
 	}
 
@@ -668,16 +850,20 @@ func mcpCoverageText(fg *scanner.FileGraph) string {
 }
 
 func handleGetHandoff(ctx context.Context, req *mcp.CallToolRequest, input HandoffInput) (*mcp.CallToolResult, any, error) {
+	if cancelled := cancellationResult(ctx, "Handoff generation"); cancelled != nil {
+		return cancelled, nil, nil
+	}
 	if input.Prefix && input.Delta {
 		return errorResult("prefix and delta options are mutually exclusive"), nil, nil
 	}
 
-	absRoot, err := filepath.Abs(input.Path)
-	if err != nil {
-		return errorResult("Invalid path: " + err.Error()), nil, nil
+	absRoot, invalid := traversalRoot(input.Path)
+	if invalid != nil {
+		return invalid, nil, nil
 	}
 
 	var artifact *handoff.Artifact
+	var err error
 	if input.Latest {
 		artifact, err = handoff.ReadLatest(absRoot)
 		if err != nil {
@@ -703,23 +889,35 @@ func handleGetHandoff(ctx context.Context, req *mcp.CallToolRequest, input Hando
 			}
 		}
 
-		artifact, err = handoff.Build(absRoot, handoff.BuildOptions{
+		artifact, err = buildHandoffForMCP(ctx, absRoot, handoff.BuildOptions{
 			BaseRef: baseRef,
 			Since:   since,
 		})
 		if err != nil {
+			if cancelled := cancellationResult(ctx, "Handoff generation"); cancelled != nil {
+				return cancelled, nil, nil
+			}
 			return errorResult("Failed to build handoff: " + err.Error()), nil, nil
 		}
 		if input.Save {
-			if err := handoff.WriteLatest(absRoot, artifact); err != nil {
+			// Persistence commit point: cancellation observed before WriteLatest
+			// prevents all writes. Once WriteLatest begins, its established
+			// non-contextual multi-file semantics remain unchanged.
+			if cancelled := cancellationResult(ctx, "Handoff generation"); cancelled != nil {
+				return cancelled, nil, nil
+			}
+			if err := writeLatestForMCP(absRoot, artifact); err != nil {
 				return errorResult("Failed to save handoff: " + err.Error()), nil, nil
 			}
 		}
 	}
 
 	if input.File != "" {
-		detail, err := handoff.BuildFileDetail(absRoot, artifact, input.File, nil)
+		detail, err := buildHandoffDetailMCP(ctx, absRoot, artifact, input.File, nil)
 		if err != nil {
+			if cancelled := cancellationResult(ctx, "Handoff detail generation"); cancelled != nil {
+				return cancelled, nil, nil
+			}
 			return errorResult("Failed to load handoff detail: " + err.Error()), nil, nil
 		}
 		structured := boundedFileDetail(detail)
@@ -1027,8 +1225,18 @@ The user may be:
 // === FILE GRAPH HANDLERS ===
 
 func handleGetHubs(ctx context.Context, req *mcp.CallToolRequest, input PathInput) (*mcp.CallToolResult, any, error) {
-	fg, err := scanner.BuildFileGraph(input.Path)
+	if cancelled := cancellationResult(ctx, "Hub analysis"); cancelled != nil {
+		return cancelled, nil, nil
+	}
+	absRoot, invalid := traversalRoot(input.Path)
+	if invalid != nil {
+		return invalid, nil, nil
+	}
+	fg, err := scanner.BuildFileGraph(ctx, absRoot, scanner.ConfiguredFilters(absRoot))
 	if err != nil {
+		if cancelled := cancellationResult(ctx, "Hub analysis"); cancelled != nil {
+			return cancelled, nil, nil
+		}
 		return errorResult("Failed to build file graph: " + err.Error()), nil, nil
 	}
 
@@ -1063,8 +1271,18 @@ func handleGetHubs(ctx context.Context, req *mcp.CallToolRequest, input PathInpu
 }
 
 func handleGetFileContext(ctx context.Context, req *mcp.CallToolRequest, input ImportersInput) (*mcp.CallToolResult, any, error) {
-	fg, err := scanner.BuildFileGraph(input.Path)
+	if cancelled := cancellationResult(ctx, "File context analysis"); cancelled != nil {
+		return cancelled, nil, nil
+	}
+	absRoot, invalid := traversalRoot(input.Path)
+	if invalid != nil {
+		return invalid, nil, nil
+	}
+	fg, err := scanner.BuildFileGraph(ctx, absRoot, scanner.ConfiguredFilters(absRoot))
 	if err != nil {
+		if cancelled := cancellationResult(ctx, "File context analysis"); cancelled != nil {
+			return cancelled, nil, nil
+		}
 		return errorResult("Failed to build file graph: " + err.Error()), nil, nil
 	}
 

--- a/mcp/main.go
+++ b/mcp/main.go
@@ -446,7 +446,7 @@ func handleGetDependencies(ctx context.Context, req *mcp.CallToolRequest, input 
 	depsProject := scanner.NewDepsProjectWithCoverage(absRoot, outcome.Analyses, externalDeps, "", coverage)
 
 	var buf bytes.Buffer
-	render.Depgraph(&buf, depsProject)
+	render.Depgraph(ctx, &buf, depsProject)
 	output := buf.String()
 
 	return textResult(output), depsProject, nil

--- a/render/depgraph.go
+++ b/render/depgraph.go
@@ -1,6 +1,7 @@
 package render
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"path/filepath"
@@ -69,7 +70,7 @@ func Depgraph(w io.Writer, project scanner.DepsProject) {
 	}
 
 	// Use BuildFileGraph for accurate file-level dependency resolution
-	fg, err := scanner.BuildFileGraph(project.Root)
+	fg, err := scanner.BuildFileGraph(context.Background(), project.Root, scanner.ConfiguredFilters(project.Root))
 	var internalDeps map[string][]string
 	var depCounts map[string]int
 	if err == nil && fg != nil {

--- a/render/depgraph.go
+++ b/render/depgraph.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"unicode"
 
+	"codemap/analysis"
 	"codemap/scanner"
 )
 
@@ -49,14 +50,18 @@ func getSystemName(dirPath string) string {
 	return "Root"
 }
 
-// Depgraph renders the dependency flow visualization
-func Depgraph(w io.Writer, project scanner.DepsProject) {
+// Depgraph renders the dependency flow visualization. The file graph is built
+// from the caller's analyses (BuildFileGraphFromAnalyses) rather than by
+// re-running the ast-grep scan, and ctx propagates cancellation through that
+// build so MCP and CLI callers are not left with an unobservable second scan.
+func Depgraph(ctx context.Context, w io.Writer, project scanner.DepsProject) {
 	files := project.Files
 	externalDeps := project.ExternalDeps
 	projectName := filepath.Base(project.Root)
 
 	if len(files) == 0 {
 		fmt.Fprintln(w, "  No source files found.")
+		renderCoverageLine(w, project.Coverage)
 		return
 	}
 
@@ -69,8 +74,9 @@ func Depgraph(w io.Writer, project scanner.DepsProject) {
 		internalNames[name] = true
 	}
 
-	// Use BuildFileGraph for accurate file-level dependency resolution
-	fg, err := scanner.BuildFileGraph(context.Background(), project.Root, scanner.ConfiguredFilters(project.Root))
+	// Build the graph from the analyses the caller already produced instead of
+	// re-scanning with BuildFileGraph, which would double the ast-grep work.
+	fg, err := scanner.BuildFileGraphFromAnalyses(ctx, project.Root, files, scanner.ConfiguredFilters(project.Root))
 	var internalDeps map[string][]string
 	var depCounts map[string]int
 	if err == nil && fg != nil {
@@ -363,5 +369,25 @@ func Depgraph(w io.Writer, project scanner.DepsProject) {
 		internalCount += len(targets)
 	}
 	fmt.Fprintf(w, "%d files · %d functions · %d deps\n", len(files), totalFuncs, internalCount)
+	renderCoverageLine(w, project.Coverage)
 	fmt.Fprintln(w)
+}
+
+// renderCoverageLine surfaces degraded scan coverage in text output so a
+// fail-closed or partial scan never reads as a complete, empty graph.
+func renderCoverageLine(w io.Writer, coverage analysis.Coverage) {
+	if coverage.Status == "" || coverage.Status == analysis.CoverageComplete {
+		return
+	}
+	var details []string
+	for _, source := range coverage.Sources {
+		if source.Detail != "" {
+			details = append(details, source.Detail)
+		}
+	}
+	if len(details) == 0 {
+		fmt.Fprintf(w, "  Coverage: %s\n", coverage.Status)
+		return
+	}
+	fmt.Fprintf(w, "  Coverage: %s — %s\n", coverage.Status, strings.Join(details, "; "))
 }

--- a/render/depgraph_test.go
+++ b/render/depgraph_test.go
@@ -2,9 +2,13 @@ package render
 
 import (
 	"bytes"
+	"context"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
+	"codemap/analysis"
 	"codemap/scanner"
 )
 
@@ -59,7 +63,7 @@ func TestDepgraphNoSourceFiles(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	Depgraph(&buf, project)
+	Depgraph(context.Background(), &buf, project)
 
 	output := buf.String()
 	if !strings.Contains(output, "No source files found.") {
@@ -83,7 +87,7 @@ func TestDepgraphRendersExternalDepsAndSummarySection(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	Depgraph(&buf, project)
+	Depgraph(context.Background(), &buf, project)
 	output := buf.String()
 
 	expectedSnippets := []string{
@@ -101,5 +105,175 @@ func TestDepgraphRendersExternalDepsAndSummarySection(t *testing.T) {
 		if !strings.Contains(output, snippet) {
 			t.Fatalf("expected output to contain %q, got:\n%s", snippet, output)
 		}
+	}
+}
+
+func writeDepgraphFile(t *testing.T, root, path, body string) {
+	t.Helper()
+	full := filepath.Join(root, filepath.FromSlash(path))
+	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(full, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Regression for PR #105: Depgraph must build the file graph from the caller's
+// analyses instead of re-running the ast-grep scan, so an internal dep edge
+// renders without any scanner binary present.
+func TestDepgraphBuildsGraphFromAnalysesWithoutRescanning(t *testing.T) {
+	root := t.TempDir()
+	writeDepgraphFile(t, root, "a.go", "package a\n")
+	writeDepgraphFile(t, root, "b.go", "package b\n")
+
+	project := scanner.DepsProject{
+		Root: root,
+		Files: []scanner.FileAnalysis{
+			{Path: "a.go", Language: "go", Functions: []string{"A"}, Imports: []string{"./b"}},
+			{Path: "b.go", Language: "go", Functions: []string{"B"}},
+		},
+	}
+
+	var buf bytes.Buffer
+	Depgraph(context.Background(), &buf, project)
+	output := buf.String()
+	if !strings.Contains(output, "a ───▶ b") {
+		t.Fatalf("expected internal dep edge resolved from analyses, got:\n%s", output)
+	}
+}
+
+// Regression for PR #105: a degraded scan must surface its coverage in text
+// output instead of reading as a complete, empty graph.
+func TestDepgraphRendersDegradedCoverage(t *testing.T) {
+	root := t.TempDir()
+	writeDepgraphFile(t, root, "main.go", "package main\n")
+	project := scanner.DepsProject{
+		Root: root,
+		Files: []scanner.FileAnalysis{
+			{Path: "main.go", Language: "go", Functions: []string{"main"}},
+		},
+		Coverage: analysis.Coverage{
+			Status:  analysis.CoverageUnavailable,
+			Sources: []analysis.Source{{Name: "ast-grep", Status: analysis.SourceTimeout, Detail: "scan timed out"}},
+		},
+	}
+
+	var buf bytes.Buffer
+	Depgraph(context.Background(), &buf, project)
+	output := buf.String()
+	if !strings.Contains(output, "Coverage: unavailable") || !strings.Contains(output, "scan timed out") {
+		t.Fatalf("expected degraded coverage in rendered deps, got:\n%s", output)
+	}
+}
+
+func TestDepgraphEmptyFilesSurfacesCoverage(t *testing.T) {
+	project := scanner.DepsProject{
+		Root:  t.TempDir(),
+		Files: nil,
+		Coverage: analysis.Coverage{
+			Status:  analysis.CoverageUnavailable,
+			Sources: []analysis.Source{{Name: "ast-grep", Status: analysis.SourceFailed, Detail: "scanner failed"}},
+		},
+	}
+
+	var buf bytes.Buffer
+	Depgraph(context.Background(), &buf, project)
+	output := buf.String()
+	if !strings.Contains(output, "No source files found.") || !strings.Contains(output, "Coverage: unavailable") {
+		t.Fatalf("expected empty-files message plus degraded coverage, got:\n%s", output)
+	}
+}
+
+func TestDepgraphCompleteCoverageOmitsLine(t *testing.T) {
+	project := scanner.DepsProject{
+		Root: t.TempDir(),
+		Files: []scanner.FileAnalysis{
+			{Path: "main.go", Language: "go", Functions: []string{"main"}},
+		},
+		Coverage: analysis.Coverage{
+			Status:  analysis.CoverageComplete,
+			Sources: []analysis.Source{{Name: "ast-grep", Status: analysis.SourceAuthoritative}},
+		},
+	}
+
+	var buf bytes.Buffer
+	Depgraph(context.Background(), &buf, project)
+	if strings.Contains(buf.String(), "Coverage:") {
+		t.Fatalf("complete coverage must not render a coverage line, got:\n%s", buf.String())
+	}
+}
+
+// Regression for PR #105: a canceled ctx must stop the graph build inside
+// Depgraph instead of running an unobservable second scan; the renderer still
+// emits the file list but no internal dependency edges.
+func TestDepgraphHonorsCancellation(t *testing.T) {
+	root := t.TempDir()
+	writeDepgraphFile(t, root, "a.go", "package a\n")
+	writeDepgraphFile(t, root, "b.go", "package b\n")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	project := scanner.DepsProject{
+		Root: root,
+		Files: []scanner.FileAnalysis{
+			{Path: "a.go", Language: "go", Functions: []string{"A"}, Imports: []string{"./b"}},
+			{Path: "b.go", Language: "go", Functions: []string{"B"}},
+		},
+	}
+
+	var buf bytes.Buffer
+	Depgraph(ctx, &buf, project)
+	output := buf.String()
+	if strings.Contains(output, "a ───▶ b") {
+		t.Fatalf("canceled Depgraph must not render graph edges, got:\n%s", output)
+	}
+	if !strings.Contains(output, "2 files") || !strings.Contains(output, "2 functions") {
+		t.Fatalf("canceled Depgraph must still render the file summary, got:\n%s", output)
+	}
+}
+
+func TestDepgraphRendersPartialCoverageWithNote(t *testing.T) {
+	root := t.TempDir()
+	writeDepgraphFile(t, root, "main.go", "package main\n")
+	project := scanner.DepsProject{
+		Root: root,
+		Files: []scanner.FileAnalysis{
+			{Path: "main.go", Language: "go", Functions: []string{"main"}},
+		},
+		Coverage: analysis.Coverage{
+			Status: analysis.CoveragePartial,
+			Sources: []analysis.Source{
+				{Name: "ast-grep", Status: analysis.SourceAuthoritative},
+				{Name: "rust-cargo", Status: analysis.SourceMixed, Detail: "Rust dependency resolution is partial"},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	Depgraph(context.Background(), &buf, project)
+	output := buf.String()
+	if !strings.Contains(output, "Coverage: partial") || !strings.Contains(output, "Rust dependency resolution is partial") {
+		t.Fatalf("expected partial coverage with note, got:\n%s", output)
+	}
+}
+
+func TestDepgraphRendersPartialCoverageWithoutDetail(t *testing.T) {
+	root := t.TempDir()
+	writeDepgraphFile(t, root, "main.go", "package main\n")
+	project := scanner.DepsProject{
+		Root:  root,
+		Files: []scanner.FileAnalysis{{Path: "main.go", Language: "go", Functions: []string{"main"}}},
+		Coverage: analysis.Coverage{
+			Status:  analysis.CoveragePartial,
+			Sources: []analysis.Source{{Name: "rust-cargo", Status: analysis.SourceMixed}},
+		},
+	}
+
+	var buf bytes.Buffer
+	Depgraph(context.Background(), &buf, project)
+	if !strings.Contains(buf.String(), "Coverage: partial") {
+		t.Fatalf("expected bare partial coverage line, got:\n%s", buf.String())
 	}
 }

--- a/render/tree_test.go
+++ b/render/tree_test.go
@@ -2,6 +2,7 @@ package render
 
 import (
 	"bytes"
+	"context"
 	"math/rand/v2"
 	"reflect"
 	"strings"
@@ -463,7 +464,7 @@ func TestCreateBuildings(t *testing.T) {
 
 func TestTreeDepgraphNoSourceFiles(t *testing.T) {
 	var buf bytes.Buffer
-	Depgraph(&buf, scanner.DepsProject{
+	Depgraph(context.Background(), &buf, scanner.DepsProject{
 		Root:  "/tmp/example",
 		Files: nil,
 	})

--- a/scanner/api_surface_test.go
+++ b/scanner/api_surface_test.go
@@ -1,0 +1,60 @@
+package scanner
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestNoRetiredCompatibilityTwins guards the single-entry-point contract: the
+// retired XxxContext/WithFilters/Outcome names must stay out of the scanner API.
+func TestNoRetiredCompatibilityTwins(t *testing.T) {
+	retired := map[string]bool{
+		"AnalyzeImpactContext":                      true,
+		"BuildFileGraphContext":                     true,
+		"BuildFileGraphFromAnalysesContext":         true,
+		"BuildFileGraphFromFilteredAnalyses":        true,
+		"BuildFileGraphFromFilteredAnalysesContext": true,
+		"BuildFileGraphFromOutcomeWithFilters":      true,
+		"BuildFileGraphWithFilters":                 true,
+		"BuildFileGraphWithFiltersContext":          true,
+		"DependencyCoverageContext":                 true,
+		"GitDiffFiles":                              true,
+		"GitDiffFilesContext":                       true,
+		"GitDiffInfoContext":                        true,
+		"HasConfiguredLanguageContext":              true,
+		"ReadExternalDepsContext":                   true,
+		"ScanConfiguredFilesContext":                true,
+		"ScanDirectoryContext":                      true,
+		"ScanDirectoryOutcome":                      true,
+		"ScanDirectoryOutcomeContext":               true,
+		"ScanFilesContext":                          true,
+		"ScanForDepsOutcome":                        true,
+		"ScanForDepsOutcomeContext":                 true,
+		"ScanForDepsOutcomeWithFilters":             true,
+		"ScanForDepsOutcomeWithFiltersContext":      true,
+		"ScanForDepsWithFilters":                    true,
+	}
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".go" {
+			continue
+		}
+		file, err := parser.ParseFile(token.NewFileSet(), entry.Name(), nil, 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		ast.Inspect(file, func(node ast.Node) bool {
+			if fn, ok := node.(*ast.FuncDecl); ok && retired[fn.Name.Name] {
+				t.Errorf("retired compatibility wrapper remains: %s", fn.Name.Name)
+			}
+			return true
+		})
+	}
+}

--- a/scanner/astgrep.go
+++ b/scanner/astgrep.go
@@ -13,6 +13,8 @@ import (
 	"strings"
 	"syscall"
 	"time"
+
+	"codemap/analysis"
 )
 
 //go:embed sg-rules/*.yml
@@ -204,10 +206,45 @@ func findNestedGitRepos(root string) []string {
 	return repos
 }
 
-// ScanDirectory analyzes all files in a directory using sg scan
-func (s *AstGrepScanner) ScanDirectory(root string) ([]FileAnalysis, error) {
+// ScanDirectory analyzes all files in a directory while honoring caller
+// cancellation and recording ast-grep provenance. A timed-out or failed scan
+// fails closed to an empty outcome whose Sources record the degraded status,
+// so callers get an honest, usable answer instead of a hard error; an
+// unavailable scanner (ast-grep not installed) still returns an error.
+func (s *AstGrepScanner) ScanDirectory(parent context.Context, root string) (ScanOutcome, error) {
+	analyses, err := s.scanDirectory(parent, root)
+	if err != nil {
+		var incomplete *IncompleteScanError
+		if errors.As(err, &incomplete) && incomplete.Outcome.Status != ScanSourceUnavailable {
+			return ScanOutcome{
+				Analyses: nil,
+				Sources:  []analysis.Source{incomplete.Outcome},
+			}, nil
+		}
+		return ScanOutcome{}, err
+	}
+	source := analysis.Source{Name: "ast-grep", Status: analysis.SourceAuthoritative}
+	for _, fileAnalysis := range analyses {
+		if DetectLanguage(fileAnalysis.Path) == "rust" {
+			source.Status = analysis.SourceMixed
+			source.Detail = rustCoverageNote
+			break
+		}
+	}
+	return ScanOutcome{
+		Analyses: analyses,
+		Sources:  []analysis.Source{source},
+	}, nil
+}
+
+// scanDirectory analyzes all files in a directory while honoring caller cancellation.
+// The existing internal timeout remains a best-effort empty-result safety cap.
+func (s *AstGrepScanner) scanDirectory(parent context.Context, root string) ([]FileAnalysis, error) {
+	if err := parent.Err(); err != nil {
+		return nil, err
+	}
 	if !s.Available() {
-		return nil, nil
+		return nil, newIncompleteScanError("ast-grep", ScanSourceUnavailable, ErrAstGrepNotFound.Error(), ErrAstGrepNotFound)
 	}
 
 	inlineRules := s.inlineRules
@@ -234,40 +271,42 @@ func (s *AstGrepScanner) ScanDirectory(root string) ([]FileAnalysis, error) {
 	}
 	args = append(args, root)
 
-	ctx, cancel := context.WithTimeout(context.Background(), astGrepScanTimeout)
+	ctx, cancel := context.WithTimeout(parent, astGrepScanTimeout)
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, s.binary, args...)
+	cmd.WaitDelay = 100 * time.Millisecond
 	out, err := cmd.Output()
 	if err != nil {
+		if parentErr := parent.Err(); parentErr != nil {
+			return nil, parentErr
+		}
 		if errors.Is(ctx.Err(), context.DeadlineExceeded) || errors.Is(err, context.DeadlineExceeded) {
-			fmt.Fprintf(os.Stderr, "warning: ast-grep timed out after %s in %s; skipping ast-grep results\n", astGrepScanTimeout, root)
-			return nil, nil
+			return nil, newIncompleteScanError("ast-grep", ScanSourceTimeout, fmt.Sprintf("ast-grep timed out after %s", astGrepScanTimeout), err)
 		}
 
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) {
 			if status, ok := exitErr.Sys().(syscall.WaitStatus); ok && status.Signaled() {
-				fmt.Fprintf(os.Stderr, "warning: ast-grep exited with signal %d in %s; skipping ast-grep results\n", status.Signal(), root)
-				return nil, nil
+				return nil, newIncompleteScanError("ast-grep", ScanSourceFailed, fmt.Sprintf("ast-grep terminated by signal %d", status.Signal()), err)
 			}
 		}
 
-		// sg scan returns non-zero if no matches, check if output contains JSON
-		if len(out) == 0 {
-			return nil, nil
-		}
+		return nil, newIncompleteScanError("ast-grep", ScanSourceFailed, "ast-grep exited unsuccessfully", err)
+	}
+	if err := parent.Err(); err != nil {
+		return nil, err
 	}
 
 	// Extract JSON array from output (handles debug output before JSON, e.g. ast-grep 0.40.2 bug)
 	jsonData := extractJSONArray(out)
 	if jsonData == nil {
-		return nil, nil
+		return nil, newIncompleteScanError("ast-grep", ScanSourceFailed, "ast-grep produced no JSON results", err)
 	}
 
 	var matches []ScanMatch
-	if err := json.Unmarshal(jsonData, &matches); err != nil {
-		return nil, err
+	if decodeErr := json.Unmarshal(jsonData, &matches); decodeErr != nil {
+		return nil, newIncompleteScanError("ast-grep", ScanSourceFailed, "ast-grep produced invalid JSON results", decodeErr)
 	}
 
 	// Group matches by file
@@ -635,12 +674,12 @@ func NewAstGrepAnalyzer() *AstGrepAnalyzer {
 }
 
 func (s *AstGrepScanner) AnalyzeFile(filePath string) (*FileAnalysis, error) {
-	results, err := s.ScanDirectory(filepath.Dir(filePath))
+	outcome, err := s.ScanDirectory(context.Background(), filepath.Dir(filePath))
 	if err != nil {
 		return nil, err
 	}
 	base := filepath.Base(filePath)
-	for _, r := range results {
+	for _, r := range outcome.Analyses {
 		if filepath.Base(r.Path) == base {
 			return &r, nil
 		}

--- a/scanner/astgrep_test.go
+++ b/scanner/astgrep_test.go
@@ -1,6 +1,7 @@
 package scanner
 
 import (
+	"context"
 	"errors"
 	"os"
 	"path/filepath"
@@ -52,7 +53,7 @@ func TestAstGrepScannerUsesEmbeddedRulesWithoutWritableTempDir(t *testing.T) {
 	t.Cleanup(scanner.Close)
 	scanner.binary = fakeBinary
 
-	if _, err := scanner.ScanDirectory(tmpDir); err != nil {
+	if _, err := scanner.ScanDirectory(context.Background(), tmpDir); err != nil {
 		t.Fatalf("ScanDirectory failed: %v", err)
 	}
 
@@ -228,7 +229,7 @@ namespace TestApp
 	}
 }
 
-func TestAstGrepScanDirectoryTimeout(t *testing.T) {
+func TestAstGrepScanDirectoryTimeoutIsIncomplete(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("requires shell script execution")
 	}
@@ -239,23 +240,82 @@ func TestAstGrepScanDirectoryTimeout(t *testing.T) {
 		t.Fatalf("failed to create fake ast-grep binary: %v", err)
 	}
 
-	scanner := &AstGrepScanner{
-		rulesDir: tmpDir,
-		binary:   fakeBinary,
-	}
-
+	scanner := &AstGrepScanner{rulesDir: tmpDir, binary: fakeBinary}
 	prevTimeout := astGrepScanTimeout
 	astGrepScanTimeout = 20 * time.Millisecond
-	t.Cleanup(func() {
-		astGrepScanTimeout = prevTimeout
-	})
+	t.Cleanup(func() { astGrepScanTimeout = prevTimeout })
 
-	results, err := scanner.ScanDirectory(tmpDir)
+	outcome, err := scanner.ScanDirectory(context.Background(), tmpDir)
 	if err != nil {
-		t.Fatalf("expected graceful timeout handling, got error: %v", err)
+		t.Fatalf("ScanDirectory() error = %v, want degraded outcome", err)
 	}
-	if results != nil {
-		t.Fatalf("expected nil results on timeout, got: %v", results)
+	if got := outcome.Sources[0].Status; got != ScanSourceTimeout {
+		t.Fatalf("status = %q, want %q", got, ScanSourceTimeout)
+	}
+}
+
+func TestAstGrepScanDirectoryOutcomeDistinguishesEmptyFromFailure(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("requires shell script execution")
+	}
+
+	for _, tt := range []struct {
+		name       string
+		script     string
+		wantStatus ScanSourceStatus
+		wantOK     bool
+	}{
+		{name: "valid empty result", script: "#!/bin/sh\nprintf '[]\\n'\n", wantStatus: ScanSourceAuthoritative, wantOK: true},
+		{name: "nonzero JSON output", script: "#!/bin/sh\nprintf '[]\\n'\nexit 2\n", wantStatus: ScanSourceFailed},
+		{name: "malformed JSON", script: "#!/bin/sh\nprintf '[{'\n", wantStatus: ScanSourceFailed},
+		{name: "terminated by signal", script: "#!/bin/sh\nkill -TERM $$\n", wantStatus: ScanSourceFailed},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			fakeBinary := filepath.Join(tmpDir, "fake-sg.sh")
+			if err := os.WriteFile(fakeBinary, []byte(tt.script), 0755); err != nil {
+				t.Fatal(err)
+			}
+			scanner := &AstGrepScanner{rulesDir: tmpDir, binary: fakeBinary}
+
+			outcome, err := scanner.ScanDirectory(context.Background(), tmpDir)
+			if tt.wantOK {
+				if err != nil {
+					t.Fatalf("ScanDirectory() error = %v", err)
+				}
+				if len(outcome.Analyses) != 0 {
+					t.Fatalf("analyses = %#v, want empty", outcome.Analyses)
+				}
+				if got := outcome.Sources[0].Status; got != tt.wantStatus {
+					t.Fatalf("status = %q, want %q", got, tt.wantStatus)
+				}
+				return
+			}
+
+			// Degraded scans fail closed: the outcome carries the source status
+			// instead of a hard error.
+			if err != nil {
+				t.Fatalf("ScanDirectory() error = %v, want degraded outcome", err)
+			}
+			if len(outcome.Analyses) != 0 {
+				t.Fatalf("analyses = %#v, want empty on failure", outcome.Analyses)
+			}
+			if got := outcome.Sources[0].Status; got != tt.wantStatus {
+				t.Fatalf("status = %q, want %q", got, tt.wantStatus)
+			}
+		})
+	}
+}
+
+func TestAstGrepScanDirectoryUnavailableIsIncomplete(t *testing.T) {
+	scanner := &AstGrepScanner{}
+	_, err := scanner.ScanDirectory(context.Background(), t.TempDir())
+	var incomplete *IncompleteScanError
+	if !errors.As(err, &incomplete) {
+		t.Fatalf("error = %v, want IncompleteScanError", err)
+	}
+	if got, want := incomplete.Outcome.Status, ScanSourceUnavailable; got != want {
+		t.Fatalf("status = %q, want %q", got, want)
 	}
 }
 
@@ -278,7 +338,7 @@ func TestScanForDepsRejectsNonAstGrepSg(t *testing.T) {
 		_ = os.Setenv("PATH", oldPath)
 	})
 
-	_, err := ScanForDeps(t.TempDir())
+	_, err := ScanForDeps(context.Background(), t.TempDir(), Filters{})
 	if !errors.Is(err, ErrAstGrepNotFound) {
 		t.Fatalf("expected ErrAstGrepNotFound, got %v", err)
 	}

--- a/scanner/bench_test.go
+++ b/scanner/bench_test.go
@@ -1,6 +1,7 @@
 package scanner
 
 import (
+	"context"
 	"os"
 	"testing"
 	"time"
@@ -23,18 +24,18 @@ func TestBenchmarkAstGrep(t *testing.T) {
 	defer scanner.Close()
 
 	start := time.Now()
-	results, err := scanner.ScanDirectory(testDir)
+	outcome, err := scanner.ScanDirectory(context.Background(), testDir)
 	if err != nil {
 		t.Fatalf("ast-grep scan error: %v", err)
 	}
 
 	var totalFuncs, totalImports int
-	for _, r := range results {
+	for _, r := range outcome.Analyses {
 		totalFuncs += len(r.Functions)
 		totalImports += len(r.Imports)
 	}
 	t.Logf("ast-grep: %v (%d functions, %d imports, %d files)",
-		time.Since(start), totalFuncs, totalImports, len(results))
+		time.Since(start), totalFuncs, totalImports, len(outcome.Analyses))
 }
 
 func TestAstGrepScanner(t *testing.T) {
@@ -49,22 +50,22 @@ func TestAstGrepScanner(t *testing.T) {
 	}
 
 	// Test on codemap's own codebase
-	results, err := scanner.ScanDirectory("..")
+	outcome, err := scanner.ScanDirectory(context.Background(), "..")
 	if err != nil {
 		t.Fatalf("ScanDirectory failed: %v", err)
 	}
 
-	if len(results) == 0 {
+	if len(outcome.Analyses) == 0 {
 		t.Error("Expected some results")
 	}
 
 	var totalFuncs, totalImports int
-	for _, r := range results {
+	for _, r := range outcome.Analyses {
 		totalFuncs += len(r.Functions)
 		totalImports += len(r.Imports)
 	}
 
-	t.Logf("Scanned %d files, found %d functions and %d imports", len(results), totalFuncs, totalImports)
+	t.Logf("Scanned %d files, found %d functions and %d imports", len(outcome.Analyses), totalFuncs, totalImports)
 
 	// Should find some Go functions
 	if totalFuncs == 0 {

--- a/scanner/cancellation_test.go
+++ b/scanner/cancellation_test.go
@@ -1,0 +1,256 @@
+package scanner
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+type cancelAfterScannerChecks struct {
+	context.Context
+	remaining int
+}
+
+func (c *cancelAfterScannerChecks) Err() error {
+	if c.remaining <= 0 {
+		return context.Canceled
+	}
+	c.remaining--
+	return nil
+}
+
+func TestScanContextCancellation(t *testing.T) {
+	root := t.TempDir()
+	for i := 0; i < 40; i++ {
+		if err := os.WriteFile(filepath.Join(root, fmt.Sprintf("file-%02d.go", i)), []byte("package fixture\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	cancelled, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := ScanFiles(cancelled, root, NewGitIgnoreCache(root), nil, nil); !errors.Is(err, context.Canceled) {
+		t.Fatalf("pre-cancelled ScanFiles error = %v, want context.Canceled", err)
+	}
+
+	inFlight := &cancelAfterScannerChecks{Context: context.Background(), remaining: 8}
+	if _, err := ScanConfiguredFiles(inFlight, root, NewGitIgnoreCache(root)); !errors.Is(err, context.Canceled) {
+		t.Fatalf("in-flight ScanConfiguredFiles error = %v, want context.Canceled", err)
+	}
+}
+
+func TestDependencyAndGraphContextCancellation(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "main.go"), []byte("package main\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	analyses := make([]FileAnalysis, 100)
+	for i := range analyses {
+		analyses[i] = FileAnalysis{Path: "main.go", Language: "go", Imports: []string{"example.com/dependency"}}
+	}
+
+	cancelled, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := ScanForDeps(cancelled, root, ConfiguredFilters(root)); !errors.Is(err, context.Canceled) {
+		t.Fatalf("pre-cancelled ScanForDeps error = %v, want context.Canceled", err)
+	}
+	if _, err := ScanForDeps(cancelled, root, Filters{}); !errors.Is(err, context.Canceled) {
+		t.Fatalf("pre-cancelled ScanForDeps error = %v, want context.Canceled", err)
+	}
+	if _, err := BuildFileGraph(cancelled, root, ConfiguredFilters(root)); !errors.Is(err, context.Canceled) {
+		t.Fatalf("pre-cancelled BuildFileGraph error = %v, want context.Canceled", err)
+	}
+	if _, err := BuildFileGraphFromAnalyses(cancelled, root, analyses, ConfiguredFilters(root)); !errors.Is(err, context.Canceled) {
+		t.Fatalf("pre-cancelled BuildFileGraphFromAnalyses error = %v, want context.Canceled", err)
+	}
+
+	inFlight := &cancelAfterScannerChecks{Context: context.Background(), remaining: 12}
+	if _, err := BuildFileGraphFromAnalyses(inFlight, root, analyses, ConfiguredFilters(root)); !errors.Is(err, context.Canceled) {
+		t.Fatalf("in-flight graph build error = %v, want context.Canceled", err)
+	}
+}
+
+func TestAstGrepCallerContextOutcomes(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("requires shell script execution")
+	}
+	root := t.TempDir()
+	fakeBinary := filepath.Join(root, "fake-sg.sh")
+	marker := filepath.Join(t.TempDir(), "started")
+	script := `#!/bin/sh
+printf '%s\n' "$$" > "$CODEMAP_AST_GREP_TEST_MARKER"
+exec sleep 10
+`
+	if err := os.WriteFile(fakeBinary, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CODEMAP_AST_GREP_TEST_MARKER", marker)
+	s := &AstGrepScanner{rulesDir: root, binary: fakeBinary}
+
+	cancelled, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := s.ScanDirectory(cancelled, root); !errors.Is(err, context.Canceled) {
+		t.Fatalf("pre-cancelled ScanDirectory error = %v, want context.Canceled", err)
+	}
+
+	deadline, stop := context.WithTimeout(context.Background(), time.Second)
+	defer stop()
+	started := time.Now()
+	done := make(chan error, 1)
+	go func() {
+		_, err := s.ScanDirectory(deadline, root)
+		done <- err
+	}()
+	var blockerPID string
+	startupDeadline := time.Now().Add(5 * time.Second)
+	for {
+		if data, err := os.ReadFile(marker); err == nil && len(data) > 0 {
+			blockerPID = strings.TrimSpace(string(data))
+			break
+		}
+		select {
+		case err := <-done:
+			t.Fatalf("ScanDirectory exited before fake ast-grep subprocess started: %v", err)
+		default:
+		}
+		if time.Now().After(startupDeadline) {
+			t.Fatal("fake ast-grep subprocess did not start")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("caller-deadline ScanDirectory error = %v, want context.DeadlineExceeded", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("ScanDirectory did not terminate deadline-exceeded subprocess")
+	}
+	if elapsed := time.Since(started); elapsed > 2*time.Second {
+		t.Fatalf("caller deadline did not terminate ast-grep promptly: %s", elapsed)
+	}
+	if err := exec.Command("/bin/kill", "-0", blockerPID).Run(); err == nil {
+		t.Fatalf("deadline-exceeded fake ast-grep left blocker process %s running", blockerPID)
+	}
+}
+
+func TestGitDiffInfoContextTerminatesSubprocess(t *testing.T) {
+	cancelled, cancelNow := context.WithCancel(context.Background())
+	cancelNow()
+	if _, err := GitDiffInfo(cancelled, t.TempDir(), "main"); !errors.Is(err, context.Canceled) {
+		t.Fatalf("pre-cancelled GitDiffInfo error = %v, want context.Canceled", err)
+	}
+
+	if runtime.GOOS == "windows" {
+		t.Skip("requires shell script execution")
+	}
+	binDir := t.TempDir()
+	marker := filepath.Join(t.TempDir(), "started")
+	fakeGit := filepath.Join(binDir, "git")
+	script := `#!/bin/sh
+printf '%s\n' "$$" > "$CODEMAP_GIT_TEST_MARKER"
+exec sleep 10
+`
+	if err := os.WriteFile(fakeGit, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CODEMAP_GIT_TEST_MARKER", marker)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	gitRoot := t.TempDir()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		_, err := GitDiffInfo(ctx, gitRoot, "main")
+		done <- err
+	}()
+	var blockerPID string
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		if data, err := os.ReadFile(marker); err == nil && len(data) > 0 {
+			blockerPID = strings.TrimSpace(string(data))
+			break
+		}
+		select {
+		case err := <-done:
+			t.Fatalf("GitDiffInfo exited before fake git subprocess started: %v", err)
+		default:
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("fake git subprocess did not start")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	cancel()
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("GitDiffInfo error = %v, want context.Canceled", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("GitDiffInfo did not terminate cancelled subprocess")
+	}
+	if err := exec.Command("/bin/kill", "-0", blockerPID).Run(); err == nil {
+		t.Fatalf("cancelled fake git left blocker process %s running", blockerPID)
+	}
+}
+
+func TestAnalyzeImpactContextPreCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := AnalyzeImpact(ctx, t.TempDir(), []FileInfo{{Path: "changed.go"}})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("AnalyzeImpact error = %v, want context.Canceled", err)
+	}
+}
+
+func TestReadExternalDepsContextBudgetAndCompatibility(t *testing.T) {
+	root := t.TempDir()
+	large := strings.Repeat("x", int(MCPManifestByteBudget)+1)
+	largeManifest := "require (\nexample.com/large v1.0.0\n)\n" + large
+	if err := os.WriteFile(filepath.Join(root, "go.mod"), []byte(largeManifest), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	smallDir := filepath.Join(root, "nested")
+	if err := os.Mkdir(smallDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(smallDir, "requirements.txt"), []byte("small-dependency==1.0\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	deps, err := ReadExternalDeps(context.Background(), root, MCPManifestByteBudget)
+	if err != nil {
+		t.Fatalf("ReadExternalDeps error: %v", err)
+	}
+	if got := deps["go"]; len(got) != 0 {
+		t.Fatalf("bounded MCP read parsed oversized go.mod: %v", got)
+	}
+	if got := deps["python"]; len(got) != 1 || got[0] != "small-dependency" {
+		t.Fatalf("bounded MCP read lost valid small manifest: %v", got)
+	}
+	legacy, err := ReadExternalDeps(context.Background(), root, 0)
+	if err != nil {
+		t.Fatalf("unbounded ReadExternalDeps error: %v", err)
+	}
+	if got := legacy["go"]; len(got) != 1 || got[0] != "example.com/large" {
+		t.Fatalf("unbounded read no longer reads oversized manifest: %v", got)
+	}
+
+	cancelled, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := ReadExternalDeps(cancelled, root, MCPManifestByteBudget); !errors.Is(err, context.Canceled) {
+		t.Fatalf("pre-cancelled dependency read error = %v, want context.Canceled", err)
+	}
+	inFlight := &cancelAfterScannerChecks{Context: context.Background(), remaining: 2}
+	if _, err := ReadExternalDeps(inFlight, root, MCPManifestByteBudget); !errors.Is(err, context.Canceled) {
+		t.Fatalf("in-flight dependency read error = %v, want context.Canceled", err)
+	}
+}

--- a/scanner/contracts_test.go
+++ b/scanner/contracts_test.go
@@ -1,0 +1,63 @@
+package scanner
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"codemap/analysis"
+)
+
+func TestNewDepsProjectReturnsVersionedCompleteCoverage(t *testing.T) {
+	project := NewDepsProject("/repo", []FileAnalysis{{Path: "empty.go"}}, map[string][]string{"go": nil}, "main")
+	if project.SchemaVersion != analysis.SchemaVersion || project.Coverage.Status != analysis.CoverageComplete {
+		t.Fatalf("versioned coverage = %#v", project)
+	}
+	if got, want := project.Coverage.Sources, []analysis.Source{{Name: "ast-grep", Status: analysis.SourceAuthoritative}}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("coverage sources = %#v, want %#v", got, want)
+	}
+	if project.Coverage.Issues == nil || project.Files[0].Functions == nil || project.Files[0].Imports == nil || project.ExternalDeps["go"] == nil {
+		t.Fatalf("dependency collections must be non-nil: %#v", project)
+	}
+}
+
+func TestNewDepsProjectProducesDeterministicCollections(t *testing.T) {
+	first := NewDepsProject("/repo", []FileAnalysis{
+		{Path: "z.go", Functions: []string{"Z", "A"}, Imports: []string{"z", "a"}},
+		{Path: "a.go"},
+	}, map[string][]string{"go": {"z", "a"}}, "")
+	second := NewDepsProject("/repo", []FileAnalysis{
+		{Path: "a.go"},
+		{Path: "z.go", Functions: []string{"A", "Z"}, Imports: []string{"a", "z"}},
+	}, map[string][]string{"go": {"a", "z"}}, "")
+	firstJSON, err := json.Marshal(first)
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondJSON, err := json.Marshal(second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(firstJSON) != string(secondJSON) {
+		t.Fatalf("dependency JSON is not deterministic:\n%s\n%s", firstJSON, secondJSON)
+	}
+}
+
+func TestNewDepsProjectOrdersDuplicateFileKeysAndReportsRustCoverage(t *testing.T) {
+	first := NewDepsProject("/repo", []FileAnalysis{
+		{Path: "same.rs", Language: "rust", Functions: []string{"z"}},
+		{Path: "same.rs", Language: "rust", Functions: []string{"a"}},
+	}, nil, "")
+	second := NewDepsProject("/repo", []FileAnalysis{
+		{Path: "same.rs", Language: "rust", Functions: []string{"a"}},
+		{Path: "same.rs", Language: "rust", Functions: []string{"z"}},
+	}, nil, "")
+	firstJSON, _ := json.Marshal(first)
+	secondJSON, _ := json.Marshal(second)
+	if string(firstJSON) != string(secondJSON) {
+		t.Fatalf("duplicate file keys are not deterministic:\n%s\n%s", firstJSON, secondJSON)
+	}
+	if first.Coverage.Status != analysis.CoveragePartial {
+		t.Fatalf("Rust coverage = %q, want partial", first.Coverage.Status)
+	}
+}

--- a/scanner/contracts_test.go
+++ b/scanner/contracts_test.go
@@ -61,3 +61,24 @@ func TestNewDepsProjectOrdersDuplicateFileKeysAndReportsRustCoverage(t *testing.
 		t.Fatalf("Rust coverage = %q, want partial", first.Coverage.Status)
 	}
 }
+
+func TestNewDepsProjectRustCoverageFromPathAndInventory(t *testing.T) {
+	// A Rust file whose Language field is empty still flips coverage to partial
+	// via DetectLanguage on the path.
+	fromPath := newDepsProject("/repo", []FileAnalysis{{Path: "crate/src/lib.rs"}}, nil, "")
+	if fromPath.Coverage.Status != analysis.CoveragePartial {
+		t.Fatalf("path-detected Rust coverage = %q, want partial", fromPath.Coverage.Status)
+	}
+	// Rust files in the FileInfo inventory also flip a complete scan to partial.
+	fromInventory := newDepsProject("/repo", []FileAnalysis{{Path: "main.go"}}, nil, "",
+		[]FileInfo{{Path: "crate/src/lib.rs", Ext: ".rs"}})
+	if fromInventory.Coverage.Status != analysis.CoveragePartial {
+		t.Fatalf("inventory Rust coverage = %q, want partial", fromInventory.Coverage.Status)
+	}
+	// No Rust anywhere keeps coverage complete.
+	complete := newDepsProject("/repo", []FileAnalysis{{Path: "main.go"}}, nil, "",
+		[]FileInfo{{Path: "main.go", Ext: ".go"}})
+	if complete.Coverage.Status != analysis.CoverageComplete {
+		t.Fatalf("non-Rust coverage = %q, want complete", complete.Coverage.Status)
+	}
+}

--- a/scanner/contracts_test.go
+++ b/scanner/contracts_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestNewDepsProjectReturnsVersionedCompleteCoverage(t *testing.T) {
-	project := NewDepsProject("/repo", []FileAnalysis{{Path: "empty.go"}}, map[string][]string{"go": nil}, "main")
+	project := newDepsProject("/repo", []FileAnalysis{{Path: "empty.go"}}, map[string][]string{"go": nil}, "main")
 	if project.SchemaVersion != analysis.SchemaVersion || project.Coverage.Status != analysis.CoverageComplete {
 		t.Fatalf("versioned coverage = %#v", project)
 	}
@@ -22,11 +22,11 @@ func TestNewDepsProjectReturnsVersionedCompleteCoverage(t *testing.T) {
 }
 
 func TestNewDepsProjectProducesDeterministicCollections(t *testing.T) {
-	first := NewDepsProject("/repo", []FileAnalysis{
+	first := newDepsProject("/repo", []FileAnalysis{
 		{Path: "z.go", Functions: []string{"Z", "A"}, Imports: []string{"z", "a"}},
 		{Path: "a.go"},
 	}, map[string][]string{"go": {"z", "a"}}, "")
-	second := NewDepsProject("/repo", []FileAnalysis{
+	second := newDepsProject("/repo", []FileAnalysis{
 		{Path: "a.go"},
 		{Path: "z.go", Functions: []string{"A", "Z"}, Imports: []string{"a", "z"}},
 	}, map[string][]string{"go": {"a", "z"}}, "")
@@ -44,11 +44,11 @@ func TestNewDepsProjectProducesDeterministicCollections(t *testing.T) {
 }
 
 func TestNewDepsProjectOrdersDuplicateFileKeysAndReportsRustCoverage(t *testing.T) {
-	first := NewDepsProject("/repo", []FileAnalysis{
+	first := newDepsProject("/repo", []FileAnalysis{
 		{Path: "same.rs", Language: "rust", Functions: []string{"z"}},
 		{Path: "same.rs", Language: "rust", Functions: []string{"a"}},
 	}, nil, "")
-	second := NewDepsProject("/repo", []FileAnalysis{
+	second := newDepsProject("/repo", []FileAnalysis{
 		{Path: "same.rs", Language: "rust", Functions: []string{"a"}},
 		{Path: "same.rs", Language: "rust", Functions: []string{"z"}},
 	}, nil, "")

--- a/scanner/deps.go
+++ b/scanner/deps.go
@@ -1,17 +1,34 @@
 package scanner
 
 import (
+	"context"
+	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
 )
 
+// MCPManifestByteBudget bounds each manifest read performed for one MCP request.
+const MCPManifestByteBudget int64 = 1 << 20
+
+var errManifestBudgetExceeded = errors.New("manifest exceeds byte budget")
+
 // ReadExternalDeps reads manifest files (go.mod, requirements.txt, package.json)
-func ReadExternalDeps(root string) map[string][]string {
+// while honoring caller cancellation. A positive manifestByteBudget skips
+// individual oversized manifests; zero keeps the legacy unbounded behavior
+// used by CLI and blast-radius callers.
+func ReadExternalDeps(ctx context.Context, root string, manifestByteBudget int64) (map[string][]string, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	deps := make(map[string][]string)
 
 	// Walk tree to find all manifest files
-	filepath.Walk(root, func(path string, info os.FileInfo, _ error) error {
+	err := filepath.Walk(root, func(path string, info os.FileInfo, _ error) error {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		if info == nil {
 			return nil
 		}
@@ -21,38 +38,35 @@ func ReadExternalDeps(root string) map[string][]string {
 			}
 			return nil
 		}
+		if !isDependencyManifest(info.Name()) {
+			return nil
+		}
+		content, err := readManifestContext(ctx, path, info.Size(), manifestByteBudget)
+		if errors.Is(err, errManifestBudgetExceeded) {
+			return nil
+		}
+		if err != nil {
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return ctxErr
+			}
+			return nil
+		}
 		switch info.Name() {
 		case "go.mod":
-			if c, err := os.ReadFile(path); err == nil {
-				deps["go"] = append(deps["go"], parseGoMod(string(c))...)
-			}
+			deps["go"] = append(deps["go"], parseGoMod(string(content))...)
 		case "requirements.txt":
-			if c, err := os.ReadFile(path); err == nil {
-				deps["python"] = append(deps["python"], parseRequirements(string(c))...)
-			}
+			deps["python"] = append(deps["python"], parseRequirements(string(content))...)
 		case "package.json":
-			if c, err := os.ReadFile(path); err == nil {
-				deps["javascript"] = append(deps["javascript"], parsePackageJson(string(c))...)
-			}
+			deps["javascript"] = append(deps["javascript"], parsePackageJson(string(content))...)
 		case "Podfile":
-			if c, err := os.ReadFile(path); err == nil {
-				deps["swift"] = append(deps["swift"], parsePodfile(string(c))...)
-			}
+			deps["swift"] = append(deps["swift"], parsePodfile(string(content))...)
 		case "Package.swift":
-			if c, err := os.ReadFile(path); err == nil {
-				deps["swift"] = append(deps["swift"], parsePackageSwift(string(c))...)
-			}
+			deps["swift"] = append(deps["swift"], parsePackageSwift(string(content))...)
 		case "packages.config":
-			if c, err := os.ReadFile(path); err == nil {
-				deps["csharp"] = append(deps["csharp"], parsePackagesConfig(string(c))...)
-			}
+			deps["csharp"] = append(deps["csharp"], parsePackagesConfig(string(content))...)
 		default:
-			// .csproj files have project-specific names, so they must be matched
-			// by extension rather than a fixed case above.
 			if strings.HasSuffix(info.Name(), ".csproj") {
-				if c, err := os.ReadFile(path); err == nil {
-					deps["csharp"] = append(deps["csharp"], parseCsproj(string(c))...)
-				}
+				deps["csharp"] = append(deps["csharp"], parseCsproj(string(content))...)
 			}
 		}
 		return nil
@@ -61,7 +75,63 @@ func ReadExternalDeps(root string) map[string][]string {
 	for k, v := range deps {
 		deps[k] = dedupe(v)
 	}
-	return deps
+	if err != nil {
+		return nil, err
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	return deps, nil
+}
+
+func isDependencyManifest(name string) bool {
+	switch name {
+	case "go.mod", "requirements.txt", "package.json", "Podfile", "Package.swift", "packages.config":
+		return true
+	default:
+		return strings.HasSuffix(name, ".csproj")
+	}
+}
+
+func readManifestContext(ctx context.Context, path string, size, budget int64) ([]byte, error) {
+	if budget > 0 && size > budget {
+		return nil, errManifestBudgetExceeded
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	reader := io.Reader(f)
+	if budget > 0 {
+		reader = io.LimitReader(f, budget+1)
+	}
+	data := make([]byte, 0, min(max(size, 0), budgetCapacity(budget)))
+	buf := make([]byte, 32*1024)
+	for {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		n, readErr := reader.Read(buf)
+		data = append(data, buf[:n]...)
+		if budget > 0 && int64(len(data)) > budget {
+			return nil, errManifestBudgetExceeded
+		}
+		if errors.Is(readErr, io.EOF) {
+			return data, nil
+		}
+		if readErr != nil {
+			return nil, readErr
+		}
+	}
+}
+
+func budgetCapacity(budget int64) int64 {
+	if budget <= 0 {
+		return 64 * 1024
+	}
+	return budget
 }
 
 func parseGoMod(c string) (deps []string) {

--- a/scanner/deps_test.go
+++ b/scanner/deps_test.go
@@ -1,6 +1,7 @@
 package scanner
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -241,7 +242,10 @@ requests
 		t.Fatal(err)
 	}
 
-	deps := ReadExternalDeps(tmpDir)
+	deps, err := ReadExternalDeps(context.Background(), tmpDir, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// Check Go deps
 	if goDeps, ok := deps["go"]; !ok {
@@ -290,7 +294,10 @@ func TestReadExternalDepsIgnoresNodeModules(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	deps := ReadExternalDeps(tmpDir)
+	deps, err := ReadExternalDeps(context.Background(), tmpDir, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// Should only have the root package.json deps
 	if jsDeps, ok := deps["javascript"]; ok {
@@ -860,7 +867,10 @@ func TestReadExternalDepsCsharp(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	deps := ReadExternalDeps(tmpDir)
+	deps, err := ReadExternalDeps(context.Background(), tmpDir, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	csDeps, ok := deps["csharp"]
 	if !ok {
@@ -886,7 +896,10 @@ func TestReadExternalDepsPackagesConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	deps := ReadExternalDeps(tmpDir)
+	deps, err := ReadExternalDeps(context.Background(), tmpDir, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	csDeps, ok := deps["csharp"]
 	if !ok {

--- a/scanner/filegraph.go
+++ b/scanner/filegraph.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"codemap/analysis"
 	"codemap/config"
 )
 
@@ -31,44 +32,42 @@ type fileIndex struct {
 	goPkgs   map[string][]string // Go package path -> files
 }
 
-// BuildFileGraph analyzes a project with its configured filters.
-func BuildFileGraph(root string) (*FileGraph, error) {
-	cfg := config.Load(root)
-	return BuildFileGraphWithFilters(root, Filters{Only: cfg.Only, Exclude: cfg.Exclude})
-}
-
-// BuildFileGraphWithFilters analyzes a project with explicit filters.
-func BuildFileGraphWithFilters(root string, filters Filters) (*FileGraph, error) {
-	analyses, err := ScanForDepsWithFilters(root, filters)
+// BuildFileGraph scans a project with explicit filters and builds its file
+// graph while honoring caller cancellation.
+func BuildFileGraph(ctx context.Context, root string, filters Filters) (*FileGraph, error) {
+	outcome, err := ScanForDeps(ctx, root, filters)
 	if err != nil {
 		return nil, err
 	}
-	return BuildFileGraphFromFilteredAnalyses(root, analyses, filters)
+	return BuildFileGraphFromOutcome(ctx, root, outcome, filters)
+}
+
+// BuildFileGraphFromOutcome builds a file graph from a scan outcome without
+// dropping scanner provenance.
+func BuildFileGraphFromOutcome(ctx context.Context, root string, outcome ScanOutcome, filters Filters) (*FileGraph, error) {
+	return buildFileGraphFromAnalysesWithCargoMetadataAndFilters(ctx, root, outcome.Analyses, filters, loadCargoMetadata, outcome.Sources...)
 }
 
 // BuildFileGraphFromAnalyses builds a file graph from pre-computed analyses
-// using the configured project filters.
-func BuildFileGraphFromAnalyses(root string, analyses []FileAnalysis) (*FileGraph, error) {
-	cfg := config.Load(root)
-	filters := Filters{Only: cfg.Only, Exclude: cfg.Exclude}
-	return buildFileGraphFromFilteredAnalysesWithCargoMetadata(context.Background(), root, filterAnalyses(analyses, filters), filters, loadCargoMetadata)
+// using the supplied filters.
+func BuildFileGraphFromAnalyses(ctx context.Context, root string, analyses []FileAnalysis, filters Filters) (*FileGraph, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	filtered, err := filterAnalysesContext(ctx, analyses, filters)
+	if err != nil {
+		return nil, err
+	}
+	return buildFileGraphFromAnalysesWithCargoMetadataAndFilters(ctx, root, filtered, filters, loadCargoMetadata)
 }
 
-// BuildFileGraphFromFilteredAnalyses builds a file graph from analyses that
-// already match the supplied filters.
-func BuildFileGraphFromFilteredAnalyses(root string, analyses []FileAnalysis, filters Filters) (*FileGraph, error) {
-	return buildFileGraphFromFilteredAnalysesWithCargoMetadata(context.Background(), root, analyses, filters, loadCargoMetadata)
-}
-
-// buildFileGraphFromAnalysesWithCargoMetadata is the testable configuration
-// aware variant of BuildFileGraphFromAnalyses.
 func buildFileGraphFromAnalysesWithCargoMetadata(ctx context.Context, root string, analyses []FileAnalysis, loader cargoMetadataLoader) (*FileGraph, error) {
 	cfg := config.Load(root)
 	filters := Filters{Only: cfg.Only, Exclude: cfg.Exclude}
-	return buildFileGraphFromFilteredAnalysesWithCargoMetadata(ctx, root, filterAnalyses(analyses, filters), filters, loader)
+	return buildFileGraphFromAnalysesWithCargoMetadataAndFilters(ctx, root, filterAnalyses(analyses, filters), filters, loader)
 }
 
-func buildFileGraphFromFilteredAnalysesWithCargoMetadata(ctx context.Context, root string, analyses []FileAnalysis, filters Filters, loader cargoMetadataLoader) (*FileGraph, error) {
+func buildFileGraphFromAnalysesWithCargoMetadataAndFilters(ctx context.Context, root string, analyses []FileAnalysis, filters Filters, loader cargoMetadataLoader, sources ...ScanSourceOutcome) (*FileGraph, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
@@ -84,6 +83,9 @@ func buildFileGraphFromFilteredAnalysesWithCargoMetadata(ctx context.Context, ro
 		Packages:    make(map[string][]string),
 		PathAliases: make(map[string][]string),
 	}
+	for _, source := range sources {
+		fg.Coverage.AddSource(source)
+	}
 
 	// Detect module name from go.mod (for Go import resolution)
 	fg.Module = detectModule(absRoot)
@@ -91,36 +93,74 @@ func buildFileGraphFromFilteredAnalysesWithCargoMetadata(ctx context.Context, ro
 	// Detect path aliases from tsconfig.json (for TS/JS import resolution)
 	fg.PathAliases, fg.BaseURL = detectPathAliases(absRoot)
 
-	// Scan all files with the same filters used for the analyses.
+	useJSWorkspace := needsJSWorkspaceResolver(analyses)
 	gitCache := NewGitIgnoreCache(root)
-	files, err := ScanFiles(root, gitCache, filters.Only, filters.Exclude)
+	scanOnly := filters.Only
+	if useJSWorkspace {
+		scanOnly = nil
+	}
+	allFiles, err := ScanFiles(ctx, root, gitCache, scanOnly, filters.Exclude)
 	if err != nil {
 		return nil, err
 	}
-	rustWorkspace := buildRustWorkspaceIndex(ctx, absRoot, analyses, files, loader)
+	files := allFiles
+	if useJSWorkspace {
+		files = make([]FileInfo, 0, len(allFiles))
+		for _, file := range allFiles {
+			if MatchesFilters(file.Path, filepath.Ext(file.Path), filters.Only, nil) {
+				files = append(files, file)
+			}
+		}
+	}
+	rustWorkspace, cargoOutcome := buildRustWorkspaceIndex(ctx, absRoot, analyses, files, loader)
+	if cargoOutcome != nil {
+		fg.Coverage.AddSource(*cargoOutcome)
+	}
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
 
 	// Build file index for fast fuzzy matching
-	idx := buildFileIndex(files, fg.Module)
+	idx, err := buildFileIndexContext(ctx, files, fg.Module)
+	if err != nil {
+		return nil, err
+	}
 	fg.Packages = idx.goPkgs
 	for _, file := range files {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		if strings.EqualFold(filepath.Ext(file.Path), ".rs") {
-			fg.Coverage = GraphCoverage{Status: rustCoverageStatus, Notes: []string{rustCoverageNote}}
+			if CoverageFromSources(fg.Coverage.Sources).Status != analysis.CoverageUnavailable {
+				fg.Coverage.AddSource(ScanSourceOutcome{Name: "rust-cargo", Status: ScanSourceMixed, Detail: rustCoverageNote})
+			}
 			break
+		}
+	}
+
+	var jsResolver *jsWorkspaceResolver
+	if useJSWorkspace {
+		jsResolver, err = buildJSWorkspaceResolver(ctx, absRoot, allFiles)
+		if err != nil {
+			return nil, err
 		}
 	}
 
 	// Resolve imports to files using universal fuzzy matching
 	for _, a := range analyses {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		var resolvedImports []string
 
 		if a.Language == "rust" {
 			resolvedImports = resolveRustReferences(absRoot, a, idx, rustWorkspace)
 		} else {
 			for _, imp := range a.Imports {
-				resolved := fuzzyResolve(imp, a.Path, idx, fg.Module, fg.PathAliases, fg.BaseURL)
+				if err := ctx.Err(); err != nil {
+					return nil, err
+				}
+				resolved := fuzzyResolveWithWorkspace(imp, a.Path, idx, fg.Module, fg.PathAliases, fg.BaseURL, jsResolver)
 				// Exclude multi-file Go package imports to avoid inflating hub counts.
 				// Go package imports start with the module prefix and resolve to all
 				// files in that package. For all other imports (e.g., C# namespace
@@ -143,11 +183,28 @@ func buildFileGraphFromFilteredAnalysesWithCargoMetadata(ctx context.Context, ro
 		}
 	}
 
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	return fg, nil
+}
+
+func needsJSWorkspaceResolver(analyses []FileAnalysis) bool {
+	for _, analysis := range analyses {
+		if isJavaScriptLanguage(DetectLanguage(analysis.Path)) {
+			return true
+		}
+	}
+	return false
 }
 
 // buildFileIndex creates a multi-key index for fast import resolution
 func buildFileIndex(files []FileInfo, goModule string) *fileIndex {
+	idx, _ := buildFileIndexContext(context.Background(), files, goModule)
+	return idx
+}
+
+func buildFileIndexContext(ctx context.Context, files []FileInfo, goModule string) (*fileIndex, error) {
 	idx := &fileIndex{
 		byExact:  make(map[string][]string),
 		bySuffix: make(map[string][]string),
@@ -156,6 +213,9 @@ func buildFileIndex(files []FileInfo, goModule string) *fileIndex {
 	}
 
 	for _, f := range files {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		path := f.Path
 		dir := filepath.Dir(path)
 		if dir == "." {
@@ -177,6 +237,9 @@ func buildFileIndex(files []FileInfo, goModule string) *fileIndex {
 		//   - "config.py"
 		parts := strings.Split(path, string(filepath.Separator))
 		for i := 1; i < len(parts); i++ {
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
 			suffix := strings.Join(parts[i:], string(filepath.Separator))
 			idx.bySuffix[suffix] = append(idx.bySuffix[suffix], path)
 			// Also without extension
@@ -195,11 +258,18 @@ func buildFileIndex(files []FileInfo, goModule string) *fileIndex {
 		}
 	}
 
-	return idx
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	return idx, nil
 }
 
 // fuzzyResolve converts an import path to compatible local file paths.
 func fuzzyResolve(imp, fromFile string, idx *fileIndex, goModule string, pathAliases map[string][]string, baseURL string) []string {
+	return fuzzyResolveWithWorkspace(imp, fromFile, idx, goModule, pathAliases, baseURL, nil)
+}
+
+func fuzzyResolveWithWorkspace(imp, fromFile string, idx *fileIndex, goModule string, pathAliases map[string][]string, baseURL string, jsResolver *jsWorkspaceResolver) []string {
 	sourceLanguage := DetectLanguage(fromFile)
 	if sourceLanguage == "" {
 		return nil
@@ -236,6 +306,9 @@ func fuzzyResolve(imp, fromFile string, idx *fileIndex, goModule string, pathAli
 		}
 	}
 	if isJavaScriptLanguage(sourceLanguage) {
+		if files := jsResolver.resolve(imp, fromFile, idx, sourceLanguage); len(files) > 0 {
+			return files
+		}
 		return nil
 	}
 
@@ -438,8 +511,6 @@ const HubThreshold = 3
 
 // IsTestFile reports whether a path names a test file across the supported
 // languages (Go _test files, JS/TS .test/.spec files, Python test_ modules).
-// Test importers are real graph edges but shouldn't confer hub status: a file
-// imported only by its own tests doesn't have blast radius.
 func IsTestFile(path string) bool {
 	base := strings.ToLower(filepath.Base(filepath.FromSlash(path)))
 	if strings.HasSuffix(base, "_test.go") {

--- a/scanner/filegraph.go
+++ b/scanner/filegraph.go
@@ -64,7 +64,11 @@ func BuildFileGraphFromAnalyses(ctx context.Context, root string, analyses []Fil
 func buildFileGraphFromAnalysesWithCargoMetadata(ctx context.Context, root string, analyses []FileAnalysis, loader cargoMetadataLoader) (*FileGraph, error) {
 	cfg := config.Load(root)
 	filters := Filters{Only: cfg.Only, Exclude: cfg.Exclude}
-	return buildFileGraphFromAnalysesWithCargoMetadataAndFilters(ctx, root, filterAnalyses(analyses, filters), filters, loader)
+	filtered, err := filterAnalysesContext(ctx, analyses, filters)
+	if err != nil {
+		return nil, err
+	}
+	return buildFileGraphFromAnalysesWithCargoMetadataAndFilters(ctx, root, filtered, filters, loader)
 }
 
 func buildFileGraphFromAnalysesWithCargoMetadataAndFilters(ctx context.Context, root string, analyses []FileAnalysis, filters Filters, loader cargoMetadataLoader, sources ...ScanSourceOutcome) (*FileGraph, error) {

--- a/scanner/filegraph_test.go
+++ b/scanner/filegraph_test.go
@@ -1,6 +1,7 @@
 package scanner
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -54,7 +55,7 @@ but-api = { path = "../but-api" }
 		}
 	}
 
-	graph, err := BuildFileGraph(root)
+	graph, err := BuildFileGraph(context.Background(), root, ConfiguredFilters(root))
 	if err != nil {
 		t.Fatalf("BuildFileGraph() error: %v", err)
 	}
@@ -108,7 +109,7 @@ edition = "2021"
 		}
 	}
 
-	graph, err := BuildFileGraph(root)
+	graph, err := BuildFileGraph(context.Background(), root, ConfiguredFilters(root))
 	if err != nil {
 		t.Fatalf("BuildFileGraph() error: %v", err)
 	}
@@ -509,7 +510,7 @@ func TestBuildFileGraphGoPackageTargets(t *testing.T) {
 		{Path: filepath.FromSlash("cmd/caller_test.go"), Language: "go", Imports: imports},
 	}
 
-	graph, err := BuildFileGraphFromAnalyses(root, analyses)
+	graph, err := BuildFileGraphFromAnalyses(context.Background(), root, analyses, ConfiguredFilters(root))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -639,7 +640,7 @@ func TestBuildFileGraphImportResolutionBoundaries(t *testing.T) {
 		{Path: "README.md", Language: "", Imports: []string{"path"}},
 	}
 
-	fg, err := BuildFileGraphFromAnalyses(root, analyses)
+	fg, err := BuildFileGraphFromAnalyses(context.Background(), root, analyses, ConfiguredFilters(root))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -701,7 +702,7 @@ func TestFilteredImportResolutionTargets(t *testing.T) {
 		filepath.FromSlash("blocked/target.ts"),
 		filepath.FromSlash("pkg/filteredpkg/target.go"),
 	}}
-	scanned, err := ScanFiles(root, NewGitIgnoreCache(root), filters.Only, filters.Exclude)
+	scanned, err := ScanFiles(context.Background(), root, NewGitIgnoreCache(root), filters.Only, filters.Exclude)
 	if err != nil {
 		t.Fatalf("ScanFiles() error: %v", err)
 	}
@@ -733,7 +734,7 @@ func TestFilteredImportResolutionTargets(t *testing.T) {
 		}
 	}
 
-	precomputed, err := BuildFileGraphFromFilteredAnalyses(root, analyses, filters)
+	precomputed, err := BuildFileGraphFromAnalyses(context.Background(), root, analyses, filters)
 	if err != nil {
 		t.Fatalf("BuildFileGraphFromFilteredAnalyses() error: %v", err)
 	}
@@ -743,7 +744,7 @@ func TestFilteredImportResolutionTargets(t *testing.T) {
 		if !NewAstGrepAnalyzer().Available() {
 			t.Skip("ast-grep not available")
 		}
-		live, err := BuildFileGraphWithFilters(root, filters)
+		live, err := BuildFileGraph(context.Background(), root, filters)
 		if err != nil {
 			t.Fatalf("BuildFileGraphWithFilters() error: %v", err)
 		}

--- a/scanner/filegraph_test.go
+++ b/scanner/filegraph_test.go
@@ -2,6 +2,8 @@ package scanner
 
 import (
 	"context"
+
+	"codemap/analysis"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -129,7 +131,7 @@ edition = "2021"
 	if got := graph.Imports["src/lib.rs"]; slices.Contains(got, "src/custom.rs") {
 		t.Fatalf("#[path] module should remain unresolved, got imports %#v", got)
 	}
-	if graph.Coverage.Status != "partial" || len(graph.Coverage.Notes) == 0 {
+	if graph.Coverage.Status != analysis.CoveragePartial || len(graph.Coverage.Notes) == 0 {
 		t.Fatalf("coverage = %+v, want explicit partial Rust coverage", graph.Coverage)
 	}
 }

--- a/scanner/filegraph_truth_test.go
+++ b/scanner/filegraph_truth_test.go
@@ -1,6 +1,7 @@
 package scanner
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -42,7 +43,7 @@ func TestGoStdlibImportsDoNotResolveToLocalFiles(t *testing.T) {
 		}},
 	}
 
-	fg, err := BuildFileGraphFromFilteredAnalyses(root, analyses, Filters{})
+	fg, err := BuildFileGraphFromAnalyses(context.Background(), root, analyses, Filters{})
 	if err != nil {
 		t.Fatalf("BuildFileGraphFromFilteredAnalyses: %v", err)
 	}
@@ -77,7 +78,7 @@ func TestGoFilesWithoutModuleGetNoFuzzyEdges(t *testing.T) {
 	analyses := []FileAnalysis{
 		{Path: "main.go", Language: "go", Imports: []string{"context"}},
 	}
-	fg, err := BuildFileGraphFromFilteredAnalyses(root, analyses, Filters{})
+	fg, err := BuildFileGraphFromAnalyses(context.Background(), root, analyses, Filters{})
 	if err != nil {
 		t.Fatalf("BuildFileGraphFromFilteredAnalyses: %v", err)
 	}
@@ -92,7 +93,7 @@ func TestNonGoResolutionUnaffectedByGoGate(t *testing.T) {
 	analyses := []FileAnalysis{
 		{Path: "app/main.py", Language: "python", Imports: []string{"app.core.config"}},
 	}
-	fg, err := BuildFileGraphFromFilteredAnalyses(root, analyses, Filters{})
+	fg, err := BuildFileGraphFromAnalyses(context.Background(), root, analyses, Filters{})
 	if err != nil {
 		t.Fatalf("BuildFileGraphFromFilteredAnalyses: %v", err)
 	}

--- a/scanner/git.go
+++ b/scanner/git.go
@@ -1,12 +1,16 @@
 package scanner
 
 import (
+	"context"
 	"fmt"
 	"os/exec"
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 )
+
+const gitContextWaitDelay = 100 * time.Millisecond
 
 // DiffInfo holds all diff-related data for changed files
 type DiffInfo struct {
@@ -15,8 +19,12 @@ type DiffInfo struct {
 	Stats     map[string]DiffStat // +/- line counts
 }
 
-// GitDiffInfo returns comprehensive diff information for the repo
-func GitDiffInfo(root, ref string) (*DiffInfo, error) {
+// GitDiffInfo returns comprehensive diff information for the repo while
+// honoring cancellation of Git subprocesses.
+func GitDiffInfo(ctx context.Context, root, ref string) (*DiffInfo, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	info := &DiffInfo{
 		Changed:   make(map[string]bool),
 		Untracked: make(map[string]bool),
@@ -24,10 +32,14 @@ func GitDiffInfo(root, ref string) (*DiffInfo, error) {
 	}
 
 	// Get modified files vs ref with stats
-	cmd := exec.Command("git", "diff", "--numstat", ref)
+	cmd := exec.CommandContext(ctx, "git", "diff", "--numstat", ref)
+	cmd.WaitDelay = gitContextWaitDelay
 	cmd.Dir = root
 	output, err := cmd.Output()
 	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, ctxErr
+		}
 		return nil, err
 	}
 
@@ -51,9 +63,19 @@ func GitDiffInfo(root, ref string) (*DiffInfo, error) {
 	}
 
 	// Get untracked files (new files)
-	cmd2 := exec.Command("git", "ls-files", "--others", "--exclude-standard")
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	cmd2 := exec.CommandContext(ctx, "git", "ls-files", "--others", "--exclude-standard")
+	cmd2.WaitDelay = gitContextWaitDelay
 	cmd2.Dir = root
-	output2, _ := cmd2.Output()
+	output2, err := cmd2.Output()
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return nil, ctxErr
+	}
+	if err != nil {
+		output2 = nil
+	}
 	for _, line := range strings.Split(strings.TrimSpace(string(output2)), "\n") {
 		if line != "" {
 			info.Changed[line] = true
@@ -64,27 +86,24 @@ func GitDiffInfo(root, ref string) (*DiffInfo, error) {
 	return info, nil
 }
 
-// GitDiffFiles returns files changed between current HEAD and the given branch/ref
-// Also includes untracked files (new files not yet committed)
-func GitDiffFiles(root, ref string) (map[string]bool, error) {
-	info, err := GitDiffInfo(root, ref)
-	if err != nil {
-		return nil, err
-	}
-	return info.Changed, nil
-}
-
-// GitDiffStats returns +/- line counts for changed files
+// DiffStat returns +/- line counts for changed files
 type DiffStat struct {
 	Added   int
 	Removed int
 }
 
-func GitDiffStats(root, ref string) (map[string]DiffStat, error) {
-	cmd := exec.Command("git", "diff", "--numstat", ref)
+func GitDiffStats(ctx context.Context, root, ref string) (map[string]DiffStat, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	cmd := exec.CommandContext(ctx, "git", "diff", "--numstat", ref)
+	cmd.WaitDelay = gitContextWaitDelay
 	cmd.Dir = root
 	output, err := cmd.Output()
 	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, ctxErr
+		}
 		return nil, err
 	}
 
@@ -160,19 +179,25 @@ type ImpactInfo struct {
 	UsedBy int    // number of other files that import/use this file
 }
 
-// AnalyzeImpact checks which changed files are imported by other files
-// Uses ast-grep to extract actual imports for accuracy
-func AnalyzeImpact(root string, changedFiles []FileInfo) []ImpactInfo {
+// AnalyzeImpact analyzes which changed files are imported by other files,
+// honoring caller cancellation. Uses ast-grep to extract actual imports.
+func AnalyzeImpact(ctx context.Context, root string, changedFiles []FileInfo) ([]ImpactInfo, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	if len(changedFiles) == 0 {
-		return nil
+		return nil, nil
 	}
 
 	// Scan all files to get their imports using ast-grep
-	analyses, err := ScanForDeps(root)
+	outcome, err := ScanForDeps(ctx, root, ConfiguredFilters(root))
 	if err != nil {
-		return nil
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, ctxErr
+		}
+		return nil, nil
 	}
-	return AnalyzeImpactFromAnalyses(changedFiles, analyses)
+	return AnalyzeImpactFromAnalyses(changedFiles, outcome.Analyses), ctx.Err()
 }
 
 // AnalyzeImpactFromAnalyses computes impact using a pre-computed ast-grep scan,

--- a/scanner/git_test.go
+++ b/scanner/git_test.go
@@ -1,6 +1,7 @@
 package scanner
 
 import (
+	"context"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -101,7 +102,7 @@ func TestGitDiffFilesInRepo(t *testing.T) {
 	}
 
 	// Get diff info
-	info, err := GitDiffInfo(tmpDir, "main")
+	info, err := GitDiffInfo(context.Background(), tmpDir, "main")
 	if err != nil {
 		t.Fatalf("GitDiffInfo failed: %v", err)
 	}
@@ -152,15 +153,15 @@ func TestGitDiffFilesHelper(t *testing.T) {
 	cmd.Dir = tmpDir
 	cmd.Run()
 
-	// Use GitDiffFiles helper
-	changed, err := GitDiffFiles(tmpDir, "main")
+	// Use GitDiffInfo helper
+	info, err := GitDiffInfo(context.Background(), tmpDir, "main")
 	if err != nil {
-		t.Fatalf("GitDiffFiles failed: %v", err)
+		t.Fatalf("GitDiffInfo failed: %v", err)
 	}
 
 	// No changes since last commit
-	if len(changed) != 0 {
-		t.Errorf("Expected no changes, got %v", changed)
+	if len(info.Changed) != 0 {
+		t.Errorf("Expected no changes, got %v", info.Changed)
 	}
 
 	// Modify file
@@ -168,12 +169,12 @@ func TestGitDiffFilesHelper(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	changed, err = GitDiffFiles(tmpDir, "main")
+	info, err = GitDiffInfo(context.Background(), tmpDir, "main")
 	if err != nil {
-		t.Fatalf("GitDiffFiles failed: %v", err)
+		t.Fatalf("GitDiffInfo failed: %v", err)
 	}
 
-	if !changed["test.go"] {
+	if !info.Changed["test.go"] {
 		t.Error("Expected test.go in changed files")
 	}
 }
@@ -205,7 +206,7 @@ func TestGitDiffStatsHelper(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	stats, err := GitDiffStats(tmpDir, "main")
+	stats, err := GitDiffStats(context.Background(), tmpDir, "main")
 	if err != nil {
 		t.Fatalf("GitDiffStats failed: %v", err)
 	}
@@ -223,7 +224,7 @@ func TestGitDiffInfoInvalidRef(t *testing.T) {
 	tmpDir := setupGitRepo(t)
 
 	// Try to diff against nonexistent ref
-	_, err := GitDiffInfo(tmpDir, "nonexistent-branch-xyz")
+	_, err := GitDiffInfo(context.Background(), tmpDir, "nonexistent-branch-xyz")
 	if err == nil {
 		// It's okay if this returns empty results instead of error
 		// but we're checking it doesn't panic
@@ -247,12 +248,18 @@ func TestImpactInfo(t *testing.T) {
 
 func TestAnalyzeImpactEmpty(t *testing.T) {
 	// Test with empty changed files
-	impacts := AnalyzeImpact(".", nil)
+	impacts, err := AnalyzeImpact(context.Background(), ".", nil)
+	if err != nil {
+		t.Fatalf("AnalyzeImpact() error: %v", err)
+	}
 	if impacts != nil {
 		t.Errorf("Expected nil impacts for empty input, got %v", impacts)
 	}
 
-	impacts = AnalyzeImpact(".", []FileInfo{})
+	impacts, err = AnalyzeImpact(context.Background(), ".", []FileInfo{})
+	if err != nil {
+		t.Fatalf("AnalyzeImpact() error: %v", err)
+	}
 	if impacts != nil {
 		t.Errorf("Expected nil impacts for empty slice, got %v", impacts)
 	}

--- a/scanner/integration_more_test.go
+++ b/scanner/integration_more_test.go
@@ -1,11 +1,14 @@
 package scanner
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
+
+	"codemap/analysis"
 )
 
 func writeScannerDepsFixture(t *testing.T, root string) {
@@ -38,10 +41,11 @@ func TestScanForDepsBuildFileGraphAndAnalyzeImpact(t *testing.T) {
 	root := t.TempDir()
 	writeScannerDepsFixture(t, root)
 
-	analyses, err := ScanForDeps(root)
+	outcome, err := ScanForDeps(context.Background(), root, ConfiguredFilters(root))
 	if err != nil {
 		t.Fatalf("ScanForDeps() error: %v", err)
 	}
+	analyses := outcome.Analyses
 	byPath := make(map[string]FileAnalysis, len(analyses))
 	for _, analysis := range analyses {
 		byPath[analysis.Path] = analysis
@@ -53,7 +57,7 @@ func TestScanForDepsBuildFileGraphAndAnalyzeImpact(t *testing.T) {
 		t.Fatalf("expected main.go to expose main(), got %+v", got)
 	}
 
-	fg, err := BuildFileGraph(root)
+	fg, err := BuildFileGraph(context.Background(), root, ConfiguredFilters(root))
 	if err != nil {
 		t.Fatalf("BuildFileGraph() error: %v", err)
 	}
@@ -67,7 +71,10 @@ func TestScanForDepsBuildFileGraphAndAnalyzeImpact(t *testing.T) {
 		t.Fatal("expected pkg/types/types.go to be detected as a hub")
 	}
 
-	impacts := AnalyzeImpact(root, []FileInfo{{Path: "pkg/types/types.go"}})
+	impacts, err := AnalyzeImpact(context.Background(), root, []FileInfo{{Path: "pkg/types/types.go"}})
+	if err != nil {
+		t.Fatalf("AnalyzeImpact() error: %v", err)
+	}
 	if len(impacts) == 0 {
 		t.Fatal("expected AnalyzeImpact to report at least one impacted file")
 	}
@@ -109,17 +116,18 @@ func TestDependencyAndGraphScansRespectConfiguredFilters(t *testing.T) {
 		}
 	}
 
-	analyses, err := ScanForDeps(root)
+	outcome, err := ScanForDeps(context.Background(), root, ConfiguredFilters(root))
 	if err != nil {
 		t.Fatalf("ScanForDeps() error: %v", err)
 	}
+	analyses := outcome.Analyses
 	for _, analysis := range analyses {
 		if analysis.Path == "schema.ts" || strings.HasPrefix(analysis.Path, "excluded/") {
 			t.Fatalf("configured-out dependency analysis returned: %s", analysis.Path)
 		}
 	}
 
-	fg, err := BuildFileGraph(root)
+	fg, err := BuildFileGraph(context.Background(), root, ConfiguredFilters(root))
 	if err != nil {
 		t.Fatalf("BuildFileGraph() error: %v", err)
 	}
@@ -133,7 +141,7 @@ func TestDependencyAndGraphScansRespectConfiguredFilters(t *testing.T) {
 		t.Fatal("extension-filtered file remains in graph")
 	}
 
-	fromAnalyses, err := BuildFileGraphFromAnalyses(root, analyses)
+	fromAnalyses, err := BuildFileGraphFromAnalyses(context.Background(), root, analyses, ConfiguredFilters(root))
 	if err != nil {
 		t.Fatalf("BuildFileGraphFromAnalyses() error: %v", err)
 	}
@@ -173,27 +181,28 @@ func TestExplicitDependencyFiltersOverrideRepositoryConfig(t *testing.T) {
 			}
 		}
 
-		analyses, err := ScanForDepsWithFilters(root, Filters{Only: []string{"go"}})
+		outcome, err := ScanForDeps(context.Background(), root, Filters{Only: []string{"go"}})
 		if err != nil {
-			t.Fatalf("ScanForDepsWithFilters() error: %v", err)
+			t.Fatalf("ScanForDeps() error: %v", err)
 		}
+		analyses := outcome.Analyses
 		for _, analysis := range analyses {
 			if filepath.Ext(analysis.Path) != ".go" {
 				t.Fatalf("explicit only filter returned %q", analysis.Path)
 			}
 		}
 
-		configured, err := ScanForDeps(root)
+		configuredOutcome, err := ScanForDeps(context.Background(), root, ConfiguredFilters(root))
 		if err != nil {
 			t.Fatalf("ScanForDeps() error: %v", err)
 		}
-		for _, analysis := range configured {
+		for _, analysis := range configuredOutcome.Analyses {
 			if filepath.Ext(analysis.Path) == ".go" {
 				t.Fatalf("configured wrapper ignored repository only filter: %q", analysis.Path)
 			}
 		}
 
-		graph, err := BuildFileGraphWithFilters(root, Filters{Only: []string{"go"}})
+		graph, err := BuildFileGraph(context.Background(), root, Filters{Only: []string{"go"}})
 		if err != nil {
 			t.Fatalf("BuildFileGraphWithFilters() error: %v", err)
 		}
@@ -225,10 +234,11 @@ func TestExplicitDependencyFiltersOverrideRepositoryConfig(t *testing.T) {
 		}
 
 		filters := Filters{Exclude: []string{"keep"}}
-		analyses, err := ScanForDepsWithFilters(root, filters)
+		outcome, err := ScanForDeps(context.Background(), root, filters)
 		if err != nil {
-			t.Fatalf("ScanForDepsWithFilters() error: %v", err)
+			t.Fatalf("ScanForDeps() error: %v", err)
 		}
+		analyses := outcome.Analyses
 		for _, analysis := range analyses {
 			if strings.HasPrefix(analysis.Path, "keep/") {
 				t.Fatalf("explicit exclude filter returned %q", analysis.Path)
@@ -238,7 +248,7 @@ func TestExplicitDependencyFiltersOverrideRepositoryConfig(t *testing.T) {
 			t.Fatal("explicit exclude filter inherited repository config")
 		}
 
-		graph, err := BuildFileGraphFromFilteredAnalyses(root, analyses, filters)
+		graph, err := BuildFileGraphFromAnalyses(context.Background(), root, analyses, filters)
 		if err != nil {
 			t.Fatalf("BuildFileGraphFromFilteredAnalyses() error: %v", err)
 		}
@@ -275,16 +285,16 @@ func TestConfiguredScanHelpers(t *testing.T) {
 		t.Fatalf("unconfigured analysis filter = %+v, want original analysis", got)
 	}
 
-	if _, err := ScanConfiguredFiles(filepath.Join(root, "missing"), nil); err == nil {
+	if _, err := ScanConfiguredFiles(context.Background(), filepath.Join(root, "missing"), nil); err == nil {
 		t.Fatal("expected configured scan of missing root to fail")
 	}
 
-	if _, err := BuildFileGraphFromFilteredAnalyses(filepath.Join(root, "missing"), nil, Filters{}); err == nil {
+	if _, err := BuildFileGraphFromAnalyses(context.Background(), filepath.Join(root, "missing"), nil, Filters{}); err == nil {
 		t.Fatal("expected explicit-filter graph of missing root to propagate a file scan error")
 	}
 }
 
-func TestScanForDepsPropagatesScanError(t *testing.T) {
+func TestScanForDepsFailsClosedOnFailedScanner(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("requires shell script execution")
 	}
@@ -297,12 +307,25 @@ func TestScanForDepsPropagatesScanError(t *testing.T) {
 	}
 	t.Setenv("PATH", binDir)
 
-	if _, err := ScanForDeps(t.TempDir()); err == nil {
-		t.Fatal("expected malformed ast-grep output to propagate a scan error")
+	// Malformed ast-grep output fails closed: no analyses, honest failed source,
+	// and no hard error so hooks and MCP keep a usable answer.
+	outcome, err := ScanForDeps(context.Background(), t.TempDir(), Filters{})
+	if err != nil {
+		t.Fatalf("ScanForDeps() error = %v, want degraded outcome", err)
+	}
+	if len(outcome.Analyses) != 0 {
+		t.Fatalf("degraded ScanForDeps analyses = %#v, want empty", outcome.Analyses)
+	}
+	if len(outcome.Sources) != 1 || outcome.Sources[0].Status != ScanSourceFailed {
+		t.Fatalf("degraded ScanForDeps sources = %#v, want failed ast-grep", outcome.Sources)
 	}
 
-	if _, err := BuildFileGraphWithFilters(t.TempDir(), Filters{}); err == nil {
-		t.Fatal("expected explicit-filter graph to propagate a dependency scan error")
+	graph, err := BuildFileGraph(context.Background(), t.TempDir(), Filters{})
+	if err != nil {
+		t.Fatalf("BuildFileGraph() error = %v, want degraded graph", err)
+	}
+	if coverage := CoverageFromSources(graph.Coverage.Sources); coverage.Status != analysis.CoverageUnavailable {
+		t.Fatalf("degraded graph coverage = %q, want unavailable", coverage.Status)
 	}
 }
 
@@ -315,7 +338,7 @@ func TestScanForDepsDoesNotRequireWritableTempDir(t *testing.T) {
 	t.Setenv("TMP", invalidTemp)
 	t.Setenv("TEMP", invalidTemp)
 
-	if _, err := ScanForDeps(t.TempDir()); err != nil {
+	if _, err := ScanForDeps(context.Background(), t.TempDir(), Filters{}); err != nil {
 		t.Fatalf("ScanForDeps should not require writable temporary storage: %v", err)
 	}
 }

--- a/scanner/jsworkspace.go
+++ b/scanner/jsworkspace.go
@@ -1,0 +1,976 @@
+package scanner
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+type jsWorkspaceResolver struct {
+	packageScopes []jsPackageScope
+	denoScopes    []jsImportScope
+	workspaces    []jsPackageWorkspace
+}
+
+type jsPackageWorkspace struct {
+	root     string
+	packages map[string][]*jsWorkspacePackage
+}
+
+type jsWorkspacePackage struct {
+	root         string
+	name         string
+	exports      jsSpecifierMap
+	hasExports   bool
+	entryTargets []string
+	sourceRoot   string
+	outDir       string
+}
+
+type jsPackageScope struct {
+	root    string
+	pkg     *jsWorkspacePackage
+	imports jsSpecifierMap
+}
+
+type jsImportScope struct {
+	root    string
+	imports jsSpecifierMap
+}
+
+type jsWorkspaceManifest struct {
+	root       string
+	pkg        *jsWorkspacePackage
+	imports    jsSpecifierMap
+	workspaces []string
+}
+
+type jsSpecifierMap struct {
+	exact   map[string]jsSpecifierTarget
+	dynamic []jsSpecifierTarget
+}
+
+type jsSpecifierTarget struct {
+	key    string
+	target string
+	valid  bool
+	prefix bool
+}
+
+func buildJSWorkspaceResolver(ctx context.Context, root string, files []FileInfo) (*jsWorkspaceResolver, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	packages := make(map[string]*jsWorkspaceManifest)
+	denoConfigs := make(map[string]*jsWorkspaceManifest)
+	tsConfigs := make(map[string]map[string]any)
+	pnpmWorkspaces := make(map[string][]string)
+	for _, file := range files {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		name := filepath.Base(file.Path)
+		manifestRoot := cleanRepoPath(filepath.Dir(file.Path))
+		if name == "pnpm-workspace.yaml" {
+			pnpmWorkspaces[manifestRoot] = readPnpmWorkspace(filepath.Join(root, file.Path))
+			continue
+		}
+		if name == "tsconfig.json" {
+			if doc, ok := readJSWorkspaceManifest(filepath.Join(root, file.Path)); ok {
+				tsConfigs[manifestRoot] = doc
+			}
+			continue
+		}
+		if name != "package.json" && name != "deno.json" && name != "deno.jsonc" {
+			continue
+		}
+
+		doc, ok := readJSWorkspaceManifest(filepath.Join(root, file.Path))
+		if !ok {
+			continue
+		}
+		if name == "package.json" {
+			packages[manifestRoot] = parsePackageManifest(manifestRoot, doc)
+		} else {
+			denoConfigs[manifestRoot] = parseDenoManifest(manifestRoot, doc)
+		}
+	}
+	for root, doc := range tsConfigs {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		if manifest := packages[root]; manifest != nil {
+			manifest.pkg.sourceRoot, manifest.pkg.outDir = parseTSOutputDirs(doc)
+		}
+	}
+
+	resolver := &jsWorkspaceResolver{}
+	for _, manifest := range packages {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		resolver.packageScopes = append(resolver.packageScopes, jsPackageScope{
+			root:    manifest.root,
+			pkg:     manifest.pkg,
+			imports: manifest.imports,
+		})
+	}
+	for _, manifest := range denoConfigs {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		resolver.denoScopes = append(resolver.denoScopes, jsImportScope{
+			root:    manifest.root,
+			imports: manifest.imports,
+		})
+	}
+	sort.Slice(resolver.packageScopes, func(i, j int) bool {
+		return len(resolver.packageScopes[i].root) > len(resolver.packageScopes[j].root)
+	})
+	sort.Slice(resolver.denoScopes, func(i, j int) bool {
+		return len(resolver.denoScopes[i].root) > len(resolver.denoScopes[j].root)
+	})
+
+	workspaces := make(map[string]*jsPackageWorkspace)
+	addWorkspace := func(owner *jsWorkspaceManifest, ownerRoot string, patterns []string, groups ...map[string]*jsWorkspaceManifest) error {
+		if len(patterns) == 0 {
+			return nil
+		}
+		workspace := workspaces[ownerRoot]
+		if workspace == nil {
+			workspace = newJSPackageWorkspace(ownerRoot)
+			workspaces[ownerRoot] = workspace
+		}
+		if owner != nil {
+			workspace.add(owner.pkg)
+		}
+		return addJSWorkspaceMembers(ctx, workspace, ownerRoot, patterns, groups...)
+	}
+	for _, owner := range packages {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		if err := addWorkspace(owner, owner.root, owner.workspaces, packages); err != nil {
+			return nil, err
+		}
+	}
+	for _, owner := range denoConfigs {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		if err := addWorkspace(owner, owner.root, owner.workspaces, packages, denoConfigs); err != nil {
+			return nil, err
+		}
+	}
+	for ownerRoot, patterns := range pnpmWorkspaces {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		if err := addWorkspace(nil, ownerRoot, patterns, packages); err != nil {
+			return nil, err
+		}
+	}
+	for _, workspace := range workspaces {
+		resolver.workspaces = append(resolver.workspaces, *workspace)
+	}
+	sort.Slice(resolver.workspaces, func(i, j int) bool {
+		return len(resolver.workspaces[i].root) > len(resolver.workspaces[j].root)
+	})
+
+	return resolver, nil
+}
+
+func addJSWorkspaceMembers(ctx context.Context, workspace *jsPackageWorkspace, ownerRoot string, patterns []string, groups ...map[string]*jsWorkspaceManifest) error {
+	for _, manifests := range groups {
+		for _, member := range manifests {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			if matchesWorkspaceMember(ownerRoot, member.root, patterns) {
+				workspace.add(member.pkg)
+			}
+		}
+	}
+	return nil
+}
+
+func newJSPackageWorkspace(root string) *jsPackageWorkspace {
+	return &jsPackageWorkspace{
+		root:     root,
+		packages: make(map[string][]*jsWorkspacePackage),
+	}
+}
+
+func (w *jsPackageWorkspace) add(pkg *jsWorkspacePackage) {
+	if pkg == nil || pkg.name == "" {
+		return
+	}
+	for _, existing := range w.packages[pkg.name] {
+		if existing.root == pkg.root {
+			return
+		}
+	}
+	w.packages[pkg.name] = append(w.packages[pkg.name], pkg)
+}
+
+func (r *jsWorkspaceResolver) resolve(imp, fromFile string, idx *fileIndex, sourceLanguage string) []string {
+	if r == nil || isExternalJSSpecifier(imp) {
+		return nil
+	}
+
+	if strings.HasPrefix(imp, "#") {
+		scope := r.nearestPackageScope(fromFile)
+		if scope == nil {
+			return nil
+		}
+		target, matched := scope.imports.resolve(imp)
+		if !matched || !target.valid {
+			return nil
+		}
+		return scope.pkg.resolveTarget(target.target, idx, sourceLanguage)
+	}
+
+	if scope := r.nearestDenoScope(fromFile); scope != nil {
+		if target, matched := scope.imports.resolve(imp); matched {
+			if !target.valid {
+				return nil
+			}
+			return resolveManifestTarget(scope.root, target.target, idx, sourceLanguage)
+		}
+	}
+
+	name, subpath, ok := splitJSPackageSpecifier(imp)
+	if !ok {
+		return nil
+	}
+	var candidates []*jsWorkspacePackage
+	for _, workspace := range r.workspaces {
+		if pathContains(workspace.root, fromFile) {
+			candidates = workspace.packages[name]
+			break
+		}
+	}
+	if len(candidates) != 1 {
+		scope := r.nearestPackageScope(fromFile)
+		if scope == nil || scope.pkg == nil || scope.pkg.name != name {
+			return nil
+		}
+		candidates = []*jsWorkspacePackage{scope.pkg}
+	}
+
+	return candidates[0].resolve(subpath, idx, sourceLanguage)
+}
+
+func (r *jsWorkspaceResolver) nearestPackageScope(fromFile string) *jsPackageScope {
+	for i := range r.packageScopes {
+		if pathContains(r.packageScopes[i].root, fromFile) {
+			return &r.packageScopes[i]
+		}
+	}
+	return nil
+}
+
+func (r *jsWorkspaceResolver) nearestDenoScope(fromFile string) *jsImportScope {
+	for i := range r.denoScopes {
+		if pathContains(r.denoScopes[i].root, fromFile) {
+			return &r.denoScopes[i]
+		}
+	}
+	return nil
+}
+
+func (pkg *jsWorkspacePackage) resolve(subpath string, idx *fileIndex, sourceLanguage string) []string {
+	key := "."
+	if subpath != "" {
+		key = "./" + subpath
+	}
+	if pkg.hasExports {
+		target, matched := pkg.exports.resolve(key)
+		if !matched || !target.valid {
+			return nil
+		}
+		return pkg.resolveTarget(target.target, idx, sourceLanguage)
+	}
+	if subpath != "" {
+		return pkg.resolveInferredTarget("./"+subpath, idx, sourceLanguage)
+	}
+	if len(pkg.entryTargets) != 1 {
+		return nil
+	}
+	return pkg.resolveInferredTarget(pkg.entryTargets[0], idx, sourceLanguage)
+}
+
+func resolveManifestTarget(root, target string, idx *fileIndex, sourceLanguage string) []string {
+	if isTypeOnlyTarget(target) {
+		return nil
+	}
+	localPath, ok := manifestLocalPath(root, target)
+	if !ok {
+		return nil
+	}
+	for _, candidate := range compatibleFiles(sourceLanguage, idx.byExact[localPath]) {
+		if candidate == localPath {
+			return []string{candidate}
+		}
+	}
+	return nil
+}
+
+func (pkg *jsWorkspacePackage) resolveTarget(target string, idx *fileIndex, sourceLanguage string) []string {
+	if files := resolveManifestTarget(pkg.root, target, idx, sourceLanguage); len(files) > 0 {
+		return files
+	}
+	if pkg.sourceRoot == "" || pkg.outDir == "" {
+		return nil
+	}
+
+	localPath, ok := manifestLocalPath(pkg.root, target)
+	if !ok {
+		return nil
+	}
+	outRoot := cleanRepoPath(filepath.Join(repoPath(pkg.root), filepath.FromSlash(pkg.outDir)))
+	if !pathContains(outRoot, localPath) || localPath == outRoot {
+		return nil
+	}
+	relative, err := filepath.Rel(outRoot, localPath)
+	if err != nil || relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
+		return nil
+	}
+	sourcePath := cleanRepoPath(filepath.Join(repoPath(pkg.root), filepath.FromSlash(pkg.sourceRoot), relative))
+	for _, extension := range []string{".mjs", ".cjs", ".jsx", ".js"} {
+		sourcePath = strings.TrimSuffix(sourcePath, extension)
+	}
+	return tryExactMatch(sourcePath, idx, sourceLanguage)
+}
+
+func (pkg *jsWorkspacePackage) resolveInferredTarget(target string, idx *fileIndex, sourceLanguage string) []string {
+	if localPath, ok := manifestLocalPath(pkg.root, target); ok {
+		if files := tryExactMatch(localPath, idx, sourceLanguage); len(files) > 0 {
+			return files
+		}
+	}
+	return pkg.resolveTarget(target, idx, sourceLanguage)
+}
+
+func (m jsSpecifierMap) resolve(specifier string) (jsSpecifierTarget, bool) {
+	if target, ok := m.exact[specifier]; ok {
+		return target, true
+	}
+
+	var matches []jsSpecifierTarget
+	bestSpecificity := -1
+	for _, mapping := range m.dynamic {
+		var remainder string
+		switch {
+		case mapping.prefix && strings.HasPrefix(specifier, mapping.key):
+			remainder = strings.TrimPrefix(specifier, mapping.key)
+		case !mapping.prefix && strings.Count(mapping.key, "*") == 1:
+			prefix, suffix, _ := strings.Cut(mapping.key, "*")
+			if !strings.HasPrefix(specifier, prefix) || !strings.HasSuffix(specifier, suffix) {
+				continue
+			}
+			remainder = specifier[len(prefix) : len(specifier)-len(suffix)]
+		default:
+			continue
+		}
+
+		specificity := len(mapping.key)
+		if specificity < bestSpecificity {
+			continue
+		}
+		resolved := mapping
+		if mapping.valid {
+			if mapping.prefix {
+				resolved.target += remainder
+			} else {
+				resolved.target = strings.Replace(mapping.target, "*", remainder, 1)
+			}
+		}
+		if specificity > bestSpecificity {
+			bestSpecificity = specificity
+			matches = matches[:0]
+		}
+		matches = append(matches, resolved)
+	}
+	if len(matches) != 1 {
+		return jsSpecifierTarget{}, len(matches) > 0
+	}
+	return matches[0], true
+}
+
+func parsePackageManifest(root string, doc map[string]any) *jsWorkspaceManifest {
+	name, _ := doc["name"].(string)
+	pkg := &jsWorkspacePackage{root: root, name: name}
+	pkg.exports, pkg.hasExports = parseExports(doc)
+	pkg.entryTargets = unambiguousEntryTargets(doc)
+	return &jsWorkspaceManifest{
+		root:       root,
+		pkg:        pkg,
+		imports:    parsePackageImports(doc["imports"]),
+		workspaces: parseWorkspacePatterns(doc["workspaces"], "packages"),
+	}
+}
+
+func parseDenoManifest(root string, doc map[string]any) *jsWorkspaceManifest {
+	name, _ := doc["name"].(string)
+	pkg := &jsWorkspacePackage{root: root, name: name}
+	pkg.exports, pkg.hasExports = parseExports(doc)
+	return &jsWorkspaceManifest{
+		root:       root,
+		pkg:        pkg,
+		imports:    parseDenoImports(doc["imports"]),
+		workspaces: parseWorkspacePatterns(doc["workspace"], "members"),
+	}
+}
+
+func parseExports(doc map[string]any) (jsSpecifierMap, bool) {
+	value, exists := doc["exports"]
+	if !exists {
+		return jsSpecifierMap{}, false
+	}
+	mappings := newJSSpecifierMap()
+	switch exports := value.(type) {
+	case string:
+		mappings.addExact(".", exports)
+	case map[string]any:
+		subpaths := true
+		for key := range exports {
+			subpaths = subpaths && strings.HasPrefix(key, ".")
+		}
+		if !subpaths {
+			target, ok := unambiguousRuntimeTarget(exports)
+			if !ok {
+				mappings.addInvalid(".")
+			} else {
+				mappings.addExact(".", target)
+			}
+			break
+		}
+		for key, value := range exports {
+			target, ok := unambiguousRuntimeTarget(value)
+			if !ok {
+				mappings.addInvalid(key)
+			} else {
+				mappings.addPattern(key, target)
+			}
+		}
+	default:
+		mappings.addInvalid(".")
+	}
+	return mappings, true
+}
+
+func unambiguousRuntimeTarget(value any) (string, bool) {
+	targets := make(map[string]bool)
+	valid := true
+	var collect func(any, bool)
+	collect = func(current any, typeOnly bool) {
+		if typeOnly {
+			return
+		}
+		switch current := current.(type) {
+		case string:
+			if !isTypeOnlyTarget(current) {
+				targets[current] = true
+			}
+		case map[string]any:
+			for key, nested := range current {
+				if key == "types" || strings.HasPrefix(key, "types@") {
+					collect(nested, true)
+				} else if isJSRuntimeCondition(key) {
+					collect(nested, false)
+				} else {
+					valid = false
+				}
+			}
+		default:
+			valid = false
+		}
+	}
+	collect(value, false)
+	if !valid || len(targets) != 1 {
+		return "", false
+	}
+	for target := range targets {
+		return target, true
+	}
+	return "", false
+}
+
+func isJSRuntimeCondition(condition string) bool {
+	switch condition {
+	case "default", "import", "require", "module-sync", "node", "node-addons", "browser", "development", "production", "deno", "bun":
+		return true
+	default:
+		return false
+	}
+}
+
+func isTypeOnlyTarget(target string) bool {
+	for _, suffix := range []string{".d.ts", ".d.mts", ".d.cts"} {
+		if strings.HasSuffix(target, suffix) {
+			return true
+		}
+	}
+	return false
+}
+
+func parsePackageImports(value any) jsSpecifierMap {
+	mappings := newJSSpecifierMap()
+	imports, ok := value.(map[string]any)
+	if !ok {
+		return mappings
+	}
+	for key, target := range imports {
+		if !strings.HasPrefix(key, "#") || key == "#" || strings.HasPrefix(key, "#/") {
+			continue
+		}
+		targetString, ok := target.(string)
+		if !ok {
+			mappings.addInvalid(key)
+			continue
+		}
+		mappings.addPattern(key, targetString)
+	}
+	return mappings
+}
+
+func parseDenoImports(value any) jsSpecifierMap {
+	mappings := newJSSpecifierMap()
+	imports, ok := value.(map[string]any)
+	if !ok {
+		return mappings
+	}
+	for key, target := range imports {
+		targetString, ok := target.(string)
+		if !ok {
+			mappings.addInvalid(key)
+			continue
+		}
+		if strings.HasSuffix(key, "/") {
+			mappings.addPrefix(key, targetString)
+		} else {
+			mappings.addExact(key, targetString)
+		}
+	}
+	return mappings
+}
+
+func newJSSpecifierMap() jsSpecifierMap {
+	return jsSpecifierMap{exact: make(map[string]jsSpecifierTarget)}
+}
+
+func (m *jsSpecifierMap) addExact(key, target string) {
+	m.exact[key] = jsSpecifierTarget{key: key, target: target, valid: validLocalTarget(target)}
+}
+
+func (m *jsSpecifierMap) addInvalid(key string) {
+	m.exact[key] = jsSpecifierTarget{key: key}
+}
+
+func (m *jsSpecifierMap) addPrefix(key, target string) {
+	m.dynamic = append(m.dynamic, jsSpecifierTarget{
+		key:    key,
+		target: target,
+		valid:  strings.HasSuffix(target, "/") && validLocalTarget(target),
+		prefix: true,
+	})
+}
+
+func (m *jsSpecifierMap) addPattern(key, target string) {
+	keyStars := strings.Count(key, "*")
+	targetStars := strings.Count(target, "*")
+	if keyStars == 0 {
+		m.addExact(key, target)
+		return
+	}
+	m.dynamic = append(m.dynamic, jsSpecifierTarget{
+		key:    key,
+		target: target,
+		valid:  keyStars == 1 && targetStars == 1 && validLocalTarget(target),
+	})
+}
+
+func unambiguousEntryTargets(doc map[string]any) []string {
+	seen := make(map[string]bool)
+	for _, key := range []string{"module", "main"} {
+		if target, ok := doc[key].(string); ok {
+			target = strings.TrimSpace(filepath.ToSlash(target))
+			if target != "" && !strings.Contains(target, ":") && !path.IsAbs(target) {
+				if !strings.HasPrefix(target, "./") {
+					target = "./" + target
+				}
+				if validLocalTarget(target) {
+					seen[target] = true
+				}
+			}
+		}
+	}
+	if len(seen) != 1 {
+		return nil
+	}
+	for target := range seen {
+		return []string{target}
+	}
+	return nil
+}
+
+func parseWorkspacePatterns(value any, objectKey string) []string {
+	if object, ok := value.(map[string]any); ok {
+		value = object[objectKey]
+	}
+	items, ok := value.([]any)
+	if !ok {
+		return nil
+	}
+	var patterns []string
+	for _, item := range items {
+		pattern, ok := item.(string)
+		if !ok {
+			return nil
+		}
+		pattern, ok = normalizeWorkspacePattern(pattern)
+		if !ok {
+			return nil
+		}
+		patterns = append(patterns, pattern)
+	}
+	return patterns
+}
+
+func readPnpmWorkspace(manifestPath string) []string {
+	data, err := os.ReadFile(manifestPath)
+	if err != nil {
+		return nil
+	}
+	var workspace struct {
+		Packages []string `yaml:"packages"`
+	}
+	if err := yaml.Unmarshal(data, &workspace); err != nil {
+		return nil
+	}
+	patterns := make([]string, 0, len(workspace.Packages))
+	for _, pattern := range workspace.Packages {
+		pattern, ok := normalizeWorkspacePattern(pattern)
+		if !ok {
+			return nil
+		}
+		patterns = append(patterns, pattern)
+	}
+	return patterns
+}
+
+func parseTSOutputDirs(doc map[string]any) (string, string) {
+	options, _ := doc["compilerOptions"].(map[string]any)
+	rootDir, _ := options["rootDir"].(string)
+	outDir, _ := options["outDir"].(string)
+	rootDir = cleanManifestDir(rootDir)
+	outDir = cleanManifestDir(outDir)
+	return rootDir, outDir
+}
+
+func cleanManifestDir(value string) string {
+	value = strings.TrimPrefix(strings.TrimSpace(filepath.ToSlash(value)), "./")
+	if value == "" || path.IsAbs(value) {
+		return ""
+	}
+	for _, part := range strings.Split(value, "/") {
+		if part == ".." {
+			return ""
+		}
+	}
+	return value
+}
+
+func matchesWorkspaceMember(ownerRoot, memberRoot string, patterns []string) bool {
+	relative, err := filepath.Rel(repoPath(ownerRoot), repoPath(memberRoot))
+	if err != nil {
+		return false
+	}
+	relative = filepath.ToSlash(relative)
+	if relative == "." || relative == ".." || strings.HasPrefix(relative, "../") {
+		return false
+	}
+	included := false
+	for _, pattern := range patterns {
+		excluded := strings.HasPrefix(pattern, "!")
+		pattern = strings.TrimPrefix(pattern, "!")
+		if matchWorkspaceGlob(pattern, relative) {
+			included = !excluded
+		}
+	}
+	return included
+}
+
+func matchWorkspaceGlob(pattern, value string) bool {
+	patternParts := strings.Split(pattern, "/")
+	valueParts := strings.Split(value, "/")
+	type position struct{ pattern, value int }
+	memo := make(map[position]bool)
+	seen := make(map[position]bool)
+
+	var match func(int, int) bool
+	match = func(patternIndex, valueIndex int) bool {
+		key := position{patternIndex, valueIndex}
+		if seen[key] {
+			return memo[key]
+		}
+		seen[key] = true
+
+		switch {
+		case patternIndex == len(patternParts):
+			memo[key] = valueIndex == len(valueParts)
+		case patternParts[patternIndex] == "**":
+			memo[key] = match(patternIndex+1, valueIndex) ||
+				(valueIndex < len(valueParts) && match(patternIndex, valueIndex+1))
+		case valueIndex < len(valueParts):
+			segmentMatch, err := path.Match(patternParts[patternIndex], valueParts[valueIndex])
+			memo[key] = err == nil && segmentMatch && match(patternIndex+1, valueIndex+1)
+		}
+		return memo[key]
+	}
+	return match(0, 0)
+}
+
+func validWorkspacePattern(pattern string) bool {
+	_, ok := normalizeWorkspacePattern(pattern)
+	return ok
+}
+
+func normalizeWorkspacePattern(pattern string) (string, bool) {
+	pattern = strings.TrimSpace(filepath.ToSlash(pattern))
+	excluded := strings.HasPrefix(pattern, "!")
+	if excluded {
+		pattern = strings.TrimSpace(strings.TrimPrefix(pattern, "!"))
+	}
+	pattern = strings.TrimPrefix(pattern, "./")
+	if pattern == "" || strings.HasPrefix(pattern, "!") || path.IsAbs(pattern) || hasDrivePrefix(pattern) {
+		return "", false
+	}
+	for _, part := range strings.Split(pattern, "/") {
+		if part == ".." {
+			return "", false
+		}
+		if part == "**" {
+			continue
+		}
+		if _, err := path.Match(part, "candidate"); err != nil {
+			return "", false
+		}
+	}
+	if excluded {
+		pattern = "!" + pattern
+	}
+	return pattern, true
+}
+
+func hasDrivePrefix(value string) bool {
+	return len(value) >= 2 && value[1] == ':' &&
+		(value[0] >= 'A' && value[0] <= 'Z' || value[0] >= 'a' && value[0] <= 'z')
+}
+
+func validLocalTarget(target string) bool {
+	if !strings.HasPrefix(target, "./") || strings.ContainsRune(target, 0) {
+		return false
+	}
+	trimmed := strings.TrimPrefix(filepath.ToSlash(target), "./")
+	if trimmed == "" {
+		return false
+	}
+	for _, part := range strings.Split(trimmed, "/") {
+		if part == ".." {
+			return false
+		}
+	}
+	return true
+}
+
+func manifestLocalPath(root, target string) (string, bool) {
+	if !validLocalTarget(target) {
+		return "", false
+	}
+	relative := strings.TrimPrefix(filepath.ToSlash(target), "./")
+	resolved := cleanRepoPath(filepath.Join(repoPath(root), filepath.FromSlash(relative)))
+	if !pathContains(root, resolved) {
+		return "", false
+	}
+	return resolved, true
+}
+
+func splitJSPackageSpecifier(specifier string) (string, string, bool) {
+	if specifier == "" || strings.HasPrefix(specifier, ".") || strings.HasPrefix(specifier, "#") {
+		return "", "", false
+	}
+	parts := strings.Split(specifier, "/")
+	if strings.HasPrefix(specifier, "@") {
+		if len(parts) < 2 || parts[0] == "" || parts[1] == "" {
+			return "", "", false
+		}
+		return strings.Join(parts[:2], "/"), strings.Join(parts[2:], "/"), true
+	}
+	if parts[0] == "" {
+		return "", "", false
+	}
+	return parts[0], strings.Join(parts[1:], "/"), true
+}
+
+func isExternalJSSpecifier(specifier string) bool {
+	lower := strings.ToLower(specifier)
+	for _, prefix := range []string{
+		"node:", "bun:", "npm:", "jsr:", "http:", "https:", "data:",
+	} {
+		if strings.HasPrefix(lower, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func pathContains(root, file string) bool {
+	root = cleanRepoPath(root)
+	file = cleanRepoPath(file)
+	return root == "" || file == root || strings.HasPrefix(file, root+string(filepath.Separator))
+}
+
+func cleanRepoPath(value string) string {
+	value = filepath.Clean(value)
+	if value == "." {
+		return ""
+	}
+	return value
+}
+
+func repoPath(value string) string {
+	if value == "" {
+		return "."
+	}
+	return value
+}
+
+func readJSWorkspaceManifest(path string) (map[string]any, bool) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, false
+	}
+	doc, err := stripJSONC(data)
+	return doc, err == nil
+}
+
+func stripJSONC(data []byte) (map[string]any, error) {
+	withoutComments, err := removeJSONComments(data)
+	if err != nil {
+		return nil, err
+	}
+	withoutTrailingCommas := removeJSONTrailingCommas(withoutComments)
+	var value map[string]any
+	if err := json.Unmarshal(withoutTrailingCommas, &value); err != nil {
+		return nil, err
+	}
+	return value, nil
+}
+
+func removeJSONComments(data []byte) ([]byte, error) {
+	result := make([]byte, 0, len(data))
+	inString := false
+	escaped := false
+	for i := 0; i < len(data); i++ {
+		current := data[i]
+		if inString {
+			result = append(result, current)
+			switch {
+			case escaped:
+				escaped = false
+			case current == '\\':
+				escaped = true
+			case current == '"':
+				inString = false
+			}
+			continue
+		}
+		if current == '"' {
+			inString = true
+			result = append(result, current)
+			continue
+		}
+		if current != '/' || i+1 >= len(data) {
+			result = append(result, current)
+			continue
+		}
+		switch data[i+1] {
+		case '/':
+			i += 2
+			for ; i < len(data) && data[i] != '\n'; i++ {
+				result = append(result, ' ')
+			}
+			if i < len(data) {
+				result = append(result, data[i])
+			}
+		case '*':
+			i += 2
+			closed := false
+			for ; i < len(data); i++ {
+				if data[i] == '\n' {
+					result = append(result, '\n')
+				} else {
+					result = append(result, ' ')
+				}
+				if i+1 < len(data) && data[i] == '*' && data[i+1] == '/' {
+					result = append(result, ' ')
+					i++
+					closed = true
+					break
+				}
+			}
+			if !closed {
+				return nil, errors.New("unterminated JSON block comment")
+			}
+		default:
+			result = append(result, current)
+		}
+	}
+	return result, nil
+}
+
+func removeJSONTrailingCommas(data []byte) []byte {
+	result := make([]byte, 0, len(data))
+	inString := false
+	escaped := false
+	for i := 0; i < len(data); i++ {
+		current := data[i]
+		if inString {
+			result = append(result, current)
+			switch {
+			case escaped:
+				escaped = false
+			case current == '\\':
+				escaped = true
+			case current == '"':
+				inString = false
+			}
+			continue
+		}
+		if current == '"' {
+			inString = true
+			result = append(result, current)
+			continue
+		}
+		if current == ',' {
+			next := i + 1
+			for next < len(data) && (data[next] == ' ' || data[next] == '\t' || data[next] == '\r' || data[next] == '\n') {
+				next++
+			}
+			if next < len(data) && (data[next] == '}' || data[next] == ']') {
+				continue
+			}
+		}
+		result = append(result, current)
+	}
+	return result
+}

--- a/scanner/jsworkspace.go
+++ b/scanner/jsworkspace.go
@@ -872,7 +872,9 @@ func splitJSPackageSpecifier(specifier string) (string, string, bool) {
 	}
 	parts := strings.Split(specifier, "/")
 	if strings.HasPrefix(specifier, "@") {
-		if len(parts) < 2 || parts[0] == "" || parts[1] == "" {
+		// A scoped specifier needs both a non-empty scope and a package name:
+		// "@/pkg" (empty scope) and "@scope/" (empty name) are malformed.
+		if len(parts) < 2 || parts[0] == "" || parts[1] == "" || parts[0] == "@" {
 			return "", "", false
 		}
 		return strings.Join(parts[:2], "/"), strings.Join(parts[2:], "/"), true

--- a/scanner/jsworkspace.go
+++ b/scanner/jsworkspace.go
@@ -102,12 +102,16 @@ func buildJSWorkspaceResolver(ctx context.Context, root string, files []FileInfo
 			denoConfigs[manifestRoot] = parseDenoManifest(manifestRoot, doc)
 		}
 	}
-	for root, doc := range tsConfigs {
+	for manifestRoot := range tsConfigs {
 		if err := ctx.Err(); err != nil {
 			return nil, err
 		}
-		if manifest := packages[root]; manifest != nil {
-			manifest.pkg.sourceRoot, manifest.pkg.outDir = parseTSOutputDirs(doc)
+		if manifest := packages[manifestRoot]; manifest != nil {
+			// Parse the merged config: packages whose tsconfig.json inherits
+			// rootDir/outDir via extends would otherwise leave both empty and
+			// drop their workspace exports from the graph.
+			configPath := filepath.Join(root, filepath.FromSlash(manifestRoot), "tsconfig.json")
+			manifest.pkg.sourceRoot, manifest.pkg.outDir = mergedTSOutputDirs(configPath)
 		}
 	}
 
@@ -534,8 +538,15 @@ func parsePackageImports(value any) jsSpecifierMap {
 		}
 		targetString, ok := target.(string)
 		if !ok {
-			mappings.addInvalid(key)
-			continue
+			// Conditional shapes such as {"default": "./src/env.ts", "types":
+			// "./src/env.d.ts"} are valid package-import targets and should use
+			// the same runtime-target selection as exports instead of being
+			// discarded as invalid.
+			targetString, ok = unambiguousRuntimeTarget(target)
+			if !ok {
+				mappings.addInvalid(key)
+				continue
+			}
 		}
 		mappings.addPattern(key, targetString)
 	}
@@ -674,6 +685,57 @@ func parseTSOutputDirs(doc map[string]any) (string, string) {
 	rootDir = cleanManifestDir(rootDir)
 	outDir = cleanManifestDir(outDir)
 	return rootDir, outDir
+}
+
+// mergedTSOutputDirs reads a tsconfig.json, follows extends chains, and returns
+// the effective compilerOptions.rootDir/outDir (child values override parents),
+// matching the older path-alias loader which already follows extends.
+func mergedTSOutputDirs(configPath string) (string, string) {
+	options := mergedTSCompilerOptions(configPath)
+	return parseTSOutputDirs(map[string]any{"compilerOptions": options})
+}
+
+func mergedTSCompilerOptions(configPath string) map[string]any {
+	return mergedTSCompilerOptionsDepth(configPath, 0)
+}
+
+func mergedTSCompilerOptionsDepth(configPath string, depth int) map[string]any {
+	// Guard against cyclic extends chains (a misconfiguration that would
+	// otherwise recurse without bound).
+	if depth > 32 {
+		return nil
+	}
+	doc, ok := readJSWorkspaceManifest(configPath)
+	if !ok {
+		return nil
+	}
+	extends, _ := doc["extends"].(string)
+	var merged map[string]any
+	if extends != "" {
+		parentPath := extends
+		if !filepath.IsAbs(parentPath) {
+			parentPath = filepath.Join(filepath.Dir(configPath), parentPath)
+		}
+		if !strings.HasSuffix(parentPath, ".json") {
+			parentPath += ".json"
+		}
+		merged = mergedTSCompilerOptionsDepth(parentPath, depth+1)
+	}
+	child, _ := doc["compilerOptions"].(map[string]any)
+	if merged == nil {
+		return child
+	}
+	if child == nil {
+		return merged
+	}
+	out := make(map[string]any, len(merged)+len(child))
+	for key, value := range merged {
+		out[key] = value
+	}
+	for key, value := range child {
+		out[key] = value
+	}
+	return out
 }
 
 func cleanManifestDir(value string) string {

--- a/scanner/jsworkspace_test.go
+++ b/scanner/jsworkspace_test.go
@@ -406,3 +406,102 @@ func assertWorkspaceImports(t *testing.T, graph *FileGraph, path string, want []
 		t.Fatalf("imports[%q] = %v, want %v", path, got, want)
 	}
 }
+
+// Regression for PR #105: package-internal "#imports" with conditional targets
+// ({"default": ..., "types": ...}) must resolve like conditional exports
+// instead of being dropped as invalid.
+func TestBuildFileGraphResolvesConditionalPackageImports(t *testing.T) {
+	root := t.TempDir()
+	writeWorkspaceFile(t, root, "package.json",
+		`{"name":"@acme/cond","exports":"./src/index.ts","imports":{"#env":{"default":"./src/env.ts","types":"./src/env.d.ts"},"#noop":"nope"}}`)
+	writeWorkspaceFiles(t, root, "src/index.ts", "src/env.ts", "src/env.d.ts", "src/consumer.ts")
+
+	graph := buildWorkspaceGraph(t, root,
+		workspaceAnalysis("src/consumer.ts", "#env", "#noop"),
+	)
+	assertWorkspaceImports(t, graph, "src/consumer.ts", []string{filepath.FromSlash("src/env.ts")})
+}
+
+// Regression for PR #105: a package whose tsconfig.json inherits rootDir/outDir
+// via extends must still remap ./dist/* exports back to src/* sources.
+func TestBuildFileGraphResolvesExtendedTsconfigOutputDirs(t *testing.T) {
+	root := t.TempDir()
+	writeWorkspaceFile(t, root, "tsconfig.base.json", `{"compilerOptions":{"rootDir":"src","outDir":"dist"}}`)
+	writeWorkspaceFile(t, root, "package.json", `{"workspaces":["packages/*"]}`)
+	writeWorkspaceFile(t, root, "packages/core/package.json", `{"name":"@acme/ext","exports":"./dist/index.js"}`)
+	writeWorkspaceFile(t, root, "packages/core/tsconfig.json", `{"extends":"../../tsconfig.base.json"}`)
+	writeWorkspaceFiles(t, root, "app/main.ts", "packages/core/src/index.ts")
+
+	graph := buildWorkspaceGraph(t, root, workspaceAnalysis("app/main.ts", "@acme/ext"))
+	assertWorkspaceImports(t, graph, "app/main.ts", []string{filepath.FromSlash("packages/core/src/index.ts")})
+}
+
+func TestParsePackageImportsConditionalTargets(t *testing.T) {
+	m := parsePackageImports(map[string]any{
+		"#env":    map[string]any{"default": "./src/env.ts", "types": "./src/env.d.ts"},
+		"#direct": "./src/direct.ts",
+		"#bad":    []any{"./a.ts", "./b.ts"},
+		"#types":  map[string]any{"types": "./src/env.d.ts"},
+	})
+	if got := m.exact["#env"]; !got.valid || got.target != "./src/env.ts" {
+		t.Fatalf("#env = %+v, want valid ./src/env.ts", got)
+	}
+	if got := m.exact["#direct"]; !got.valid || got.target != "./src/direct.ts" {
+		t.Fatalf("#direct = %+v, want valid ./src/direct.ts", got)
+	}
+	if got := m.exact["#bad"]; got.valid {
+		t.Fatalf("#bad array must stay invalid, got %+v", got)
+	}
+	if got := m.exact["#types"]; got.valid {
+		t.Fatalf("#types-only target must stay invalid, got %+v", got)
+	}
+}
+
+func TestMergedTSOutputDirsChildOverridesParent(t *testing.T) {
+	root := t.TempDir()
+	writeWorkspaceFile(t, root, "tsconfig.base.json", `{"compilerOptions":{"rootDir":"lib","outDir":"build"}}`)
+	writeWorkspaceFile(t, root, "tsconfig.json", `{"extends":"./tsconfig.base.json","compilerOptions":{"outDir":"dist"}}`)
+	rootDir, outDir := mergedTSOutputDirs(filepath.Join(root, "tsconfig.json"))
+	if rootDir != "lib" || outDir != "dist" {
+		t.Fatalf("merged dirs = (%q, %q), want (lib, dist)", rootDir, outDir)
+	}
+}
+
+func TestMergedTSOutputDirsExtendsWithoutExtension(t *testing.T) {
+	root := t.TempDir()
+	writeWorkspaceFile(t, root, "tsconfig.base.json", `{"compilerOptions":{"rootDir":"src","outDir":"dist"}}`)
+	writeWorkspaceFile(t, root, "tsconfig.json", `{"extends":"./tsconfig.base"}`)
+	rootDir, outDir := mergedTSOutputDirs(filepath.Join(root, "tsconfig.json"))
+	if rootDir != "src" || outDir != "dist" {
+		t.Fatalf("merged dirs = (%q, %q), want (src, dist)", rootDir, outDir)
+	}
+}
+
+func TestMergedTSOutputDirsCycleGuardTerminates(t *testing.T) {
+	root := t.TempDir()
+	writeWorkspaceFile(t, root, "a.json", `{"extends":"./b.json"}`)
+	writeWorkspaceFile(t, root, "b.json", `{"extends":"./a.json"}`)
+	rootDir, outDir := mergedTSOutputDirs(filepath.Join(root, "a.json"))
+	if rootDir != "" || outDir != "" {
+		t.Fatalf("cyclic extends must yield empty dirs, got (%q, %q)", rootDir, outDir)
+	}
+}
+
+func TestParsePackageImportsSkipsNonPackageKeys(t *testing.T) {
+	m := parsePackageImports(map[string]any{
+		"#ok":   "./src/ok.ts",
+		"env":   "./src/env.ts",
+		"#":     "./src/hash.ts",
+		"#/":    "./src/slash.ts",
+		"#sub/": "./src/sub.ts",
+	})
+	if got := m.exact["#ok"]; !got.valid {
+		t.Fatalf("#ok must stay valid, got %+v", got)
+	}
+	// Non-# keys, bare "#", "#/" and trailing-#/ keys are not package imports.
+	for _, key := range []string{"env", "#", "#/"} {
+		if _, ok := m.exact[key]; ok {
+			t.Fatalf("key %q must be skipped, got %+v", key, m.exact[key])
+		}
+	}
+}

--- a/scanner/jsworkspace_test.go
+++ b/scanner/jsworkspace_test.go
@@ -505,3 +505,333 @@ func TestParsePackageImportsSkipsNonPackageKeys(t *testing.T) {
 		}
 	}
 }
+
+func TestParseExportsEdgeCases(t *testing.T) {
+	tests := []struct {
+		name    string
+		exports any
+		check   func(t *testing.T, m jsSpecifierMap, hasExports bool)
+	}{
+		{
+			name:    "string export",
+			exports: "./index.js",
+			check: func(t *testing.T, m jsSpecifierMap, _ bool) {
+				target, ok := m.exact["."]
+				if !ok || !target.valid || target.target != "./index.js" {
+					t.Fatalf("string export = %+v, want valid ./index.js", target)
+				}
+			},
+		},
+		{
+			name:    "escaping string export is invalid",
+			exports: "./bad/../index.js",
+			check: func(t *testing.T, m jsSpecifierMap, _ bool) {
+				if target, ok := m.exact["."]; !ok || target.valid {
+					t.Fatalf("escaping export must be invalid, got %+v", target)
+				}
+			},
+		},
+		{
+			name:    "subpath map",
+			exports: map[string]any{".": "./index.js", "./feature": "./feature.js"},
+			check: func(t *testing.T, m jsSpecifierMap, _ bool) {
+				if _, ok := m.exact["."]; !ok {
+					t.Fatal("missing root export")
+				}
+				if _, ok := m.exact["./feature"]; !ok {
+					t.Fatal("missing subpath export")
+				}
+			},
+		},
+		{
+			name:    "conditional types-only default",
+			exports: map[string]any{".": map[string]any{"types": "./index.d.ts", "default": "./index.js"}},
+			check: func(t *testing.T, m jsSpecifierMap, _ bool) {
+				target, ok := m.exact["."]
+				if !ok || !target.valid || target.target != "./index.js" {
+					t.Fatalf("conditional export = %+v, want ./index.js", target)
+				}
+			},
+		},
+		{
+			name:    "ambiguous runtime conditions are invalid",
+			exports: map[string]any{".": map[string]any{"import": "./a.mjs", "require": "./a.cjs"}},
+			check: func(t *testing.T, m jsSpecifierMap, _ bool) {
+				if target, ok := m.exact["."]; !ok || target.valid {
+					t.Fatalf("ambiguous conditional export must be invalid, got %+v", target)
+				}
+			},
+		},
+		{
+			name:    "non-subpath key map invalidates root",
+			exports: map[string]any{"node": "./node.js", "browser": "./browser.js"},
+			check: func(t *testing.T, m jsSpecifierMap, _ bool) {
+				if target, ok := m.exact["."]; !ok || target.valid {
+					t.Fatalf("non-subpath map must invalidate root, got %+v", target)
+				}
+			},
+		},
+		{
+			name:    "wildcard subpath",
+			exports: map[string]any{"./": "./src/", "./*": "./src/*.js"},
+			check: func(t *testing.T, m jsSpecifierMap, _ bool) {
+				if len(m.dynamic) == 0 {
+					t.Fatal("expected wildcard dynamic entries")
+				}
+			},
+		},
+		{
+			name:    "non-object export is invalid",
+			exports: 42,
+			check: func(t *testing.T, m jsSpecifierMap, _ bool) {
+				if target, ok := m.exact["."]; !ok || target.valid {
+					t.Fatalf("numeric export must be invalid, got %+v", target)
+				}
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m, has := parseExports(map[string]any{"exports": tt.exports})
+			if !has {
+				t.Fatal("parseExports reported no exports")
+			}
+			tt.check(t, m, has)
+		})
+	}
+}
+
+func TestParseExportsMissingKey(t *testing.T) {
+	m, has := parseExports(map[string]any{})
+	if has {
+		t.Fatal("missing exports key must report no exports")
+	}
+	if len(m.exact) != 0 || len(m.dynamic) != 0 {
+		t.Fatalf("empty exports map = %+v", m)
+	}
+}
+
+func TestSplitJSPackageSpecifier(t *testing.T) {
+	tests := []struct {
+		spec     string
+		wantName string
+		wantSub  string
+		wantOK   bool
+	}{
+		{"lodash", "lodash", "", true},
+		{"lodash/fp", "lodash", "fp", true},
+		{"lodash/deep/nested", "lodash", "deep/nested", true},
+		{"@scope/pkg", "@scope/pkg", "", true},
+		{"@scope/pkg/sub", "@scope/pkg", "sub", true},
+		{"", "", "", false},
+		{"./relative", "", "", false},
+		{"../parent", "", "", false},
+		{"#alias", "", "", false},
+		{"/abs", "", "", false},
+		{"@scope/", "", "", false},
+		{"@/pkg", "", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.spec, func(t *testing.T) {
+			name, sub, ok := splitJSPackageSpecifier(tt.spec)
+			if ok != tt.wantOK || name != tt.wantName || sub != tt.wantSub {
+				t.Fatalf("splitJSPackageSpecifier(%q) = (%q, %q, %v), want (%q, %q, %v)", tt.spec, name, sub, ok, tt.wantName, tt.wantSub, tt.wantOK)
+			}
+		})
+	}
+}
+
+func TestValidLocalTargetAndManifestLocalPath(t *testing.T) {
+	for _, valid := range []string{"./x.js", "./a/b.ts", "./x.js?query", "./weird name.ts"} {
+		if !validLocalTarget(valid) {
+			t.Fatalf("validLocalTarget(%q) = false, want true", valid)
+		}
+	}
+	for _, invalid := range []string{"x.js", "./", "./..", "./a/../b.js", "../x.js", "/abs/x.js", "./x\x00.js", ""} {
+		if validLocalTarget(invalid) {
+			t.Fatalf("validLocalTarget(%q) = true, want false", invalid)
+		}
+	}
+
+	root := t.TempDir()
+	if got, ok := manifestLocalPath(root, "./src/x.js"); !ok || got != filepath.Join(root, "src", "x.js") {
+		t.Fatalf("manifestLocalPath inside root = (%q, %v), want joined path", got, ok)
+	}
+	for _, target := range []string{"../escape.js", "./src/../../escape.js", "https://deno.land/std/", "/abs"} {
+		if _, ok := manifestLocalPath(root, target); ok {
+			t.Fatalf("manifestLocalPath(%q) escaped, want rejection", target)
+		}
+	}
+}
+
+func TestUnambiguousRuntimeTargetTable(t *testing.T) {
+	tests := []struct {
+		name   string
+		value  any
+		want   string
+		wantOK bool
+	}{
+		{"plain string", "./x.js", "./x.js", true},
+		{"types only", "./x.d.ts", "", false},
+		{"default plus types", map[string]any{"default": "./x.js", "types": "./x.d.ts"}, "./x.js", true},
+		{"import plus require", map[string]any{"import": "./a.mjs", "require": "./a.cjs"}, "", false},
+		{"duplicate targets collapse", map[string]any{"default": "./x.js", "development": "./x.js"}, "./x.js", true},
+		{"unknown condition invalid", map[string]any{"custom": "./x.js"}, "", false},
+		{"nested node conditions", map[string]any{"node": map[string]any{"types": "./x.d.ts", "default": "./x.js"}}, "./x.js", true},
+		{"non-object invalid", 42, "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := unambiguousRuntimeTarget(tt.value)
+			if ok != tt.wantOK || got != tt.want {
+				t.Fatalf("unambiguousRuntimeTarget(%v) = (%q, %v), want (%q, %v)", tt.value, got, ok, tt.want, tt.wantOK)
+			}
+		})
+	}
+}
+
+func TestParseDenoImportsExactAndPrefix(t *testing.T) {
+	m := parseDenoImports(map[string]any{
+		"fmt/": "https://deno.land/std/fmt/",
+		"fmt":  "./fmt.ts",
+		"bad":  42,
+	})
+	exact, ok := m.exact["fmt"]
+	if !ok || !exact.valid || exact.target != "./fmt.ts" {
+		t.Fatalf("deno exact import = %+v, want ./fmt.ts", exact)
+	}
+	if target, ok := m.exact["bad"]; !ok || target.valid {
+		t.Fatalf("deno non-string import must be invalid, got %+v", target)
+	}
+	if len(m.dynamic) != 1 || m.dynamic[0].key != "fmt/" {
+		t.Fatalf("deno prefix imports = %+v, want single fmt/ prefix", m.dynamic)
+	}
+	// External URL prefix targets are not local and must be marked invalid.
+	if m.dynamic[0].valid {
+		t.Fatal("external URL prefix target must be invalid")
+	}
+}
+
+func TestResolveTargetMapsOutDirToSourceRoot(t *testing.T) {
+	root := "packages/alpha"
+	idx := buildFileIndex([]FileInfo{
+		{Path: root + "/src/index.ts", Ext: ".ts"},
+		{Path: root + "/src/util.mjs", Ext: ".mjs"},
+		{Path: root + "/dist/index.d.ts", Ext: ".d.ts"},
+	}, "")
+
+	tests := []struct {
+		name     string
+		pkg      *jsWorkspacePackage
+		target   string
+		wantPath string
+		wantNil  bool
+	}{
+		{
+			name:     "dist target maps through sourceRoot",
+			pkg:      &jsWorkspacePackage{root: root, sourceRoot: "src", outDir: "dist"},
+			target:   "./dist/index.js",
+			wantPath: root + "/src/index.ts",
+		},
+		{
+			name:     "dist mjs target maps to source mjs",
+			pkg:      &jsWorkspacePackage{root: root, sourceRoot: "src", outDir: "dist"},
+			target:   "./dist/util.mjs",
+			wantPath: root + "/src/util.mjs",
+		},
+		{
+			name:    "type-only target never resolves",
+			pkg:     &jsWorkspacePackage{root: root, sourceRoot: "src", outDir: "dist"},
+			target:  "./dist/index.d.ts",
+			wantNil: true,
+		},
+		{
+			name:    "target outside outDir is rejected",
+			pkg:     &jsWorkspacePackage{root: root, sourceRoot: "src", outDir: "dist"},
+			target:  "./lib/index.js",
+			wantNil: true,
+		},
+		{
+			name:    "target equal to outDir root is rejected",
+			pkg:     &jsWorkspacePackage{root: root, sourceRoot: "src", outDir: "dist"},
+			target:  "./dist",
+			wantNil: true,
+		},
+		{
+			name:    "no source/out dirs falls back to nil",
+			pkg:     &jsWorkspacePackage{root: root},
+			target:  "./dist/index.js",
+			wantNil: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.pkg.resolveTarget(tt.target, idx, "typescript")
+			if tt.wantNil {
+				if len(got) != 0 {
+					t.Fatalf("resolveTarget(%q) = %v, want nil", tt.target, got)
+				}
+				return
+			}
+			if len(got) != 1 || got[0] != tt.wantPath {
+				t.Fatalf("resolveTarget(%q) = %v, want [%s]", tt.target, got, tt.wantPath)
+			}
+		})
+	}
+}
+
+func TestResolveInferredTargetExactThenOutDirFallback(t *testing.T) {
+	root := "packages/alpha"
+	idx := buildFileIndex([]FileInfo{
+		{Path: root + "/src/index.ts", Ext: ".ts"},
+		{Path: root + "/index.ts", Ext: ".ts"},
+	}, "")
+
+	// Exact source file wins without consulting outDir.
+	direct := &jsWorkspacePackage{root: root, sourceRoot: "src", outDir: "dist"}
+	if got := direct.resolveInferredTarget("./index.ts", idx, "typescript"); len(got) != 1 || got[0] != root+"/index.ts" {
+		t.Fatalf("resolveInferredTarget exact = %v, want [%s]", got, root+"/index.ts")
+	}
+	// No exact file: fall through to the outDir -> sourceRoot mapping.
+	if got := direct.resolveInferredTarget("./dist/index.js", idx, "typescript"); len(got) != 1 || got[0] != root+"/src/index.ts" {
+		t.Fatalf("resolveInferredTarget fallback = %v, want [%s]", got, root+"/src/index.ts")
+	}
+}
+
+func TestReadPnpmWorkspaceEdgeCases(t *testing.T) {
+	root := t.TempDir()
+	if got := readPnpmWorkspace(filepath.Join(root, "missing.yaml")); got != nil {
+		t.Fatalf("missing pnpm workspace = %v, want nil", got)
+	}
+	if err := os.WriteFile(filepath.Join(root, "bad.yaml"), []byte("packages: [unclosed"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if got := readPnpmWorkspace(filepath.Join(root, "bad.yaml")); got != nil {
+		t.Fatalf("invalid yaml = %v, want nil", got)
+	}
+	if err := os.WriteFile(filepath.Join(root, "pnpm-workspace.yaml"), []byte("packages:\n  - \"packages/*\"\n  - \"!packages/skip\"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	got := readPnpmWorkspace(filepath.Join(root, "pnpm-workspace.yaml"))
+	want := []string{"packages/*", "!packages/skip"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("pnpm patterns = %v, want %v", got, want)
+	}
+}
+
+func TestCleanManifestDir(t *testing.T) {
+	tests := []struct{ in, want string }{
+		{"src", "src"},
+		{"./dist", "dist"},
+		{"", ""},
+		{"/abs/path", ""},
+		{"../up", ""},
+		{"a/../b", ""},
+		{"nested/dir", "nested/dir"},
+	}
+	for _, tt := range tests {
+		if got := cleanManifestDir(tt.in); got != tt.want {
+			t.Fatalf("cleanManifestDir(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}

--- a/scanner/jsworkspace_test.go
+++ b/scanner/jsworkspace_test.go
@@ -1,0 +1,408 @@
+package scanner
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"testing"
+)
+
+func TestBuildFileGraphResolvesPackageWorkspaces(t *testing.T) {
+	tests := []struct{ name, workspaces, memberDir string }{
+		{"node nested workspace glob", `["packages/**"]`, "packages/components/ui"},
+		{"bun workspace object", `{"packages":["modules/*"]}`, "modules/ui"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			writeWorkspaceFile(t, root, "package.json", `{"name":"workspace-root","workspaces":`+tt.workspaces+`}`)
+			writeWorkspaceFile(t, root, ".codemap/config.json", `{"only":["ts"]}`)
+			writeWorkspaceFile(t, root, tt.memberDir+"/package.json",
+				`{"name":"@acme/ui","exports":{".":"./src/index.ts","./button":"./src/button.ts","./features/*":"./src/features/*.ts"},"imports":{"#internal/*":"./src/internal/*.ts"}}`)
+			writeWorkspaceFiles(t, root,
+				"app/main.ts", "app/local.ts", tt.memberDir+"/src/index.ts", tt.memberDir+"/src/button.ts",
+				tt.memberDir+"/src/features/card.ts",
+				tt.memberDir+"/src/internal/util.ts", tt.memberDir+"/src/consumer.ts",
+			)
+			graph := buildWorkspaceGraph(t, root,
+				workspaceAnalysis("app/main.ts",
+					"@acme/ui", "@acme/ui/button", "@acme/ui/features/card", "#internal/util",
+					"node:path", "external-package", "./local",
+				),
+				workspaceAnalysis(tt.memberDir+"/src/consumer.ts", "#internal/util"),
+			)
+			assertWorkspaceImports(t, graph, "app/main.ts", []string{
+				filepath.FromSlash("app/local.ts"),
+				filepath.FromSlash(tt.memberDir + "/src/button.ts"),
+				filepath.FromSlash(tt.memberDir + "/src/features/card.ts"),
+				filepath.FromSlash(tt.memberDir + "/src/index.ts"),
+			})
+			assertWorkspaceImports(t, graph, tt.memberDir+"/src/consumer.ts", []string{
+				filepath.FromSlash(tt.memberDir + "/src/internal/util.ts"),
+			})
+		})
+	}
+}
+
+func TestBuildFileGraphResolvesDenoAndHybridWorkspaces(t *testing.T) {
+	root := t.TempDir()
+	writeWorkspaceFile(t, root, "deno.jsonc", `{
+		// URL comments and trailing commas exercise JSONC normalization.
+		"imports":{"@exact":"./lib/exact.ts","@core/":"./lib/core/","url-literal":"https://example.com/a//b"},
+		"workspace":["./members/tool","./members/hybrid"],
+	}`)
+	writeWorkspaceFile(t, root, "members/tool/deno.json",
+		`{"name":"@deno/tool","exports":"./mod.ts","imports":{"@exact":"./local.ts"}}`)
+	writeWorkspaceFile(t, root, "members/hybrid/package.json",
+		`{"name":"@hybrid/pkg","exports":{".":"./src/index.ts"}}`)
+
+	writeWorkspaceFiles(t, root,
+		"app/main.ts", "lib/exact.ts", "lib/core/util.ts",
+		"members/tool/mod.ts", "members/tool/local.ts", "members/tool/consumer.ts",
+		"members/hybrid/src/index.ts",
+	)
+
+	graph := buildWorkspaceGraph(t, root,
+		workspaceAnalysis("app/main.ts",
+			"@exact", "@core/util.ts", "@deno/tool", "@hybrid/pkg", "url-literal",
+			"npm:chalk", "jsr:@std/path", "bun:test", "node:path", "https://example.com/mod.ts",
+			"data:text/javascript,export default 1",
+		),
+		workspaceAnalysis("members/tool/consumer.ts", "@exact"),
+	)
+
+	assertWorkspaceImports(t, graph, "app/main.ts", []string{
+		filepath.FromSlash("lib/core/util.ts"),
+		filepath.FromSlash("lib/exact.ts"),
+		filepath.FromSlash("members/hybrid/src/index.ts"),
+		filepath.FromSlash("members/tool/mod.ts"),
+	})
+	assertWorkspaceImports(t, graph, "members/tool/consumer.ts", []string{
+		filepath.FromSlash("members/tool/local.ts"),
+	})
+}
+
+func TestBuildFileGraphResolvesDenoObjectWorkspaceMembers(t *testing.T) {
+	root := t.TempDir()
+	writeWorkspaceFile(t, root, "deno.json", `{"workspace":{"members":["members/tool"]}}`)
+	writeWorkspaceFile(t, root, "members/tool/deno.json", `{"name":"@deno/tool","exports":"./mod.ts"}`)
+	writeWorkspaceFiles(t, root, "app.ts", "members/tool/mod.ts")
+	graph := buildWorkspaceGraph(t, root, workspaceAnalysis("app.ts", "@deno/tool"))
+	assertWorkspaceImports(t, graph, "app.ts", []string{filepath.FromSlash("members/tool/mod.ts")})
+}
+
+func TestBuildFileGraphCombinesWorkspaceDeclarationsAtSameRoot(t *testing.T) {
+	root := t.TempDir()
+	writeWorkspaceFile(t, root, "package.json", `{"workspaces":["packages/*"]}`)
+	writeWorkspaceFile(t, root, "pnpm-workspace.yaml", "packages:\n  - \"tools/*\"\n")
+	writeWorkspaceFile(t, root, "packages/web/package.json", `{"name":"web","exports":"./index.ts"}`)
+	writeWorkspaceFile(t, root, "tools/cli/package.json", `{"name":"tooling","exports":"./index.ts"}`)
+	writeWorkspaceFiles(t, root, "app.ts", "packages/web/index.ts", "tools/cli/index.ts")
+	graph := buildWorkspaceGraph(t, root, workspaceAnalysis("app.ts", "web", "tooling"))
+	assertWorkspaceImports(t, graph, "app.ts", []string{
+		filepath.FromSlash("packages/web/index.ts"),
+		filepath.FromSlash("tools/cli/index.ts"),
+	})
+}
+
+func TestJSWorkspaceResolverUsesExplicitFilters(t *testing.T) {
+	root := t.TempDir()
+	writeWorkspaceFile(t, root, ".codemap/config.json", `{"exclude":["packages/web"]}`)
+	writeWorkspaceFile(t, root, "package.json", `{"workspaces":["packages/*"]}`)
+	writeWorkspaceFile(t, root, "packages/web/package.json", `{"name":"web","exports":"./index.ts"}`)
+	writeWorkspaceFile(t, root, "app.ts", "")
+	writeWorkspaceFile(t, root, "packages/web/index.ts", "")
+
+	graph, err := BuildFileGraphFromAnalyses(context.Background(), root, []FileAnalysis{{
+		Path: "app.ts", Language: "typescript", Imports: []string{"web"},
+	}}, Filters{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertWorkspaceImports(t, graph, "app.ts", []string{filepath.FromSlash("packages/web/index.ts")})
+}
+
+func TestJSWorkspaceResolverOnlyWidensJavaScriptScans(t *testing.T) {
+	if needsJSWorkspaceResolver([]FileAnalysis{{Path: "main.go", Language: "go"}}) {
+		t.Fatal("Go-only analysis should not widen the filtered file scan")
+	}
+	if !needsJSWorkspaceResolver([]FileAnalysis{{Path: "app.ts", Language: "typescript"}}) {
+		t.Fatal("TypeScript analysis should enable workspace manifest scanning")
+	}
+}
+
+func TestBuildJSWorkspaceResolverHonorsCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := buildJSWorkspaceResolver(ctx, t.TempDir(), nil); err != context.Canceled {
+		t.Fatalf("buildJSWorkspaceResolver() error = %v, want context.Canceled", err)
+	}
+}
+
+func TestAddJSWorkspaceMembersHonorsMidBuildCancellation(t *testing.T) {
+	ctx := &cancelAfterContext{Context: context.Background(), remaining: 1}
+	workspace := newJSPackageWorkspace("")
+	members := map[string]*jsWorkspaceManifest{
+		"a": {root: "packages/a", pkg: &jsWorkspacePackage{root: "packages/a", name: "a"}},
+		"b": {root: "packages/b", pkg: &jsWorkspacePackage{root: "packages/b", name: "b"}},
+		"c": {root: "packages/c", pkg: &jsWorkspacePackage{root: "packages/c", name: "c"}},
+	}
+	if err := addJSWorkspaceMembers(ctx, workspace, "", []string{"packages/*"}, members); err != context.Canceled {
+		t.Fatalf("addJSWorkspaceMembers() error = %v, want context.Canceled", err)
+	}
+	if len(workspace.packages) > 1 {
+		t.Fatalf("added %d packages after cancellation boundary, want at most 1", len(workspace.packages))
+	}
+}
+
+type cancelAfterContext struct {
+	context.Context
+	remaining int
+}
+
+func (c *cancelAfterContext) Err() error {
+	if c.remaining == 0 {
+		return context.Canceled
+	}
+	c.remaining--
+	return nil
+}
+
+func TestBuildFileGraphResolvesWorkspaceEntriesWithoutExports(t *testing.T) {
+	root := t.TempDir()
+	writeWorkspaceFile(t, root, "package.json", `{"workspaces":["packages/*"]}`)
+	writeWorkspaceFile(t, root, "packages/plain/package.json", `{"name":"@acme/plain","main":"src/index.ts"}`)
+	writeWorkspaceFile(t, root, "packages/conflict/package.json",
+		`{"name":"@acme/conflict","module":"src/module.ts","main":"src/main.ts"}`)
+	writeWorkspaceFiles(t, root,
+		"app/main.ts",
+		"packages/plain/src/index.ts",
+		"packages/plain/feature.ts",
+		"packages/conflict/src/module.ts",
+		"packages/conflict/src/main.ts",
+	)
+
+	graph := buildWorkspaceGraph(t, root,
+		workspaceAnalysis("app/main.ts", "@acme/plain", "@acme/plain/feature", "@acme/conflict"),
+	)
+	assertWorkspaceImports(t, graph, "app/main.ts", []string{
+		filepath.FromSlash("packages/plain/feature.ts"),
+		filepath.FromSlash("packages/plain/src/index.ts"),
+	})
+}
+
+func TestBuildFileGraphResolvesPnpmConditionalExportsToSources(t *testing.T) {
+	root := t.TempDir()
+	writeWorkspaceFile(t, root, "pnpm-workspace.yaml", "packages:\n  - packages/**\n  - '!packages/excluded'\n")
+	writeWorkspaceFile(t, root, "packages/foundation/core/package.json",
+		`{"name":"@acme/core","exports":{"./*":{"import":"./dist/*.js","types":"./dist/*.d.ts","types@>=5.0":"./dist/*.d.ts"}}}`)
+	writeWorkspaceFile(t, root, "packages/foundation/core/tsconfig.json",
+		`{"compilerOptions":{"rootDir":"src","outDir":"dist"}}`)
+	writeWorkspaceFile(t, root, "packages/ambiguous/package.json",
+		`{"name":"@acme/ambiguous","exports":{".":{"import":"./dist/import.js","require":"./dist/require.cjs"},"./array":["./dist/one.js","./dist/two.js"],"./empty":null}}`)
+	writeWorkspaceFile(t, root, "packages/ambiguous/tsconfig.json",
+		`{"compilerOptions":{"rootDir":"src","outDir":"dist"}}`)
+	writeWorkspaceFile(t, root, "packages/no-map/package.json",
+		`{"name":"@acme/no-map","exports":{"./*":{"import":"./dist/*.js"}}}`)
+	writeWorkspaceFile(t, root, "packages/excluded/package.json",
+		`{"name":"@acme/excluded","exports":"./src/index.ts"}`)
+
+	writeWorkspaceFiles(t, root,
+		"app/main.ts",
+		"packages/foundation/core/src/context.ts",
+		"packages/ambiguous/src/import.ts",
+		"packages/ambiguous/src/require.ts",
+		"packages/ambiguous/src/one.ts",
+		"packages/ambiguous/src/two.ts",
+		"packages/no-map/src/context.ts",
+		"packages/excluded/src/index.ts",
+	)
+
+	graph := buildWorkspaceGraph(t, root,
+		workspaceAnalysis("app/main.ts",
+			"@acme/core/context",
+			"@acme/ambiguous",
+			"@acme/ambiguous/array",
+			"@acme/ambiguous/empty",
+			"@acme/no-map/context",
+			"@acme/excluded",
+		),
+	)
+	assertWorkspaceImports(t, graph, "app/main.ts", []string{
+		filepath.FromSlash("packages/foundation/core/src/context.ts"),
+	})
+}
+
+func TestBuildFileGraphDoesNotLeakPackagesAcrossWorkspaceOwners(t *testing.T) {
+	root := t.TempDir()
+	writeWorkspaceFile(t, root, "one/package.json", `{"name":"one-root","workspaces":["packages/*"]}`)
+	writeWorkspaceFile(t, root, "one/packages/local/package.json", `{"name":"@acme/local","exports":"./src/index.ts"}`)
+	writeWorkspaceFile(t, root, "two/deno.json", `{"workspace":["./packages/external"]}`)
+	writeWorkspaceFile(t, root, "two/packages/external/package.json", `{"name":"@acme/external","exports":"./src/index.ts"}`)
+	writeWorkspaceFiles(t, root,
+		"one/app/main.ts",
+		"one/packages/local/src/index.ts",
+		"two/packages/external/src/index.ts",
+	)
+
+	graph := buildWorkspaceGraph(t, root,
+		workspaceAnalysis("one/app/main.ts", "@acme/local", "@acme/external"),
+	)
+	assertWorkspaceImports(t, graph, "one/app/main.ts", []string{
+		filepath.FromSlash("one/packages/local/src/index.ts"),
+	})
+}
+
+func TestBuildFileGraphAppliesOrderedWorkspacePatterns(t *testing.T) {
+	root := t.TempDir()
+	writeWorkspaceFile(t, root, "package.json", `{"workspaces":["packages/*"," !packages/private ","!packages/restored","packages/restored"]}`)
+	writeWorkspaceFile(t, root, "packages/ui/package.json", `{"name":"@acme/ui","exports":"./src/index.ts"}`)
+	writeWorkspaceFile(t, root, "packages/private/package.json", `{"name":"@acme/private","exports":"./src/index.ts"}`)
+	writeWorkspaceFile(t, root, "packages/restored/package.json", `{"name":"@acme/restored","exports":"./src/index.ts"}`)
+	writeWorkspaceFiles(t, root, "packages/ui/src/index.ts", "packages/private/src/index.ts", "packages/restored/src/index.ts")
+	writeWorkspaceFile(t, root, "app/main.ts", "")
+
+	graph := buildWorkspaceGraph(t, root, workspaceAnalysis("app/main.ts", "@acme/ui", "@acme/private", "@acme/restored"))
+	assertWorkspaceImports(t, graph, "app/main.ts", []string{
+		filepath.FromSlash("packages/restored/src/index.ts"),
+		filepath.FromSlash("packages/ui/src/index.ts"),
+	})
+}
+
+func TestValidWorkspacePatterns(t *testing.T) {
+	for pattern, want := range map[string]bool{
+		"!packages/private": true,
+		"!../outside":       false,
+		"!!packages/*":      false,
+		"!":                 false,
+		"C:/outside":        false,
+		"!C:/outside":       false,
+	} {
+		if got := validWorkspacePattern(pattern); got != want {
+			t.Errorf("validWorkspacePattern(%q) = %v, want %v", pattern, got, want)
+		}
+	}
+}
+
+func TestBuildFileGraphRejectsInvalidWorkspacePatterns(t *testing.T) {
+	root := t.TempDir()
+	writeWorkspaceFile(t, root, "package.json", `{"workspaces":["packages/*","../outside/*"]}`)
+	writeWorkspaceFile(t, root, "packages/ui/package.json", `{"name":"@acme/ui","exports":"./src/index.ts"}`)
+	writeWorkspaceFiles(t, root, "packages/ui/src/index.ts", "app/main.ts")
+	graph := buildWorkspaceGraph(t, root, workspaceAnalysis("app/main.ts", "@acme/ui"))
+	assertWorkspaceImports(t, graph, "app/main.ts", nil)
+}
+
+func TestBuildFileGraphRejectsAmbiguousOrEscapingWorkspaceTargets(t *testing.T) {
+	root := t.TempDir()
+	writeWorkspaceFile(t, root, "package.json", `{"workspaces":["packages/*"]}`)
+
+	manifests := map[string]string{
+		"packages/dup-a/package.json":        `{"name":"@acme/duplicate","exports":"./src/index.ts"}`,
+		"packages/dup-b/package.json":        `{"name":"@acme/duplicate","exports":"./src/index.ts"}`,
+		"packages/conditional/package.json":  `{"name":"@acme/conditional","exports":{".":{"import":"./src/import.ts","require":"./src/require.ts"}}}`,
+		"packages/escape/package.json":       `{"name":"@acme/escape","exports":"../outside.ts"}`,
+		"packages/unknown/package.json":      `{"name":"@acme/unknown","exports":{".":{"custom":"./src/index.ts"}}}`,
+		"packages/typesfoo/package.json":     `{"name":"@acme/typesfoo","exports":{".":{"typesfoo":"./src/index.ts","import":"./src/index.ts"}}}`,
+		"packages/declaration/package.json":  `{"name":"@acme/declaration","exports":"./src/index.d.ts"}`,
+		"packages/incompatible/package.json": `{"name":"@acme/incompatible","exports":"./src/index.go"}`,
+		"packages/implicit/package.json":     `{"name":"@acme/implicit","exports":"./src/index"}`,
+	}
+	for path, body := range manifests {
+		writeWorkspaceFile(t, root, path, body)
+	}
+	writeWorkspaceFiles(t, root,
+		"app/main.ts",
+		"outside.ts",
+		"packages/dup-a/src/index.ts",
+		"packages/dup-b/src/index.ts",
+		"packages/conditional/src/import.ts",
+		"packages/conditional/src/require.ts",
+		"packages/unknown/src/index.ts",
+		"packages/typesfoo/src/index.ts",
+		"packages/declaration/src/index.d.ts",
+		"packages/incompatible/src/index.go",
+		"packages/implicit/src/index.ts",
+	)
+
+	graph := buildWorkspaceGraph(t, root,
+		workspaceAnalysis("app/main.ts", "@acme/duplicate", "@acme/conditional", "@acme/escape", "@acme/unknown", "@acme/typesfoo", "@acme/declaration", "@acme/incompatible", "@acme/implicit"),
+	)
+	assertWorkspaceImports(t, graph, "app/main.ts", nil)
+}
+
+func TestStripJSONC(t *testing.T) {
+	input := []byte(`{
+		"url": "https://example.com/a//b",
+		"quoted": "/* not a comment */",
+		// line comment
+		"array": [1, 2,],
+		/* block
+		   comment */
+		"object": {"ok": true,},
+	}`)
+
+	got, err := stripJSONC(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := map[string]any{
+		"url":    "https://example.com/a//b",
+		"quoted": "/* not a comment */",
+		"array":  []any{float64(1), float64(2)},
+		"object": map[string]any{"ok": true},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("stripJSONC() = %#v, want %#v", got, want)
+	}
+
+	if _, err := stripJSONC([]byte(`{"value": /* unterminated`)); err == nil {
+		t.Fatal("expected unterminated block comment to fail")
+	}
+	if _, err := stripJSONC([]byte(`{"value": invalid}`)); err == nil {
+		t.Fatal("expected invalid JSON to fail")
+	}
+}
+
+func writeWorkspaceFile(t *testing.T, root, path, body string) {
+	t.Helper()
+	fullPath := filepath.Join(root, filepath.FromSlash(path))
+	if err := os.MkdirAll(filepath.Dir(fullPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(fullPath, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func writeWorkspaceFiles(t *testing.T, root string, paths ...string) {
+	t.Helper()
+	for _, path := range paths {
+		writeWorkspaceFile(t, root, path, "")
+	}
+}
+
+func workspaceAnalysis(path string, imports ...string) FileAnalysis {
+	return FileAnalysis{Path: filepath.FromSlash(path), Language: "typescript", Imports: imports}
+}
+
+func buildWorkspaceGraph(t *testing.T, root string, analyses ...FileAnalysis) *FileGraph {
+	t.Helper()
+	graph, err := BuildFileGraphFromAnalyses(context.Background(), root, analyses, Filters{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return graph
+}
+
+func assertWorkspaceImports(t *testing.T, graph *FileGraph, path string, want []string) {
+	t.Helper()
+	got := append([]string(nil), graph.Imports[filepath.FromSlash(path)]...)
+	sort.Strings(got)
+	sort.Strings(want)
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("imports[%q] = %v, want %v", path, got, want)
+	}
+}

--- a/scanner/outcome.go
+++ b/scanner/outcome.go
@@ -34,6 +34,9 @@ type GraphCoverage struct {
 }
 
 // AddSource records one scanner outcome and marks degraded results partial.
+// Only usable fallback/mixed sources promote coverage to partial; a
+// timeout/failed/unavailable source (which extracted no dependency references)
+// keeps coverage unavailable unless a usable source was already recorded.
 func (c *GraphCoverage) AddSource(outcome ScanSourceOutcome) {
 	if c == nil || outcome.Name == "" {
 		return
@@ -42,7 +45,11 @@ func (c *GraphCoverage) AddSource(outcome ScanSourceOutcome) {
 	if outcome.Status == ScanSourceAuthoritative {
 		return
 	}
-	c.Status = analysis.CoveragePartial
+	if outcome.Status == ScanSourceFallback || outcome.Status == ScanSourceMixed {
+		c.Status = analysis.CoveragePartial
+	} else if c.Status == "" {
+		c.Status = analysis.CoverageUnavailable
+	}
 	if outcome.Detail != "" {
 		c.Notes = append(c.Notes, outcome.Detail)
 	}

--- a/scanner/outcome.go
+++ b/scanner/outcome.go
@@ -34,25 +34,49 @@ type GraphCoverage struct {
 }
 
 // AddSource records one scanner outcome and marks degraded results partial.
-// Only usable fallback/mixed sources promote coverage to partial; a
+// Only usable sources (authoritative, fallback, mixed) keep coverage usable: a
 // timeout/failed/unavailable source (which extracted no dependency references)
-// keeps coverage unavailable unless a usable source was already recorded.
+// leaves the graph unavailable unless a usable source was also recorded, and an
+// authoritative source can repair an earlier degraded-only unavailable reading.
 func (c *GraphCoverage) AddSource(outcome ScanSourceOutcome) {
 	if c == nil || outcome.Name == "" {
 		return
 	}
 	c.Sources = append(c.Sources, outcome)
-	if outcome.Status == ScanSourceAuthoritative {
-		return
-	}
-	if outcome.Status == ScanSourceFallback || outcome.Status == ScanSourceMixed {
+	switch outcome.Status {
+	case ScanSourceAuthoritative:
+		// Authoritative alone keeps the default complete coverage. It cannot
+		// make coverage unavailable, so a degraded-only reading observed
+		// earlier must at least become partial once a usable source exists.
+		if c.Status == analysis.CoverageUnavailable {
+			c.Status = analysis.CoveragePartial
+		}
+	case ScanSourceFallback, ScanSourceMixed:
 		c.Status = analysis.CoveragePartial
-	} else if c.Status == "" {
-		c.Status = analysis.CoverageUnavailable
+	default:
+		// timeout/failed/unavailable extracted no dependency references; the
+		// graph is only unavailable while no usable source has been recorded.
+		if hasUsableSource(c.Sources) {
+			c.Status = analysis.CoveragePartial
+		} else {
+			c.Status = analysis.CoverageUnavailable
+		}
 	}
 	if outcome.Detail != "" {
 		c.Notes = append(c.Notes, outcome.Detail)
 	}
+}
+
+// hasUsableSource reports whether any recorded source extracted dependency
+// references (authoritative, fallback, or mixed).
+func hasUsableSource(sources []analysis.Source) bool {
+	for _, source := range sources {
+		switch source.Status {
+		case analysis.SourceAuthoritative, analysis.SourceFallback, analysis.SourceMixed:
+			return true
+		}
+	}
+	return false
 }
 
 // CoverageFromSources derives honest coverage from source capability evidence.

--- a/scanner/outcome.go
+++ b/scanner/outcome.go
@@ -1,0 +1,112 @@
+package scanner
+
+import (
+	"fmt"
+
+	"codemap/analysis"
+)
+
+// Deprecated scanner spellings are aliases, not a second provenance contract.
+// The analysis package owns the shared vocabulary; scanner consumes it.
+type ScanSourceStatus = analysis.SourceStatus
+type ScanSourceOutcome = analysis.Source
+
+const (
+	ScanSourceAuthoritative = analysis.SourceAuthoritative
+	ScanSourceMixed         = analysis.SourceMixed
+	ScanSourceFallback      = analysis.SourceFallback
+	ScanSourceTimeout       = analysis.SourceTimeout
+	ScanSourceUnavailable   = analysis.SourceUnavailable
+	ScanSourceFailed        = analysis.SourceFailed
+)
+
+// ScanOutcome contains dependency analyses and their provenance.
+type ScanOutcome struct {
+	Analyses []FileAnalysis    `json:"analyses"`
+	Sources  []analysis.Source `json:"sources,omitempty"`
+}
+
+// GraphCoverage describes graph blind spots and scanner provenance.
+type GraphCoverage struct {
+	Status  string            `json:"status,omitempty"`
+	Notes   []string          `json:"notes,omitempty"`
+	Sources []analysis.Source `json:"sources,omitempty"`
+}
+
+// AddSource records one scanner outcome and marks degraded results partial.
+func (c *GraphCoverage) AddSource(outcome ScanSourceOutcome) {
+	if c == nil || outcome.Name == "" {
+		return
+	}
+	c.Sources = append(c.Sources, outcome)
+	if outcome.Status == ScanSourceAuthoritative {
+		return
+	}
+	c.Status = "partial"
+	if outcome.Detail != "" {
+		c.Notes = append(c.Notes, outcome.Detail)
+	}
+}
+
+// CoverageFromSources derives honest coverage from source capability evidence.
+// A failed-only scan is unavailable; a usable fallback is partial; only an
+// all-authoritative set is complete.
+func CoverageFromSources(sources []analysis.Source) analysis.Coverage {
+	coverage := analysis.Coverage{Sources: append([]analysis.Source(nil), sources...), Issues: []analysis.Issue{}}
+	if len(sources) == 0 {
+		coverage.Status = analysis.CoverageUnavailable
+		return analysis.NormalizeCoverage(coverage)
+	}
+	allAuthoritative := true
+	usable := false
+	for _, source := range sources {
+		switch source.Status {
+		case analysis.SourceAuthoritative:
+			usable = true
+		case analysis.SourceFallback, analysis.SourceMixed:
+			usable = true
+			allAuthoritative = false
+		default:
+			allAuthoritative = false
+		}
+	}
+	switch {
+	case allAuthoritative:
+		coverage.Status = analysis.CoverageComplete
+	case usable:
+		coverage.Status = analysis.CoveragePartial
+	default:
+		coverage.Status = analysis.CoverageUnavailable
+	}
+	return analysis.NormalizeCoverage(coverage)
+}
+
+// IncompleteScanError prevents incomplete scanner output from looking authoritative.
+type IncompleteScanError struct {
+	Outcome ScanSourceOutcome
+	Err     error
+}
+
+func newIncompleteScanError(source string, status ScanSourceStatus, detail string, err error) error {
+	return &IncompleteScanError{
+		Outcome: analysis.Source{Name: source, Status: status, Detail: detail},
+		Err:     err,
+	}
+}
+
+func (e *IncompleteScanError) Error() string {
+	if e == nil {
+		return "incomplete dependency scan"
+	}
+	if e.Outcome.Detail != "" {
+		return e.Outcome.Detail
+	}
+	return fmt.Sprintf("%s dependency scan is %s", e.Outcome.Name, e.Outcome.Status)
+}
+
+func (e *IncompleteScanError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}

--- a/scanner/outcome.go
+++ b/scanner/outcome.go
@@ -28,9 +28,9 @@ type ScanOutcome struct {
 
 // GraphCoverage describes graph blind spots and scanner provenance.
 type GraphCoverage struct {
-	Status  string            `json:"status,omitempty"`
-	Notes   []string          `json:"notes,omitempty"`
-	Sources []analysis.Source `json:"sources,omitempty"`
+	Status  analysis.CoverageStatus `json:"status,omitempty"`
+	Notes   []string                `json:"notes,omitempty"`
+	Sources []analysis.Source       `json:"sources,omitempty"`
 }
 
 // AddSource records one scanner outcome and marks degraded results partial.
@@ -42,7 +42,7 @@ func (c *GraphCoverage) AddSource(outcome ScanSourceOutcome) {
 	if outcome.Status == ScanSourceAuthoritative {
 		return
 	}
-	c.Status = "partial"
+	c.Status = analysis.CoveragePartial
 	if outcome.Detail != "" {
 		c.Notes = append(c.Notes, outcome.Detail)
 	}

--- a/scanner/outcome_test.go
+++ b/scanner/outcome_test.go
@@ -182,3 +182,61 @@ func TestCoverageFromSourcesMatrix(t *testing.T) {
 		})
 	}
 }
+
+// Regression for PR #105: a timed-out or failed primary scan that extracted no
+// dependency references must keep graph coverage unavailable, and only a usable
+// fallback/mixed source may promote it to partial.
+func TestGraphCoverageTimeoutStaysUnavailable(t *testing.T) {
+	coverage := GraphCoverage{}
+	coverage.AddSource(ScanSourceOutcome{Name: "ast-grep", Status: ScanSourceTimeout, Detail: "30s limit hit"})
+	if got, want := coverage.Status, analysis.CoverageUnavailable; got != want {
+		t.Fatalf("timeout status = %q, want %q", got, want)
+	}
+
+	coverage.AddSource(ScanSourceOutcome{Name: "cargo-metadata", Status: ScanSourceFallback})
+	if got, want := coverage.Status, analysis.CoveragePartial; got != want {
+		t.Fatalf("status after fallback = %q, want %q", got, want)
+	}
+	if len(coverage.Notes) != 1 || coverage.Notes[0] != "30s limit hit" {
+		t.Fatalf("notes = %#v, want timeout detail only", coverage.Notes)
+	}
+}
+
+func TestGraphCoverageFailedOnlyStaysUnavailable(t *testing.T) {
+	coverage := GraphCoverage{}
+	coverage.AddSource(ScanSourceOutcome{Name: "ast-grep", Status: ScanSourceFailed, Detail: "malformed output"})
+	if got, want := coverage.Status, analysis.CoverageUnavailable; got != want {
+		t.Fatalf("failed status = %q, want %q", got, want)
+	}
+	if len(coverage.Notes) != 1 || coverage.Notes[0] != "malformed output" {
+		t.Fatalf("notes = %#v, want failed detail", coverage.Notes)
+	}
+}
+
+func TestGraphCoveragePartialNotDemotedByTimeout(t *testing.T) {
+	coverage := GraphCoverage{Status: analysis.CoveragePartial}
+	coverage.AddSource(ScanSourceOutcome{Name: "cargo-metadata", Status: ScanSourceMixed})
+	coverage.AddSource(ScanSourceOutcome{Name: "ast-grep", Status: ScanSourceTimeout})
+	if got, want := coverage.Status, analysis.CoveragePartial; got != want {
+		t.Fatalf("status = %q, want %q (usable sources must not be demoted)", got, want)
+	}
+}
+
+func TestGraphCoverageAuthoritativeLeavesStatusUnset(t *testing.T) {
+	coverage := GraphCoverage{}
+	coverage.AddSource(ScanSourceOutcome{Name: "ast-grep", Status: ScanSourceAuthoritative})
+	if coverage.Status != "" {
+		t.Fatalf("authoritative-only status = %q, want unset", coverage.Status)
+	}
+}
+
+func TestGraphCoverageUnavailableSourceStaysUnavailable(t *testing.T) {
+	coverage := GraphCoverage{}
+	coverage.AddSource(ScanSourceOutcome{Name: "ast-grep", Status: ScanSourceUnavailable, Detail: "scanner not installed"})
+	if got, want := coverage.Status, analysis.CoverageUnavailable; got != want {
+		t.Fatalf("unavailable source status = %q, want %q", got, want)
+	}
+	if len(coverage.Notes) != 1 || coverage.Notes[0] != "scanner not installed" {
+		t.Fatalf("notes = %#v, want unavailable detail", coverage.Notes)
+	}
+}

--- a/scanner/outcome_test.go
+++ b/scanner/outcome_test.go
@@ -1,0 +1,162 @@
+package scanner
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func requireSourceOutcome(t *testing.T, coverage GraphCoverage, source string) ScanSourceOutcome {
+	t.Helper()
+	for _, outcome := range coverage.Sources {
+		if outcome.Name == source {
+			return outcome
+		}
+	}
+	t.Fatalf("source %q missing from %#v", source, coverage.Sources)
+	return ScanSourceOutcome{}
+}
+
+func TestGraphCoverageSourceOutcomesPreserveSemanticCoverage(t *testing.T) {
+	coverage := GraphCoverage{Status: "partial", Notes: []string{"dynamic routes unresolved"}}
+	coverage.AddSource(ScanSourceOutcome{Name: "ast-grep", Status: ScanSourceAuthoritative})
+	coverage.AddSource(ScanSourceOutcome{Name: "cargo-metadata", Status: ScanSourceFallback, Detail: "1 of 1 Cargo manifests used fallback topology"})
+
+	if got, want := coverage.Status, "partial"; got != want {
+		t.Fatalf("status = %q, want %q", got, want)
+	}
+	if got := requireSourceOutcome(t, coverage, "ast-grep").Status; got != ScanSourceAuthoritative {
+		t.Fatalf("ast-grep status = %q", got)
+	}
+	if got := requireSourceOutcome(t, coverage, "cargo-metadata").Status; got != ScanSourceFallback {
+		t.Fatalf("cargo status = %q", got)
+	}
+	if got, want := coverage.Notes[len(coverage.Notes)-1], "1 of 1 Cargo manifests used fallback topology"; got != want {
+		t.Fatalf("last note = %q, want %q", got, want)
+	}
+}
+
+func TestScannerOutcomeGuardPaths(t *testing.T) {
+	var nilCoverage *GraphCoverage
+	nilCoverage.AddSource(ScanSourceOutcome{Name: "ignored", Status: ScanSourceFailed})
+
+	coverage := GraphCoverage{}
+	coverage.AddSource(ScanSourceOutcome{})
+	if len(coverage.Sources) != 0 {
+		t.Fatalf("empty source was recorded: %#v", coverage.Sources)
+	}
+
+	cause := errors.New("scanner failed")
+	withDetail := &IncompleteScanError{
+		Outcome: ScanSourceOutcome{Name: "scanner", Status: ScanSourceFailed, Detail: "stable detail"},
+		Err:     cause,
+	}
+	if got, want := withDetail.Error(), "stable detail"; got != want {
+		t.Fatalf("detail error = %q, want %q", got, want)
+	}
+	if !errors.Is(withDetail, cause) {
+		t.Fatal("wrapped scanner error is not discoverable")
+	}
+
+	withoutDetail := &IncompleteScanError{Outcome: ScanSourceOutcome{Name: "scanner", Status: ScanSourceFailed}}
+	if got, want := withoutDetail.Error(), "scanner dependency scan is failed"; got != want {
+		t.Fatalf("fallback error = %q, want %q", got, want)
+	}
+
+	var nilError *IncompleteScanError
+	if got, want := nilError.Error(), "incomplete dependency scan"; got != want {
+		t.Fatalf("nil error = %q, want %q", got, want)
+	}
+	if nilError.Unwrap() != nil {
+		t.Fatal("nil error unwrap must be nil")
+	}
+}
+
+func TestCargoMetadataOutcomesAndRetry(t *testing.T) {
+	root := t.TempDir()
+	writeRustCargoFixture(t, root, map[string]string{
+		"Cargo.toml": "[package]\nname = \"app\"\nversion = \"0.1.0\"\n",
+		"src/lib.rs": "pub fn call() {}\n",
+	})
+	metadata := cargoMetadataJSON(t, root, []map[string]any{cargoPackage(root, ".", "app", "app", nil)})
+	analyses := []FileAnalysis{{Path: "src/lib.rs", Language: "rust"}}
+	attempts := 0
+	loader := func(context.Context, string) ([]byte, error) {
+		attempts++
+		if attempts == 1 {
+			return []byte("{\"packages\":[]}"), nil
+		}
+		return metadata, nil
+	}
+
+	first, err := buildFileGraphFromAnalysesWithCargoMetadata(context.Background(), root, analyses, loader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := requireSourceOutcome(t, first.Coverage, "cargo-metadata").Status; got != ScanSourceFallback {
+		t.Fatalf("first status = %q, want %q", got, ScanSourceFallback)
+	}
+
+	second, err := buildFileGraphFromAnalysesWithCargoMetadata(context.Background(), root, analyses, loader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := requireSourceOutcome(t, second.Coverage, "cargo-metadata").Status; got != ScanSourceAuthoritative {
+		t.Fatalf("second status = %q, want %q", got, ScanSourceAuthoritative)
+	}
+	if attempts != 2 {
+		t.Fatalf("metadata attempts = %d, want 2", attempts)
+	}
+}
+
+func TestCargoMetadataMixedOutcome(t *testing.T) {
+	root := t.TempDir()
+	writeRustCargoFixture(t, root, map[string]string{
+		"Cargo.toml":        "[package]\nname = \"fallback\"\nversion = \"0.1.0\"\n",
+		"src/lib.rs":        "pub fn fallback() {}\n",
+		"nested/Cargo.toml": "[package]\nname = \"nested\"\nversion = \"0.1.0\"\n",
+		"nested/src/lib.rs": "pub fn nested() {}\n",
+	})
+	nestedRoot := filepath.Join(root, "nested")
+	metadata := cargoMetadataJSON(t, nestedRoot, []map[string]any{cargoPackage(root, "nested", "nested", "nested", nil)})
+	loader := func(_ context.Context, manifest string) ([]byte, error) {
+		if filepath.Clean(manifest) == filepath.Join(nestedRoot, "Cargo.toml") {
+			return metadata, nil
+		}
+		return nil, errors.New("cargo unavailable")
+	}
+	graph, err := buildFileGraphFromAnalysesWithCargoMetadata(context.Background(), root, []FileAnalysis{
+		{Path: "src/lib.rs", Language: "rust"},
+		{Path: "nested/src/lib.rs", Language: "rust"},
+	}, loader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := requireSourceOutcome(t, graph.Coverage, "cargo-metadata").Status; got != ScanSourceMixed {
+		t.Fatalf("status = %q, want %q", got, ScanSourceMixed)
+	}
+}
+
+func TestNonCargoGraphHasNoCargoOutcome(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "main.go"), []byte("package main\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	graph, err := BuildFileGraphFromOutcome(context.Background(), root, ScanOutcome{
+		Analyses: []FileAnalysis{{Path: "main.go", Language: "go"}},
+		Sources:  []ScanSourceOutcome{{Name: "ast-grep", Status: ScanSourceAuthoritative}},
+	}, Filters{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := requireSourceOutcome(t, graph.Coverage, "ast-grep").Status; got != ScanSourceAuthoritative {
+		t.Fatalf("ast-grep status = %q", got)
+	}
+	for _, outcome := range graph.Coverage.Sources {
+		if outcome.Name == "cargo-metadata" {
+			t.Fatalf("unexpected Cargo outcome: %#v", outcome)
+		}
+	}
+}

--- a/scanner/outcome_test.go
+++ b/scanner/outcome_test.go
@@ -240,3 +240,35 @@ func TestGraphCoverageUnavailableSourceStaysUnavailable(t *testing.T) {
 		t.Fatalf("notes = %#v, want unavailable detail", coverage.Notes)
 	}
 }
+
+// A usable source recorded after a degraded-only source must repair the
+// reading: coverage can never stay "unavailable" once dependency references
+// were extracted by any source.
+func TestGraphCoverageAuthoritativeRepairsUnavailable(t *testing.T) {
+	coverage := GraphCoverage{}
+	coverage.AddSource(ScanSourceOutcome{Name: "ast-grep", Status: ScanSourceTimeout, Detail: "30s limit hit"})
+	coverage.AddSource(ScanSourceOutcome{Name: "cargo-metadata", Status: ScanSourceAuthoritative})
+	if got, want := coverage.Status, analysis.CoveragePartial; got != want {
+		t.Fatalf("status after authoritative repair = %q, want %q", got, want)
+	}
+	if len(coverage.Sources) != 2 {
+		t.Fatalf("sources = %d, want 2 recorded", len(coverage.Sources))
+	}
+	if len(coverage.Notes) != 1 || coverage.Notes[0] != "30s limit hit" {
+		t.Fatalf("notes = %#v, want timeout detail only", coverage.Notes)
+	}
+}
+
+// A degraded source appended after a usable one must not mark the graph
+// unavailable: the usable source already extracted dependency references.
+func TestGraphCoverageDegradedAfterUsableKeepsPartial(t *testing.T) {
+	coverage := GraphCoverage{}
+	coverage.AddSource(ScanSourceOutcome{Name: "ast-grep", Status: ScanSourceAuthoritative})
+	coverage.AddSource(ScanSourceOutcome{Name: "cargo-metadata", Status: ScanSourceTimeout, Detail: "cargo hung"})
+	if got, want := coverage.Status, analysis.CoveragePartial; got != want {
+		t.Fatalf("status = %q, want %q", got, want)
+	}
+	if len(coverage.Notes) != 1 || coverage.Notes[0] != "cargo hung" {
+		t.Fatalf("notes = %#v, want cargo detail", coverage.Notes)
+	}
+}

--- a/scanner/outcome_test.go
+++ b/scanner/outcome_test.go
@@ -2,6 +2,8 @@ package scanner
 
 import (
 	"context"
+
+	"codemap/analysis"
 	"errors"
 	"os"
 	"path/filepath"
@@ -20,11 +22,11 @@ func requireSourceOutcome(t *testing.T, coverage GraphCoverage, source string) S
 }
 
 func TestGraphCoverageSourceOutcomesPreserveSemanticCoverage(t *testing.T) {
-	coverage := GraphCoverage{Status: "partial", Notes: []string{"dynamic routes unresolved"}}
+	coverage := GraphCoverage{Status: analysis.CoveragePartial, Notes: []string{"dynamic routes unresolved"}}
 	coverage.AddSource(ScanSourceOutcome{Name: "ast-grep", Status: ScanSourceAuthoritative})
 	coverage.AddSource(ScanSourceOutcome{Name: "cargo-metadata", Status: ScanSourceFallback, Detail: "1 of 1 Cargo manifests used fallback topology"})
 
-	if got, want := coverage.Status, "partial"; got != want {
+	if got, want := coverage.Status, analysis.CoveragePartial; got != want {
 		t.Fatalf("status = %q, want %q", got, want)
 	}
 	if got := requireSourceOutcome(t, coverage, "ast-grep").Status; got != ScanSourceAuthoritative {
@@ -158,5 +160,25 @@ func TestNonCargoGraphHasNoCargoOutcome(t *testing.T) {
 		if outcome.Name == "cargo-metadata" {
 			t.Fatalf("unexpected Cargo outcome: %#v", outcome)
 		}
+	}
+}
+
+func TestCoverageFromSourcesMatrix(t *testing.T) {
+	tests := []struct {
+		name    string
+		sources []analysis.Source
+		want    analysis.CoverageStatus
+	}{
+		{"empty", nil, analysis.CoverageUnavailable},
+		{"authoritative", []analysis.Source{{Name: "ast-grep", Status: analysis.SourceAuthoritative}}, analysis.CoverageComplete},
+		{"fallback", []analysis.Source{{Name: "ast-grep", Status: analysis.SourceFallback}}, analysis.CoveragePartial},
+		{"timeout", []analysis.Source{{Name: "ast-grep", Status: analysis.SourceTimeout}}, analysis.CoverageUnavailable},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := CoverageFromSources(tt.sources).Status; got != tt.want {
+				t.Fatalf("CoverageFromSources(%v) = %q, want %q", tt.sources, got, tt.want)
+			}
+		})
 	}
 }

--- a/scanner/rustcargo.go
+++ b/scanner/rustcargo.go
@@ -3,6 +3,7 @@ package scanner
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -74,10 +75,15 @@ func parseCargoMetadata(data []byte) (cargoMetadata, error) {
 	return metadata, err
 }
 
-func buildRustWorkspaceIndex(ctx context.Context, root string, analyses []FileAnalysis, files []FileInfo, loader cargoMetadataLoader) *rustWorkspaceIndex {
+func buildRustWorkspaceIndex(ctx context.Context, root string, analyses []FileAnalysis, files []FileInfo, loader cargoMetadataLoader) (*rustWorkspaceIndex, *ScanSourceOutcome) {
 	index := buildRustFallbackWorkspaceIndex(root, analyses)
+	manifestPaths := discoverCargoManifests(root, files)
+	if len(manifestPaths) == 0 {
+		return index, nil
+	}
 	if loader == nil {
-		return index
+		outcome := cargoMetadataOutcome(0, len(manifestPaths))
+		return index, &outcome
 	}
 	ctx, cancel := context.WithTimeout(ctx, cargoMetadataTimeout)
 	defer cancel()
@@ -89,7 +95,7 @@ func buildRustWorkspaceIndex(ctx context.Context, root string, analyses []FileAn
 	pendingByRoot := make(map[string][]pendingRustDependency)
 	handledManifests := make(map[string]bool)
 
-	for _, manifestPath := range discoverCargoManifests(root, files) {
+	for _, manifestPath := range manifestPaths {
 		manifestPath = filepath.Clean(manifestPath)
 		if handledManifests[manifestPath] {
 			continue
@@ -103,15 +109,19 @@ func buildRustWorkspaceIndex(ctx context.Context, root string, analyses []FileAn
 			continue
 		}
 
-		handledManifests[manifestPath] = true
+		covered := false
 		for _, metadataPackage := range metadata.Packages {
 			pkg, pending, ok := rustPackageFromCargoMetadata(root, metadataPackage)
-			if !ok {
+			if !ok || (pkg.lib == nil && len(pkg.targets) == 0) {
 				continue
 			}
+			covered = true
 			packagesByRoot[pkg.root] = pkg
 			pendingByRoot[pkg.root] = pending
 			handledManifests[filepath.Clean(metadataPackage.ManifestPath)] = true
+		}
+		if covered {
+			handledManifests[manifestPath] = true
 		}
 	}
 
@@ -152,7 +162,29 @@ func buildRustWorkspaceIndex(ctx context.Context, root string, analyses []FileAn
 		}
 		return len(index.packages[i].root) > len(index.packages[j].root)
 	})
-	return index
+
+	handled := 0
+	for _, manifestPath := range manifestPaths {
+		if handledManifests[filepath.Clean(manifestPath)] {
+			handled++
+		}
+	}
+	outcome := cargoMetadataOutcome(handled, len(manifestPaths))
+	return index, &outcome
+}
+
+func cargoMetadataOutcome(handled, total int) ScanSourceOutcome {
+	outcome := ScanSourceOutcome{Name: "cargo-metadata", Status: ScanSourceAuthoritative}
+	fallbacks := total - handled
+	if fallbacks <= 0 {
+		return outcome
+	}
+	outcome.Status = ScanSourceMixed
+	if handled == 0 {
+		outcome.Status = ScanSourceFallback
+	}
+	outcome.Detail = fmt.Sprintf("%d of %d Cargo manifests used fallback topology", fallbacks, total)
+	return outcome
 }
 
 func discoverCargoManifests(root string, files []FileInfo) []string {

--- a/scanner/rustgraph.go
+++ b/scanner/rustgraph.go
@@ -10,8 +10,7 @@ import (
 )
 
 const (
-	rustCoverageStatus = "partial"
-	rustCoverageNote   = "Rust macro-generated, string-routed, and #[path] module edges may be unresolved"
+	rustCoverageNote = "Rust macro-generated, string-routed, and #[path] module edges may be unresolved"
 
 	rustTargetLib         = "lib"
 	rustTargetBin         = "bin"
@@ -20,12 +19,6 @@ const (
 	rustTargetBench       = "bench"
 	rustTargetCustomBuild = "custom-build"
 )
-
-// GraphCoverage describes known dependency-graph blind spots.
-type GraphCoverage struct {
-	Status string   `json:"status,omitempty"`
-	Notes  []string `json:"notes,omitempty"`
-}
 
 type rustTarget struct {
 	rootFile  string

--- a/scanner/types.go
+++ b/scanner/types.go
@@ -61,7 +61,11 @@ type DepsProject struct {
 	DiffRef       string              `json:"diff_ref,omitempty"`
 }
 
-func NewDepsProject(root string, files []FileAnalysis, externalDeps map[string][]string, diffRef string, inventory ...[]FileInfo) DepsProject {
+// newDepsProject builds a DepsProject with default coverage derived from the
+// analyses and inventory (Rust repos are partial). Production callers pass
+// explicit graph-derived coverage via NewDepsProjectWithCoverage; this default
+// constructor is kept for the determinism and Rust-coverage tests.
+func newDepsProject(root string, files []FileAnalysis, externalDeps map[string][]string, diffRef string, inventory ...[]FileInfo) DepsProject {
 	coverage := analysis.Coverage{
 		Status:  analysis.CoverageComplete,
 		Sources: []analysis.Source{{Name: "ast-grep", Status: analysis.SourceAuthoritative}},

--- a/scanner/types.go
+++ b/scanner/types.go
@@ -2,8 +2,11 @@ package scanner
 
 import (
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
+
+	"codemap/analysis"
 )
 
 // FileInfo represents a single file in the codebase.
@@ -49,11 +52,83 @@ type ImportReference struct {
 
 // DepsProject is the JSON output for --deps mode.
 type DepsProject struct {
-	Root         string              `json:"root"`
-	Mode         string              `json:"mode"`
-	Files        []FileAnalysis      `json:"files"`
-	ExternalDeps map[string][]string `json:"external_deps"`
-	DiffRef      string              `json:"diff_ref,omitempty"`
+	SchemaVersion string              `json:"schema_version"`
+	Coverage      analysis.Coverage   `json:"coverage"`
+	Root          string              `json:"root"`
+	Mode          string              `json:"mode"`
+	Files         []FileAnalysis      `json:"files"`
+	ExternalDeps  map[string][]string `json:"external_deps"`
+	DiffRef       string              `json:"diff_ref,omitempty"`
+}
+
+func NewDepsProject(root string, files []FileAnalysis, externalDeps map[string][]string, diffRef string, inventory ...[]FileInfo) DepsProject {
+	coverage := analysis.Coverage{
+		Status:  analysis.CoverageComplete,
+		Sources: []analysis.Source{{Name: "ast-grep", Status: analysis.SourceAuthoritative}},
+	}
+	for _, file := range files {
+		if file.Language == "rust" || DetectLanguage(file.Path) == "rust" {
+			coverage.Status = analysis.CoveragePartial
+			coverage.Sources[0].Detail = rustCoverageNote
+			break
+		}
+	}
+	if coverage.Status == analysis.CoverageComplete && len(inventory) > 0 {
+		for _, file := range inventory[0] {
+			if DetectLanguage(file.Path) == "rust" {
+				coverage.Status = analysis.CoveragePartial
+				coverage.Sources[0].Detail = rustCoverageNote
+				break
+			}
+		}
+	}
+	return NewDepsProjectWithCoverage(root, files, externalDeps, diffRef, coverage)
+}
+
+// NewDepsProjectWithCoverage builds a normalized DepsProject with caller-provided
+// provenance coverage, so degraded scans stay honest in the output.
+func NewDepsProjectWithCoverage(root string, files []FileAnalysis, externalDeps map[string][]string, diffRef string, coverage analysis.Coverage) DepsProject {
+	files = slices.Clone(files)
+	if files == nil {
+		files = []FileAnalysis{}
+	}
+	for index := range files {
+		files[index].Functions = slices.Clone(files[index].Functions)
+		if files[index].Functions == nil {
+			files[index].Functions = []string{}
+		}
+		files[index].Imports = slices.Clone(files[index].Imports)
+		if files[index].Imports == nil {
+			files[index].Imports = []string{}
+		}
+		slices.Sort(files[index].Functions)
+		slices.Sort(files[index].Imports)
+	}
+	sort.Slice(files, func(i, j int) bool {
+		if files[i].Path != files[j].Path {
+			return files[i].Path < files[j].Path
+		}
+		if files[i].Language != files[j].Language {
+			return files[i].Language < files[j].Language
+		}
+		if order := slices.Compare(files[i].Functions, files[j].Functions); order != 0 {
+			return order < 0
+		}
+		return slices.Compare(files[i].Imports, files[j].Imports) < 0
+	})
+	deps := make(map[string][]string, len(externalDeps))
+	for language, values := range externalDeps {
+		deps[language] = slices.Clone(values)
+		if deps[language] == nil {
+			deps[language] = []string{}
+		}
+		slices.Sort(deps[language])
+	}
+	return DepsProject{
+		SchemaVersion: analysis.SchemaVersion,
+		Coverage:      analysis.NormalizeCoverage(coverage),
+		Root:          root, Mode: "deps", Files: files, ExternalDeps: deps, DiffRef: diffRef,
+	}
 }
 
 // ImportersReport is the JSON output for --importers mode.

--- a/scanner/walker.go
+++ b/scanner/walker.go
@@ -336,11 +336,6 @@ func ScanConfiguredFiles(ctx context.Context, root string, cache *GitIgnoreCache
 	return configured, nil
 }
 
-func filterAnalyses(analyses []FileAnalysis, filters Filters) []FileAnalysis {
-	filtered, _ := filterAnalysesContext(context.Background(), analyses, filters)
-	return filtered
-}
-
 func filterAnalysesContext(ctx context.Context, analyses []FileAnalysis, filters Filters) ([]FileAnalysis, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
@@ -364,7 +359,8 @@ func filterAnalysesContext(ctx context.Context, analyses []FileAnalysis, filters
 
 func filterConfiguredAnalyses(root string, analyses []FileAnalysis) []FileAnalysis {
 	cfg := config.Load(root)
-	return filterAnalyses(analyses, Filters{Only: cfg.Only, Exclude: cfg.Exclude})
+	filtered, _ := filterAnalysesContext(context.Background(), analyses, Filters{Only: cfg.Only, Exclude: cfg.Exclude})
+	return filtered
 }
 
 // ScanForDeps performs dependency analysis with explicit filters, provenance,

--- a/scanner/walker.go
+++ b/scanner/walker.go
@@ -2,6 +2,7 @@ package scanner
 
 import (
 	"bufio"
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -222,15 +223,21 @@ func LoadGitignore(root string) *ignore.GitIgnore {
 	return nil
 }
 
-// ScanFiles walks the directory tree and returns all files.
-// Supports nested .gitignore files via GitIgnoreCache.
+// ScanFiles walks the directory tree and returns all files while honoring
+// caller cancellation. Supports nested .gitignore files via GitIgnoreCache.
 // only: list of extensions to include (empty = all)
 // exclude: list of patterns to exclude
-func ScanFiles(root string, cache *GitIgnoreCache, only []string, exclude []string) ([]FileInfo, error) {
+func ScanFiles(ctx context.Context, root string, cache *GitIgnoreCache, only []string, exclude []string) ([]FileInfo, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	var files []FileInfo
 	absRoot, _ := filepath.Abs(root)
 
 	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
 		if err != nil {
 			return err
 		}
@@ -290,6 +297,9 @@ func ScanFiles(root string, cache *GitIgnoreCache, only []string, exclude []stri
 
 		return nil
 	})
+	if err == nil {
+		err = ctx.Err()
+	}
 
 	return files, err
 }
@@ -300,10 +310,20 @@ type Filters struct {
 	Exclude []string
 }
 
-// ScanConfiguredFiles scans using the active setup root's project filters.
-func ScanConfiguredFiles(root string, cache *GitIgnoreCache) ([]FileInfo, error) {
+// ConfiguredFilters returns the project's configured dependency filters.
+func ConfiguredFilters(root string) Filters {
 	cfg := config.Load(root)
-	files, err := ScanFiles(root, cache, cfg.Only, cfg.Exclude)
+	return Filters{Only: cfg.Only, Exclude: cfg.Exclude}
+}
+
+// ScanConfiguredFiles scans using the active setup root's project filters
+// while honoring caller cancellation.
+func ScanConfiguredFiles(ctx context.Context, root string, cache *GitIgnoreCache) ([]FileInfo, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	cfg := config.Load(root)
+	files, err := ScanFiles(ctx, root, cache, cfg.Only, cfg.Exclude)
 	if err != nil {
 		return nil, err
 	}
@@ -317,18 +337,29 @@ func ScanConfiguredFiles(root string, cache *GitIgnoreCache) ([]FileInfo, error)
 }
 
 func filterAnalyses(analyses []FileAnalysis, filters Filters) []FileAnalysis {
+	filtered, _ := filterAnalysesContext(context.Background(), analyses, filters)
+	return filtered
+}
+
+func filterAnalysesContext(ctx context.Context, analyses []FileAnalysis, filters Filters) ([]FileAnalysis, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	if len(filters.Only) == 0 && len(filters.Exclude) == 0 {
-		return analyses
+		return analyses, ctx.Err()
 	}
 
 	filtered := make([]FileAnalysis, 0, len(analyses))
 	for _, analysis := range analyses {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		path := filepath.ToSlash(analysis.Path)
 		if MatchesFilters(path, filepath.Ext(path), filters.Only, filters.Exclude) {
 			filtered = append(filtered, analysis)
 		}
 	}
-	return filtered
+	return filtered, ctx.Err()
 }
 
 func filterConfiguredAnalyses(root string, analyses []FileAnalysis) []FileAnalysis {
@@ -336,27 +367,25 @@ func filterConfiguredAnalyses(root string, analyses []FileAnalysis) []FileAnalys
 	return filterAnalyses(analyses, Filters{Only: cfg.Only, Exclude: cfg.Exclude})
 }
 
-// ScanForDeps uses the configured project filters for batched dependency analysis.
-func ScanForDeps(root string) ([]FileAnalysis, error) {
-	cfg := config.Load(root)
-	return ScanForDepsWithFilters(root, Filters{Only: cfg.Only, Exclude: cfg.Exclude})
-}
-
-// ScanForDepsWithFilters uses ast-grep for batched dependency analysis with explicit filters.
-func ScanForDepsWithFilters(root string, filters Filters) ([]FileAnalysis, error) {
+// ScanForDeps performs dependency analysis with explicit filters, provenance,
+// and caller cancellation.
+func ScanForDeps(ctx context.Context, root string, filters Filters) (ScanOutcome, error) {
+	if err := ctx.Err(); err != nil {
+		return ScanOutcome{}, err
+	}
 	astScanner, err := NewAstGrepScanner()
 	if err != nil {
-		return nil, err
+		return ScanOutcome{}, err
 	}
 	defer astScanner.Close()
 
-	if !astScanner.Available() {
-		return nil, ErrAstGrepNotFound
-	}
-
-	analyses, err := astScanner.ScanDirectory(root)
+	outcome, err := astScanner.ScanDirectory(ctx, root)
 	if err != nil {
-		return nil, err
+		return ScanOutcome{}, err
 	}
-	return filterAnalyses(analyses, filters), nil
+	outcome.Analyses, err = filterAnalysesContext(ctx, outcome.Analyses, filters)
+	if err != nil {
+		return ScanOutcome{}, err
+	}
+	return outcome, nil
 }

--- a/scanner/walker_test.go
+++ b/scanner/walker_test.go
@@ -2,6 +2,7 @@ package scanner
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -790,5 +791,58 @@ func TestScanFilesWithOnlyAndExcludeFilters(t *testing.T) {
 	want := []string{"cmd/main.go"}
 	if !reflect.DeepEqual(paths, want) {
 		t.Fatalf("expected %v, got %v", want, paths)
+	}
+}
+
+func TestScanConfiguredFilesExcludesCodemapState(t *testing.T) {
+	root := t.TempDir()
+	for path, content := range map[string]string{
+		"main.go":             "package main\n",
+		".codemap/state.json": "{}",
+		"pkg/util.go":         "package pkg\n",
+	} {
+		full := filepath.Join(root, filepath.FromSlash(path))
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	files, err := ScanConfiguredFiles(context.Background(), root, NewGitIgnoreCache(root))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var paths []string
+	for _, f := range files {
+		paths = append(paths, filepath.ToSlash(f.Path))
+	}
+	want := []string{"main.go", "pkg/util.go"}
+	if !reflect.DeepEqual(paths, want) {
+		t.Fatalf("configured files = %v, want %v (no .codemap entries)", paths, want)
+	}
+}
+
+func TestFilterAnalysesContextBranches(t *testing.T) {
+	analyses := []FileAnalysis{
+		{Path: "a.go", Language: "go"},
+		{Path: "b.py", Language: "python"},
+	}
+	// No filters: analyses pass through unchanged.
+	got, err := filterAnalysesContext(context.Background(), analyses, Filters{})
+	if err != nil || len(got) != 2 {
+		t.Fatalf("empty filters = %d analyses, err %v, want passthrough", len(got), err)
+	}
+	// Only filter keeps only Go files.
+	got, err = filterAnalysesContext(context.Background(), analyses, Filters{Only: []string{"go"}})
+	if err != nil || len(got) != 1 || got[0].Path != "a.go" {
+		t.Fatalf("only-go filter = %v, err %v, want [a.go]", got, err)
+	}
+	// Pre-cancelled context fails closed with the context error.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := filterAnalysesContext(ctx, analyses, Filters{}); !errors.Is(err, context.Canceled) {
+		t.Fatalf("cancelled filter error = %v, want context.Canceled", err)
 	}
 }

--- a/scanner/walker_test.go
+++ b/scanner/walker_test.go
@@ -1,6 +1,7 @@
 package scanner
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -58,7 +59,7 @@ func TestScanFiles(t *testing.T) {
 	}
 
 	// Scan the directory
-	result, err := ScanFiles(tmpDir, nil, nil, nil)
+	result, err := ScanFiles(context.Background(), tmpDir, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("ScanFiles failed: %v", err)
 	}
@@ -89,7 +90,7 @@ func TestScanFilesIgnoresDirs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	result, err := ScanFiles(tmpDir, nil, nil, nil)
+	result, err := ScanFiles(context.Background(), tmpDir, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("ScanFiles failed: %v", err)
 	}
@@ -123,7 +124,7 @@ func TestScanFilesExtensions(t *testing.T) {
 		}
 	}
 
-	result, err := ScanFiles(tmpDir, nil, nil, nil)
+	result, err := ScanFiles(context.Background(), tmpDir, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -294,7 +295,7 @@ func TestNestedGitignore(t *testing.T) {
 
 	// Scan with GitIgnoreCache
 	cache := NewGitIgnoreCache(tmpDir)
-	files, err := ScanFiles(tmpDir, cache, nil, nil)
+	files, err := ScanFiles(context.Background(), tmpDir, cache, nil, nil)
 	if err != nil {
 		t.Fatalf("ScanFiles failed: %v", err)
 	}
@@ -337,7 +338,7 @@ func TestGitIgnoreCacheNil(t *testing.T) {
 	}
 
 	// Scan without gitignore cache
-	files, err := ScanFiles(tmpDir, nil, nil, nil)
+	files, err := ScanFiles(context.Background(), tmpDir, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("ScanFiles failed: %v", err)
 	}
@@ -435,7 +436,7 @@ func TestNestedGitignoreMonorepo(t *testing.T) {
 
 	// Scan with GitIgnoreCache
 	cache := NewGitIgnoreCache(tmpDir)
-	files, err := ScanFiles(tmpDir, cache, nil, nil)
+	files, err := ScanFiles(context.Background(), tmpDir, cache, nil, nil)
 	if err != nil {
 		t.Fatalf("ScanFiles failed: %v", err)
 	}
@@ -482,7 +483,7 @@ func TestNestedGitignoreUnignore(t *testing.T) {
 	os.WriteFile(filepath.Join(tmpDir, "sub", "other.log"), []byte("other"), 0644)
 
 	cache := NewGitIgnoreCache(tmpDir)
-	files, err := ScanFiles(tmpDir, cache, nil, nil)
+	files, err := ScanFiles(context.Background(), tmpDir, cache, nil, nil)
 	if err != nil {
 		t.Fatalf("ScanFiles failed: %v", err)
 	}
@@ -539,7 +540,7 @@ func TestNestedGitignoreDirectoryIgnore(t *testing.T) {
 	}
 
 	cache := NewGitIgnoreCache(tmpDir)
-	files, err := ScanFiles(tmpDir, cache, nil, nil)
+	files, err := ScanFiles(context.Background(), tmpDir, cache, nil, nil)
 	if err != nil {
 		t.Fatalf("ScanFiles failed: %v", err)
 	}
@@ -775,7 +776,7 @@ func TestScanFilesWithOnlyAndExcludeFilters(t *testing.T) {
 		}
 	}
 
-	got, err := ScanFiles(tmpDir, nil, []string{"go"}, []string{"*_test.go"})
+	got, err := ScanFiles(context.Background(), tmpDir, nil, []string{"go"}, []string{"*_test.go"})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/watch/daemon.go
+++ b/watch/daemon.go
@@ -2,6 +2,7 @@
 package watch
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -173,11 +174,11 @@ func (d *Daemon) WriteInitialState() {
 func (d *Daemon) fullScan() error {
 	start := time.Now()
 
-	files, err := scanner.ScanFiles(d.root, d.gitCache, nil, nil)
+	files, err := scanner.ScanFiles(context.Background(), d.root, d.gitCache, nil, nil)
 	if err != nil {
 		return err
 	}
-	configuredFiles, err := scanner.ScanConfiguredFiles(d.root, d.gitCache)
+	configuredFiles, err := scanner.ScanConfiguredFiles(context.Background(), d.root, d.gitCache)
 	if err != nil {
 		return err
 	}
@@ -222,7 +223,7 @@ func (d *Daemon) refreshConfiguredFiles(resetIgnoreCache bool) error {
 		gitCache = scanner.NewGitIgnoreCache(d.root)
 		d.gitCache = gitCache
 	}
-	files, err := scanner.ScanConfiguredFiles(d.root, gitCache)
+	files, err := scanner.ScanConfiguredFiles(context.Background(), d.root, gitCache)
 	if err != nil {
 		return err
 	}
@@ -254,7 +255,7 @@ func (d *Daemon) computeDeps() {
 	start := time.Now()
 
 	// Build file graph (internal file-to-file dependencies)
-	fg, err := scanner.BuildFileGraph(d.root)
+	fg, err := scanner.BuildFileGraph(context.Background(), d.root, scanner.ConfiguredFilters(d.root))
 	if err != nil {
 		if d.verbose {
 			fmt.Printf("[watch] File graph unavailable: %v\n", err)

--- a/watch/watch_test.go
+++ b/watch/watch_test.go
@@ -285,7 +285,6 @@ func TestDebounce(t *testing.T) {
 		if err := os.WriteFile(testFile, content, 0644); err != nil {
 			t.Fatalf("Failed to modify file: %v", err)
 		}
-		time.Sleep(20 * time.Millisecond) // 20ms < 100ms debounce window
 	}
 
 	time.Sleep(300 * time.Millisecond)


### PR DESCRIPTION
## What does this PR do?

Bundles four related behavior changes that touch the same scan paths, and settles three contracts for how the scanner reports provenance:

- fix(mcp): Bound cancellable project scans — propagates request cancellation through scanner, Git, handoff, and MCP traversals, and bounds project and manifest discovery.
- feat(analysis): Add structured dependency contract — adds versioned, deterministic dependency JSON and MCP structured output for agentic coding in isolated worktrees and restricted sandboxes while preserving the existing text response; coverage remains explicit, including known partial Rust analysis.
- feat(scanner): Fail closed and report fallback provenance — prevents failed, timed-out, or unavailable ast-grep scans from appearing complete, and carries Cargo metadata fallback provenance through file graphs.
- feat(scanner): Resolve JS/TS workspace imports — resolves local JS/TS imports from package, pnpm, Bun, and Deno workspace manifests; ambiguous, external, escaping, and unsupported targets remain unresolved.

## The three contracts this change settles

### 1. One provenance vocabulary

`analysis` owns the shared contract (`analysis.SourceStatus`, `analysis.Source`, `analysis.Coverage`, `analysis.NormalizeCoverage`); the scanner consumes it rather than defining a parallel copy.
The byte-identical `scanner.ScanSourceStatus`/`ScanSourceOutcome` duplicate is gone — what remains are aliases (`type ScanSourceStatus = analysis.SourceStatus`, `type ScanSourceOutcome = analysis.Source`), so there is exactly one enum and one struct in the binary.
Cargo-metadata and the new `rust-cargo` (mixed) source feed the same `analysis.Source` list.

### 2. One scanner entry point

`ScanForDeps(ctx, root, filters) (ScanOutcome, error)` collapses the WithFilters × Context × Outcome axes.
All retired compatibility twins were removed (`ScanForDepsContext`, `ScanForDepsWithFilters`, `ScanForDepsOutcome*`, `BuildFileGraphContext`, `BuildFileGraphWithFilters*`, `BuildFileGraphFrom*Context/FilteredAnalyses/OutcomeWithFilters`, `ScanDirectoryContext/Outcome`, `ScanConfiguredFilesContext`, `ScanFilesContext`, `ReadExternalDepsContext`, `GitDiffInfoContext`, `GitDiffFiles*`, `AnalyzeImpactContext`, `DependencyCoverageContext`, `HasConfiguredLanguageContext`).
`codemap` has no external importers, so the compatibility surface was dropped rather than preserved; all callers (CLI, MCP, handoff, blast-radius, watch, render, cmd) were updated to the single API, and ctx is threaded through every subprocess-bounded path.

### 3. Fail-closed without losing the degraded path

A timed-out or failed ast-grep scan now fails closed to an honest, usable answer instead of a hard error:

- `ScanOutcome{Analyses: nil, Sources: [{name: "ast-grep", status: timeout|failed, detail}]}` is returned with a nil error, so hooks (which run codemap on every edit) and MCP keep a usable empty answer on exactly the large repos where a 30s timeout fires — previously that was a hard error.
- A genuinely unavailable scanner (ast-grep not installed) still returns `ErrAstGrepNotFound` wrapped in `IncompleteScanError`, so setup problems stay visible.
- Deps coverage (`--deps --json`, MCP `get_dependencies`) is derived from the graph's source provenance via `CoverageFromSources`, so a degraded scan is observable in the output (`unavailable`/`partial`) instead of silently looking complete; Rust repos report `partial` through the `rust-cargo` mixed source, and cargo-metadata fallback provenance is surfaced the same way.

## CLI / MCP surface

No new CLI commands or arguments, and no new MCP tools — the MCP tool set is unchanged (15 tools; `get_dependencies` merely gains an `OutputSchema`).
The changes affect the output and behavior of existing commands:

- `codemap --json --deps .` output gains `schema_version` and `coverage` (deterministic, versioned shape; MCP `get_dependencies` returns the same as structured content).
- `codemap --deps <path>` resolves local JS/TS imports from package, pnpm, Bun, and Deno workspace manifests.
- Failed or timed-out scans degrade to an empty outcome with `Sources` provenance instead of a hard error.
- Scan, Git, handoff, and MCP traversals honor request cancellation.

Developed with carefully directed, manually reviewed AI assistance.

Co-Authored-By: GPT-5.6 Sol <codex@openai.com>