### PR TITLE
feat(scanner): Resolve Rush workspace projects

### DIFF
--- a/scanner/jsworkspace.go
+++ b/scanner/jsworkspace.go
@@ -52,6 +52,11 @@ type jsWorkspaceManifest struct {
 	workspaces []string
 }
 
+type jsRushProject struct {
+	name string
+	root string
+}
+
 type jsSpecifierMap struct {
 	exact   map[string]jsSpecifierTarget
 	dynamic []jsSpecifierTarget
@@ -72,6 +77,7 @@ func buildJSWorkspaceResolver(ctx context.Context, root string, files []FileInfo
 	denoConfigs := make(map[string]*jsWorkspaceManifest)
 	tsConfigs := make(map[string]map[string]any)
 	pnpmWorkspaces := make(map[string][]string)
+	rushWorkspaces := make(map[string][]jsRushProject)
 	for _, file := range files {
 		if err := ctx.Err(); err != nil {
 			return nil, err
@@ -85,6 +91,14 @@ func buildJSWorkspaceResolver(ctx context.Context, root string, files []FileInfo
 		if name == "tsconfig.json" {
 			if doc, ok := readJSWorkspaceManifest(filepath.Join(root, file.Path)); ok {
 				tsConfigs[manifestRoot] = doc
+			}
+			continue
+		}
+		if name == "rush.json" {
+			if doc, ok := readJSWorkspaceManifest(filepath.Join(root, file.Path)); ok {
+				if projects, ok := parseRushProjects(manifestRoot, doc); ok {
+					rushWorkspaces[manifestRoot] = projects
+				}
 			}
 			continue
 		}
@@ -181,6 +195,23 @@ func buildJSWorkspaceResolver(ctx context.Context, root string, files []FileInfo
 			return nil, err
 		}
 	}
+	for ownerRoot, projects := range rushWorkspaces {
+		members, ok, err := validateRushProjects(ctx, projects, packages)
+		if err != nil {
+			return nil, err
+		}
+		if !ok || len(members) == 0 {
+			continue
+		}
+		workspace := workspaces[ownerRoot]
+		if workspace == nil {
+			workspace = newJSPackageWorkspace(ownerRoot)
+			workspaces[ownerRoot] = workspace
+		}
+		for _, member := range members {
+			workspace.add(member.pkg)
+		}
+	}
 	for _, workspace := range workspaces {
 		resolver.workspaces = append(resolver.workspaces, *workspace)
 	}
@@ -203,6 +234,71 @@ func addJSWorkspaceMembers(ctx context.Context, workspace *jsPackageWorkspace, o
 		}
 	}
 	return nil
+}
+
+func parseRushProjects(ownerRoot string, doc map[string]any) ([]jsRushProject, bool) {
+	items, ok := doc["projects"].([]any)
+	if !ok {
+		return nil, false
+	}
+	projects := make([]jsRushProject, 0, len(items))
+	names := make(map[string]bool, len(items))
+	roots := make(map[string]bool, len(items))
+	for _, item := range items {
+		project, ok := item.(map[string]any)
+		if !ok {
+			return nil, false
+		}
+		name, nameOK := project["packageName"].(string)
+		folder, folderOK := project["projectFolder"].(string)
+		name = strings.TrimSpace(name)
+		folder, folderOK = normalizeRushProjectFolder(folder, folderOK)
+		if !nameOK || name == "" || !folderOK || names[name] || roots[folder] {
+			return nil, false
+		}
+		names[name], roots[folder] = true, true
+		projects = append(projects, jsRushProject{
+			name: name,
+			root: cleanRepoPath(filepath.Join(repoPath(ownerRoot), filepath.FromSlash(folder))),
+		})
+	}
+	return projects, true
+}
+
+func normalizeRushProjectFolder(folder string, ok bool) (string, bool) {
+	if !ok {
+		return "", false
+	}
+	folder = strings.TrimSpace(strings.ReplaceAll(folder, `\`, "/"))
+	folder = strings.TrimPrefix(folder, "./")
+	if folder == "" || strings.HasPrefix(folder, "!") || path.IsAbs(folder) || hasDrivePrefix(folder) || strings.ContainsAny(folder, "*?[\x00") {
+		return "", false
+	}
+	for _, part := range strings.Split(folder, "/") {
+		if part == ".." {
+			return "", false
+		}
+	}
+	folder = path.Clean(folder)
+	if folder == "." || path.IsAbs(folder) || hasDrivePrefix(folder) {
+		return "", false
+	}
+	return folder, true
+}
+
+func validateRushProjects(ctx context.Context, projects []jsRushProject, packages map[string]*jsWorkspaceManifest) ([]*jsWorkspaceManifest, bool, error) {
+	members := make([]*jsWorkspaceManifest, 0, len(projects))
+	for _, project := range projects {
+		if err := ctx.Err(); err != nil {
+			return nil, false, err
+		}
+		member := packages[project.root]
+		if member == nil || member.pkg == nil || member.pkg.name != project.name {
+			return nil, false, nil
+		}
+		members = append(members, member)
+	}
+	return members, true, nil
 }
 
 func newJSPackageWorkspace(root string) *jsPackageWorkspace {

--- a/scanner/jsworkspace_test.go
+++ b/scanner/jsworkspace_test.go
@@ -107,6 +107,69 @@ func TestBuildFileGraphCombinesWorkspaceDeclarationsAtSameRoot(t *testing.T) {
 	})
 }
 
+func TestBuildFileGraphResolvesRushWorkspaceProjects(t *testing.T) {
+	root := t.TempDir()
+	writeWorkspaceFile(t, root, "rush.json", `{
+		// Rush inventories projects explicitly.
+		"projects": [
+			{"packageName":"@acme/app","projectFolder":"apps/app"},
+			{"packageName":"@acme/lib","projectFolder":"packages/lib"},
+		],
+	}`)
+	writeWorkspaceFile(t, root, "apps/app/package.json", `{"name":"@acme/app"}`)
+	writeWorkspaceFile(t, root, "packages/lib/package.json", `{"name":"@acme/lib","exports":"./index.ts"}`)
+	writeWorkspaceFile(t, root, "packages/unlisted/package.json", `{"name":"@acme/unlisted","exports":"./index.ts"}`)
+	writeWorkspaceFile(t, root, "nested/rush.json", `{"projects":[{"packageName":"nested-app","projectFolder":"app"},{"packageName":"@acme/lib","projectFolder":"lib"}]}`)
+	writeWorkspaceFile(t, root, "nested/app/package.json", `{"name":"nested-app"}`)
+	writeWorkspaceFile(t, root, "nested/lib/package.json", `{"name":"@acme/lib","exports":"./index.ts"}`)
+	writeWorkspaceFiles(t, root, "apps/app/main.ts", "packages/lib/index.ts", "packages/unlisted/index.ts", "nested/app/main.ts", "nested/lib/index.ts")
+
+	graph := buildWorkspaceGraph(t, root,
+		workspaceAnalysis("apps/app/main.ts", "@acme/lib", "@acme/unlisted"),
+		workspaceAnalysis("nested/app/main.ts", "@acme/lib"),
+	)
+	assertWorkspaceImports(t, graph, "apps/app/main.ts", []string{filepath.FromSlash("packages/lib/index.ts")})
+	assertWorkspaceImports(t, graph, "nested/app/main.ts", []string{filepath.FromSlash("nested/lib/index.ts")})
+}
+
+func TestNormalizeRushProjectFolderRejectsDisguisedUnsafePaths(t *testing.T) {
+	for _, folder := range []string{"./C:/outside", `./\server\share`, ".//outside", "packages/../other", "!packages/x"} {
+		if got, ok := normalizeRushProjectFolder(folder, true); ok {
+			t.Errorf("normalizeRushProjectFolder(%q) = %q, want invalid", folder, got)
+		}
+	}
+}
+
+func TestBuildFileGraphRejectsInvalidRushWorkspaceAtomically(t *testing.T) {
+	tests := map[string]struct {
+		entry string
+		files map[string]string
+	}{
+		"missing package name":        {`{"projectFolder":"packages/missing-name"}`, nil},
+		"unsafe folder":               {`{"packageName":"bad","projectFolder":"../bad"}`, nil},
+		"missing manifest":            {`{"packageName":"missing","projectFolder":"packages/missing"}`, nil},
+		"package name mismatch":       {`{"packageName":"declared","projectFolder":"packages/mismatch"}`, map[string]string{"packages/mismatch/package.json": `{"name":"actual"}`}},
+		"duplicate normalized folder": {`{"packageName":"other","projectFolder":"packages/good/."}`, nil},
+		"duplicate package name":      {`{"packageName":"@acme/good","projectFolder":"packages/other"}`, map[string]string{"packages/other/package.json": `{"name":"@acme/good"}`}},
+		"exact duplicate":             {`{"packageName":"@acme/good","projectFolder":"packages/good"}`, nil},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			root := t.TempDir()
+			writeWorkspaceFile(t, root, "rush.json", `{"projects":[{"packageName":"@acme/app","projectFolder":"apps/app"},{"packageName":"@acme/good","projectFolder":"packages/good"},`+tt.entry+`]}`)
+			writeWorkspaceFile(t, root, "apps/app/package.json", `{"name":"@acme/app"}`)
+			writeWorkspaceFile(t, root, "packages/good/package.json", `{"name":"@acme/good","exports":"./index.ts"}`)
+			for path, body := range tt.files {
+				writeWorkspaceFile(t, root, path, body)
+			}
+			writeWorkspaceFiles(t, root, "apps/app/main.ts", "packages/good/index.ts")
+
+			graph := buildWorkspaceGraph(t, root, workspaceAnalysis("apps/app/main.ts", "@acme/good"))
+			assertWorkspaceImports(t, graph, "apps/app/main.ts", nil)
+		})
+	}
+}
+
 func TestJSWorkspaceResolverUsesExplicitFilters(t *testing.T) {
 	root := t.TempDir()
 	writeWorkspaceFile(t, root, ".codemap/config.json", `{"exclude":["packages/web"]}`)
@@ -141,7 +204,7 @@ func TestBuildJSWorkspaceResolverHonorsCancellation(t *testing.T) {
 	}
 }
 
-func TestAddJSWorkspaceMembersHonorsMidBuildCancellation(t *testing.T) {
+func TestJSWorkspaceMemberBuildersHonorMidBuildCancellation(t *testing.T) {
 	ctx := &cancelAfterContext{Context: context.Background(), remaining: 1}
 	workspace := newJSPackageWorkspace("")
 	members := map[string]*jsWorkspaceManifest{
@@ -154,6 +217,13 @@ func TestAddJSWorkspaceMembersHonorsMidBuildCancellation(t *testing.T) {
 	}
 	if len(workspace.packages) > 1 {
 		t.Fatalf("added %d packages after cancellation boundary, want at most 1", len(workspace.packages))
+	}
+
+	ctx = &cancelAfterContext{Context: context.Background(), remaining: 1}
+	projects := []jsRushProject{{name: "a", root: "packages/a"}, {name: "b", root: "packages/b"}}
+	packages := map[string]*jsWorkspaceManifest{"packages/a": members["a"], "packages/b": members["b"]}
+	if _, _, err := validateRushProjects(ctx, projects, packages); err != context.Canceled {
+		t.Fatalf("validateRushProjects() error = %v, want context.Canceled", err)
 	}
 }
 


### PR DESCRIPTION
## What does this PR do?

Resolve local JS/TS imports from the explicit project inventory in `rush.json`. Invalid, missing, mismatched, unsafe, or duplicate project entries reject the Rush declaration without partial edges.

This lets a sandboxed coding agent run `codemap --deps ../rush-worktree` and follow local Rush projects without invoking Node, Rush, or a package manager.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] New language support
- [ ] Documentation
- [ ] Other (describe below)

## Checklist

- [x] I've tested this locally with `go build && ./codemap .`
- [x] I've read `CONTRIBUTING.md`; this does not add a new language.
- [x] Documentation is unchanged because existing dependency output gains Rush workspace edges.

## Additional notes

Focused verification:

```sh
go test ./scanner -run 'Test.*(Rush|JSWorkspaceMemberBuilders)' -count=1
```

The branch also passes the full macOS race/coverage, vet, Staticcheck, and build checks, plus the Rush-focused Linux Go 1.24 scanner test.

Developed with carefully directed, manually reviewed AI assistance.