### PR TITLE
fix(scanner): Keep ast-grep authoritative, dedupe coverage notes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ __pycache__/
 
 # Runtime state
 .codemap/
+.cache/
 /codemap-dev
 /dev_codemap
 /bundled-tools/

--- a/render/depgraph.go
+++ b/render/depgraph.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"sort"
 	"strings"
 	"unicode"
@@ -381,7 +382,10 @@ func renderCoverageLine(w io.Writer, coverage analysis.Coverage) {
 	}
 	var details []string
 	for _, source := range coverage.Sources {
-		if source.Detail != "" {
+		// Sources are normalized (sorted, deduped by name/status/detail), but
+		// two distinct sources can still carry the same caveat; render each
+		// detail once so the warning is not doubled.
+		if source.Detail != "" && !slices.Contains(details, source.Detail) {
 			details = append(details, source.Detail)
 		}
 	}

--- a/render/depgraph.go
+++ b/render/depgraph.go
@@ -382,9 +382,9 @@ func renderCoverageLine(w io.Writer, coverage analysis.Coverage) {
 	}
 	var details []string
 	for _, source := range coverage.Sources {
-		// Sources are normalized (sorted, deduped by name/status/detail), but
-		// two distinct sources can still carry the same caveat; render each
-		// detail once so the warning is not doubled.
+		// NormalizeCoverage sorts Sources by name/status/detail but does not
+		// deduplicate them; two distinct sources can still carry the same
+		// caveat, so render each detail once to keep the warning single.
 		if source.Detail != "" && !slices.Contains(details, source.Detail) {
 			details = append(details, source.Detail)
 		}

--- a/render/depgraph_test.go
+++ b/render/depgraph_test.go
@@ -277,3 +277,33 @@ func TestDepgraphRendersPartialCoverageWithoutDetail(t *testing.T) {
 		t.Fatalf("expected bare partial coverage line, got:\n%s", buf.String())
 	}
 }
+
+// Regression for PR #105 follow-up: two sources carrying the same caveat (the
+// shared Rust resolution note) must render that detail once, not doubled — a
+// timed-out/partial scan should read as one warning, not two.
+func TestDepgraphRendersSharedCoverageDetailOnce(t *testing.T) {
+	root := t.TempDir()
+	writeDepgraphFile(t, root, "main.go", "package main\n")
+	project := scanner.DepsProject{
+		Root:  root,
+		Files: []scanner.FileAnalysis{{Path: "main.go", Language: "go", Functions: []string{"main"}}},
+		Coverage: analysis.Coverage{
+			Status: analysis.CoveragePartial,
+			Sources: []analysis.Source{
+				{Name: "ast-grep", Status: analysis.SourceAuthoritative},
+				{Name: "rust-cargo", Status: analysis.SourceMixed, Detail: "Rust dependency resolution is partial"},
+				{Name: "cargo-metadata", Status: analysis.SourceMixed, Detail: "Rust dependency resolution is partial"},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	Depgraph(context.Background(), &buf, project)
+	output := buf.String()
+	if got := strings.Count(output, "Rust dependency resolution is partial"); got != 1 {
+		t.Fatalf("shared detail rendered %d times, want 1:\n%s", got, output)
+	}
+	if !strings.Contains(output, "Coverage: partial") {
+		t.Fatalf("expected partial coverage line, got:\n%s", output)
+	}
+}

--- a/scanner/astgrep.go
+++ b/scanner/astgrep.go
@@ -223,17 +223,15 @@ func (s *AstGrepScanner) ScanDirectory(parent context.Context, root string) (Sca
 		}
 		return ScanOutcome{}, err
 	}
-	source := analysis.Source{Name: "ast-grep", Status: analysis.SourceAuthoritative}
-	for _, fileAnalysis := range analyses {
-		if DetectLanguage(fileAnalysis.Path) == "rust" {
-			source.Status = analysis.SourceMixed
-			source.Detail = rustCoverageNote
-			break
-		}
-	}
+	// ast-grep extraction is authoritative regardless of language: it scanned
+	// the files and reported every reference it found. The Rust caveat
+	// (macro-generated, string-routed, and #[path] edges) is a *resolution*
+	// gap owned by rust-cargo, which the file graph records separately; labeling
+	// ast-grep mixed here would degrade a Go+Rust monorepo's Go analysis and
+	// duplicate the same caveat on two sources.
 	return ScanOutcome{
 		Analyses: analyses,
-		Sources:  []analysis.Source{source},
+		Sources:  []analysis.Source{{Name: "ast-grep", Status: analysis.SourceAuthoritative}},
 	}, nil
 }
 

--- a/scanner/astgrep_test.go
+++ b/scanner/astgrep_test.go
@@ -319,6 +319,51 @@ func TestAstGrepScanDirectoryUnavailableIsIncomplete(t *testing.T) {
 	}
 }
 
+// Regression for PR #105 follow-up: ast-grep extraction is authoritative even
+// when the scan contains Rust files. The Rust caveat (macro-generated,
+// string-routed, #[path] edges) is a *resolution* gap owned by rust-cargo, so
+// ast-grep must not be demoted to mixed with a Rust-specific detail — doing so
+// degrades a Go+Rust monorepo's Go analysis and duplicates the caveat.
+func TestAstGrepScanDirectoryRustStaysAuthoritative(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("requires shell script execution")
+	}
+
+	tmpDir := t.TempDir()
+	rootDir := filepath.Join(tmpDir, "repo")
+	if err := os.MkdirAll(filepath.Join(rootDir, "src"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	fakeBinary := filepath.Join(tmpDir, "fake-sg.sh")
+	// Emit a successful scan whose only analysis is a Rust file.
+	match := `[{"file":"` + filepath.Join(rootDir, "src", "lib.rs") +
+		`","ruleId":"rust-use-imports","range":{"start":{"line":1,"column":1}}` +
+		`,"text":"use std::collections::HashMap;","metaVariables":{"single":{"PATH":{"text":"std::collections::HashMap"}}}}]`
+	script := "#!/bin/sh\nprintf '%s\\n' '" + match + "'\n"
+	if err := os.WriteFile(fakeBinary, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	scanner := &AstGrepScanner{rulesDir: tmpDir, binary: fakeBinary}
+
+	outcome, err := scanner.ScanDirectory(context.Background(), rootDir)
+	if err != nil {
+		t.Fatalf("ScanDirectory() error = %v", err)
+	}
+	if len(outcome.Analyses) != 1 || outcome.Analyses[0].Language != "rust" {
+		t.Fatalf("analyses = %#v, want one Rust analysis", outcome.Analyses)
+	}
+	if len(outcome.Sources) != 1 {
+		t.Fatalf("sources = %#v, want exactly ast-grep", outcome.Sources)
+	}
+	source := outcome.Sources[0]
+	if source.Name != "ast-grep" || source.Status != ScanSourceAuthoritative {
+		t.Fatalf("source = %#v, want authoritative ast-grep", source)
+	}
+	if source.Detail != "" {
+		t.Fatalf("ast-grep detail = %q, want empty (Rust caveat belongs to rust-cargo)", source.Detail)
+	}
+}
+
 func TestScanForDepsRejectsNonAstGrepSg(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("requires shell script execution")

--- a/scanner/contracts_test.go
+++ b/scanner/contracts_test.go
@@ -82,3 +82,21 @@ func TestNewDepsProjectRustCoverageFromPathAndInventory(t *testing.T) {
 		t.Fatalf("non-Rust coverage = %q, want complete", complete.Coverage.Status)
 	}
 }
+
+// Regression for PR #105 follow-up: the default deps coverage must mirror the
+// graph-derived production shape — ast-grep stays authoritative (it did its
+// job) and the Rust caveat is carried by a rust-cargo source, never attached
+// to ast-grep. Attaching it to ast-grep mislabels Go analysis in a Go+Rust
+// monorepo and duplicates the caveat when rust-cargo is also recorded.
+func TestNewDepsProjectRustCaveatOwnedByRustCargoSource(t *testing.T) {
+	project := newDepsProject("/repo", []FileAnalysis{{Path: "crate/src/lib.rs"}}, nil, "")
+	if got, want := project.Coverage.Sources, []analysis.Source{
+		{Name: "ast-grep", Status: analysis.SourceAuthoritative},
+		{Name: "rust-cargo", Status: analysis.SourceMixed, Detail: rustCoverageNote},
+	}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("coverage sources = %#v, want %#v", got, want)
+	}
+	if project.Coverage.Status != analysis.CoveragePartial {
+		t.Fatalf("Rust coverage = %q, want partial", project.Coverage.Status)
+	}
+}

--- a/scanner/outcome.go
+++ b/scanner/outcome.go
@@ -2,6 +2,7 @@ package scanner
 
 import (
 	"fmt"
+	"slices"
 
 	"codemap/analysis"
 )
@@ -62,7 +63,10 @@ func (c *GraphCoverage) AddSource(outcome ScanSourceOutcome) {
 			c.Status = analysis.CoverageUnavailable
 		}
 	}
-	if outcome.Detail != "" {
+	// Record the detail once: distinct sources may legitimately carry the same
+	// caveat (e.g. a shared Rust resolution note), and consumers surface every
+	// note, so a duplicate would read as a doubled warning in the output.
+	if outcome.Detail != "" && !slices.Contains(c.Notes, outcome.Detail) {
 		c.Notes = append(c.Notes, outcome.Detail)
 	}
 }

--- a/scanner/outcome_test.go
+++ b/scanner/outcome_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 )
 
@@ -270,5 +271,28 @@ func TestGraphCoverageDegradedAfterUsableKeepsPartial(t *testing.T) {
 	}
 	if len(coverage.Notes) != 1 || coverage.Notes[0] != "cargo hung" {
 		t.Fatalf("notes = %#v, want cargo detail", coverage.Notes)
+	}
+}
+
+// Regression for PR #105 follow-up: distinct sources may legitimately carry the
+// same caveat (the shared Rust resolution note), but every recorded note is
+// surfaced to users, so AddSource must record each detail only once. Without
+// dedup, ast-grep + rust-cargo both carrying the Rust note doubled the warning
+// in rendered output and in CoverageNotes.
+func TestGraphCoverageAddSourceDedupesSharedDetail(t *testing.T) {
+	coverage := GraphCoverage{}
+	coverage.AddSource(ScanSourceOutcome{Name: "ast-grep", Status: ScanSourceAuthoritative, Detail: rustCoverageNote})
+	coverage.AddSource(ScanSourceOutcome{Name: "rust-cargo", Status: ScanSourceMixed, Detail: rustCoverageNote})
+	coverage.AddSource(ScanSourceOutcome{Name: "cargo-metadata", Status: ScanSourceFallback, Detail: "1 of 1 Cargo manifests used fallback topology"})
+
+	if got, want := coverage.Status, analysis.CoveragePartial; got != want {
+		t.Fatalf("status = %q, want %q", got, want)
+	}
+	if len(coverage.Sources) != 3 {
+		t.Fatalf("sources = %d, want 3 recorded", len(coverage.Sources))
+	}
+	wantNotes := []string{rustCoverageNote, "1 of 1 Cargo manifests used fallback topology"}
+	if !reflect.DeepEqual(coverage.Notes, wantNotes) {
+		t.Fatalf("notes = %#v, want deduped %#v", coverage.Notes, wantNotes)
 	}
 }

--- a/scanner/types.go
+++ b/scanner/types.go
@@ -64,24 +64,34 @@ type DepsProject struct {
 // newDepsProject builds a DepsProject with default coverage derived from the
 // analyses and inventory (Rust repos are partial). Production callers pass
 // explicit graph-derived coverage via NewDepsProjectWithCoverage; this default
-// constructor is kept for the determinism and Rust-coverage tests.
+// constructor is kept for the determinism and Rust-coverage tests. It mirrors
+// the graph-derived production shape: ast-grep stays authoritative (it did its
+// job) and the Rust caveat is carried by a rust-cargo source, never attached
+// to ast-grep, so the source list reads as what each tool contributed.
 func newDepsProject(root string, files []FileAnalysis, externalDeps map[string][]string, diffRef string, inventory ...[]FileInfo) DepsProject {
 	coverage := analysis.Coverage{
 		Status:  analysis.CoverageComplete,
 		Sources: []analysis.Source{{Name: "ast-grep", Status: analysis.SourceAuthoritative}},
 	}
+	addRustCaveat := func() {
+		if coverage.Status == analysis.CoveragePartial {
+			return
+		}
+		coverage.Status = analysis.CoveragePartial
+		coverage.Sources = append(coverage.Sources, analysis.Source{
+			Name: "rust-cargo", Status: analysis.SourceMixed, Detail: rustCoverageNote,
+		})
+	}
 	for _, file := range files {
 		if file.Language == "rust" || DetectLanguage(file.Path) == "rust" {
-			coverage.Status = analysis.CoveragePartial
-			coverage.Sources[0].Detail = rustCoverageNote
+			addRustCaveat()
 			break
 		}
 	}
 	if coverage.Status == analysis.CoverageComplete && len(inventory) > 0 {
 		for _, file := range inventory[0] {
 			if DetectLanguage(file.Path) == "rust" {
-				coverage.Status = analysis.CoveragePartial
-				coverage.Sources[0].Detail = rustCoverageNote
+				addRustCaveat()
 				break
 			}
 		}


### PR DESCRIPTION
Follow-up to #105, closing the two open findings from the maintainer re-review on the coverage line.

## What this PR does

Both findings were in the coverage line — cosmetic but user-facing:

**1. The Rust note printed twice.** `ast-grep` and `rust-cargo` both carried an identical `Detail`, and `GraphCoverage.AddSource` appended each source's detail to `Notes` with no dedup. A two-crate workspace rendered:

```
Coverage: partial — Rust macro-generated, string-routed, and #[path] module edges may be
unresolved; Rust macro-generated, string-routed, and #[path] module edges may be unresolved
```

**2. `ast-grep` was labeled `mixed` carrying a Rust-specific detail.** The `DetectLanguage(...) == "rust"` loop in `scanner/astgrep.go` demoted ast-grep's source status even though its extraction is not degraded — the macro/`#[path]`/string-routed caveat is a *Rust resolution* gap, which `rust-cargo` owns. Consequences: on a Go+Rust monorepo the Go analysis was reported degraded too, and the same sentence landed on two sources, producing the duplicate in (1).

## Changes

- **`scanner/astgrep.go`** — ast-grep stays `authoritative` on a successful scan regardless of language; the Rust caveat is no longer attached to its source. The file graph already records `rust-cargo` (mixed, with the caveat) for Rust repos, so coverage remains `partial` where it should.
- **`scanner/outcome.go`** — `GraphCoverage.AddSource` records each source detail once (dedup before append), so every `Notes` consumer (MCP structured `coverage_notes`, `--importers`, intent, watch state) inherits the dedup.
- **`render/depgraph.go`** — `renderCoverageLine` renders each detail once, so a shared caveat prints a single warning in the text output even if two sources carry it.
- **`scanner/types.go`** — the default `newDepsProject` coverage mirrors the production shape (ast-grep `authoritative` + `rust-cargo` `mixed` carrying the note) instead of attaching the note to ast-grep.

## Before / after

JSON sources before:

```json
{"name": "ast-grep",       "status": "mixed",         "detail": "Rust macro-generated, ..."}
{"name": "cargo-metadata", "status": "authoritative"}
{"name": "rust-cargo",     "status": "mixed",         "detail": "Rust macro-generated, ..."}
```

JSON sources after — the list reads as what each tool actually contributed:

```json
{"name": "ast-grep",       "status": "authoritative"}
{"name": "cargo-metadata", "status": "authoritative"}
{"name": "rust-cargo",     "status": "mixed",         "detail": "Rust macro-generated, ..."}
```

## Regression tests

- `TestAstGrepScanDirectoryRustStaysAuthoritative` — Rust scans keep ast-grep `authoritative` with no Rust detail.
- `TestGraphCoverageAddSourceDedupesSharedDetail` — shared caveat recorded once across sources.
- `TestDepgraphRendersSharedCoverageDetailOnce` — a shared detail renders once in text output.
- `TestNewDepsProjectRustCaveatOwnedByRustCargoSource` — default coverage shape matches production.

## Verification

- `go build ./...`, `go vet ./scanner ./render ./analysis .`, `gofmt` clean.
- Targeted `scanner` coverage/contract tests and render `TestDepgraph*` pass.

Developed with carefully directed, manually reviewed AI assistance.

Co-authored-by: GPT-5.6 Sol <codex@openai.com>