### PR TITLE
feat(scanner): Recover Cargo topology on scan failure

### DIFF
--- a/scanner/cargofallback.go
+++ b/scanner/cargofallback.go
@@ -1,0 +1,164 @@
+package scanner
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+var errCargoFallbackUnavailable = errors.New("cargo dependency fallback unavailable")
+
+type dependencyOutcomeScanner func(string) (ScanOutcome, error)
+
+type cargoFallbackPackage struct {
+	packageInfo  rustPackage
+	dependencies []cargoMetadataDependency
+}
+
+func buildFileGraphWithFallback(ctx context.Context, root string, scan dependencyOutcomeScanner, loader cargoMetadataLoader) (*FileGraph, error) {
+	return buildFileGraphWithFallbackWithFilters(ctx, root, Filters{}, scan, loader)
+}
+
+func buildFileGraphFromOutcomeWithCargoMetadataAndFilters(ctx context.Context, root string, outcome ScanOutcome, filters Filters, loader cargoMetadataLoader) (*FileGraph, error) {
+	fg, err := buildFileGraphFromAnalysesWithCargoMetadataAndFilters(ctx, root, outcome.Analyses, filters, loader, outcome.Sources...)
+	if err != nil {
+		return nil, err
+	}
+	applyPrecomputedFileEdges(fg, outcome.precomputedEdges)
+	return fg, nil
+}
+
+func buildFileGraphWithFallbackWithFilters(ctx context.Context, root string, filters Filters, scan dependencyOutcomeScanner, loader cargoMetadataLoader) (*FileGraph, error) {
+	outcome, usedFallback, err := scanForGraphOutcomeWithFilters(ctx, root, filters, scan, loader)
+	if err != nil {
+		return nil, err
+	}
+	graphLoader := loadCargoMetadata
+	if usedFallback {
+		graphLoader = nil
+	}
+	return buildFileGraphFromOutcomeWithCargoMetadataAndFilters(ctx, root, outcome, filters, graphLoader)
+}
+
+func scanForGraphOutcome(ctx context.Context, root string, scan dependencyOutcomeScanner, loader cargoMetadataLoader) (ScanOutcome, bool, error) {
+	return scanForGraphOutcomeWithFilters(ctx, root, Filters{}, scan, loader)
+}
+
+func scanForGraphOutcomeWithFilters(ctx context.Context, root string, filters Filters, scan dependencyOutcomeScanner, loader cargoMetadataLoader) (ScanOutcome, bool, error) {
+	outcome, err := scan(root)
+	if err == nil {
+		return outcome, false, nil
+	}
+
+	var incomplete *IncompleteScanError
+	if !errors.As(err, &incomplete) || incomplete.Outcome.Name != "ast-grep" {
+		return ScanOutcome{}, false, err
+	}
+	files, scanErr := ScanFiles(ctx, root, NewGitIgnoreCache(root), filters.Only, filters.Exclude)
+	if scanErr != nil {
+		return ScanOutcome{}, false, err
+	}
+	fallback, fallbackErr := buildCargoFallbackOutcome(ctx, root, files, loader)
+	if fallbackErr != nil {
+		return ScanOutcome{}, false, err
+	}
+	fallback.Sources = append([]ScanSourceOutcome{incomplete.Outcome}, fallback.Sources...)
+	return fallback, true, nil
+}
+
+func buildCargoFallbackOutcome(ctx context.Context, root string, files []FileInfo, loader cargoMetadataLoader) (ScanOutcome, error) {
+	manifests := discoverCargoManifests(root, files)
+	if len(manifests) == 0 || loader == nil {
+		return ScanOutcome{}, errCargoFallbackUnavailable
+	}
+
+	allowed := make(map[string]bool, len(files))
+	for _, file := range files {
+		allowed[filepath.Clean(file.Path)] = true
+	}
+	packages := make(map[string]cargoFallbackPackage)
+	handledManifests := make(map[string]bool)
+
+	manifest := filepath.Clean(manifests[0])
+	data, err := loader(ctx, manifest)
+	if err != nil {
+		return ScanOutcome{}, errCargoFallbackUnavailable
+	}
+	metadata, err := parseCargoMetadata(data)
+	if err != nil {
+		return ScanOutcome{}, errCargoFallbackUnavailable
+	}
+	covered := false
+	for _, metadataPackage := range metadata.Packages {
+		pkg, _, ok := rustPackageFromCargoMetadata(root, metadataPackage)
+		if !ok || len(pkg.targets) == 0 {
+			continue
+		}
+		packages[pkg.root] = cargoFallbackPackage{packageInfo: pkg, dependencies: metadataPackage.Dependencies}
+		handledManifests[filepath.Clean(metadataPackage.ManifestPath)] = true
+		covered = true
+	}
+	if !covered {
+		return ScanOutcome{}, errCargoFallbackUnavailable
+	}
+	handledManifests[manifest] = true
+
+	edgeSet := make(map[fileEdge]bool)
+	for _, pkg := range packages {
+		for _, target := range pkg.packageInfo.targets {
+			if !allowed[target.rootFile] {
+				continue
+			}
+			for _, dependency := range pkg.dependencies {
+				if dependency.Path == "" || dependency.Optional || cargoDependencyIsConditional(dependency) || !rustDependencyEligible(dependency.Kind, target.kind) {
+					continue
+				}
+				dependencyRoot, ok := projectRelativePath(root, dependency.Path)
+				if !ok {
+					continue
+				}
+				dependencyPackage, ok := packages[dependencyRoot]
+				if !ok || dependencyPackage.packageInfo.lib == nil || !allowed[dependencyPackage.packageInfo.lib.rootFile] {
+					continue
+				}
+				edgeSet[fileEdge{from: target.rootFile, to: dependencyPackage.packageInfo.lib.rootFile}] = true
+			}
+		}
+	}
+	if len(edgeSet) == 0 {
+		return ScanOutcome{}, errCargoFallbackUnavailable
+	}
+
+	edges := make([]fileEdge, 0, len(edgeSet))
+	for edge := range edgeSet {
+		edges = append(edges, edge)
+	}
+	sort.Slice(edges, func(i, j int) bool {
+		if edges[i].from == edges[j].from {
+			return edges[i].to < edges[j].to
+		}
+		return edges[i].from < edges[j].from
+	})
+	handled := 0
+	for _, manifest := range manifests {
+		if handledManifests[filepath.Clean(manifest)] {
+			handled++
+		}
+	}
+	return ScanOutcome{
+		Sources: []ScanSourceOutcome{{
+			Name:   "cargo-metadata",
+			Status: ScanSourceFallback,
+			Detail: fmt.Sprintf("Cargo metadata fallback recovered %d dependency edges from %d of %d manifests", len(edges), handled, len(manifests)),
+		}},
+		precomputedEdges: edges,
+	}, nil
+}
+
+func cargoDependencyIsConditional(dependency cargoMetadataDependency) bool {
+	target := strings.TrimSpace(string(dependency.Target))
+	return target != "" && target != "null"
+}

--- a/scanner/cargofallback.go
+++ b/scanner/cargofallback.go
@@ -59,6 +59,9 @@ func scanForGraphOutcomeWithFilters(ctx context.Context, root string, filters Fi
 	}
 	files, scanErr := ScanFiles(ctx, root, NewGitIgnoreCache(root), filters.Only, filters.Exclude)
 	if scanErr != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ScanOutcome{}, false, ctxErr
+		}
 		return ScanOutcome{}, false, err
 	}
 	fallback, fallbackErr := buildCargoFallbackOutcome(ctx, root, files, loader)

--- a/scanner/cargofallback.go
+++ b/scanner/cargofallback.go
@@ -43,10 +43,6 @@ func buildFileGraphWithFallbackWithFilters(ctx context.Context, root string, fil
 	return buildFileGraphFromOutcomeWithCargoMetadataAndFilters(ctx, root, outcome, filters, graphLoader)
 }
 
-func scanForGraphOutcome(ctx context.Context, root string, scan dependencyOutcomeScanner, loader cargoMetadataLoader) (ScanOutcome, bool, error) {
-	return scanForGraphOutcomeWithFilters(ctx, root, Filters{}, scan, loader)
-}
-
 func scanForGraphOutcomeWithFilters(ctx context.Context, root string, filters Filters, scan dependencyOutcomeScanner, loader cargoMetadataLoader) (ScanOutcome, bool, error) {
 	outcome, err := scan(root)
 	if err == nil {

--- a/scanner/cargofallback_test.go
+++ b/scanner/cargofallback_test.go
@@ -1,0 +1,227 @@
+package scanner
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func cargoFallbackFixture(t *testing.T, dependency map[string]any) (string, []byte) {
+	t.Helper()
+	root := t.TempDir()
+	writeRustCargoFixture(t, root, map[string]string{
+		"Cargo.toml":      "[workspace]\nmembers = [\"app\", \"core\"]\n",
+		"app/Cargo.toml":  "[package]\nname = \"app\"\nversion = \"0.1.0\"\n",
+		"app/src/lib.rs":  "pub fn call() {}\n",
+		"core/Cargo.toml": "[package]\nname = \"core\"\nversion = \"0.1.0\"\n",
+		"core/src/lib.rs": "pub fn api() {}\n",
+	})
+	return root, cargoMetadataJSON(t, root, []map[string]any{
+		cargoPackage(root, "app", "app", "app", []map[string]any{dependency}),
+		cargoPackage(root, "core", "core", "core", nil),
+	})
+}
+
+func TestBuildFileGraphUsesCargoFallbackOnce(t *testing.T) {
+	root, metadata := cargoFallbackFixture(t, map[string]any{
+		"name": "core", "path": "core", "kind": nil,
+	})
+	loads := 0
+	graph, err := buildFileGraphWithFallback(
+		context.Background(),
+		root,
+		func(string) (ScanOutcome, error) {
+			return ScanOutcome{}, newIncompleteScanError("ast-grep", ScanSourceUnavailable, "ast-grep unavailable", ErrAstGrepNotFound)
+		},
+		func(context.Context, string) ([]byte, error) {
+			loads++
+			return metadata, nil
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := graph.Imports["app/src/lib.rs"], []string{"core/src/lib.rs"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("fallback imports = %#v, want %#v", got, want)
+	}
+	if loads != 1 {
+		t.Fatalf("Cargo metadata loads = %d, want 1", loads)
+	}
+	if graph.Coverage.Status != "partial" {
+		t.Fatalf("coverage status = %q, want partial", graph.Coverage.Status)
+	}
+	if got := requireSourceOutcome(t, graph.Coverage, "ast-grep").Status; got != ScanSourceUnavailable {
+		t.Fatalf("ast-grep status = %q, want %q", got, ScanSourceUnavailable)
+	}
+	if got := requireSourceOutcome(t, graph.Coverage, "cargo-metadata").Status; got != ScanSourceFallback {
+		t.Fatalf("Cargo status = %q, want %q", got, ScanSourceFallback)
+	}
+	if len(graph.Coverage.Sources) < 2 {
+		t.Fatalf("sources = %#v, want primary and fallback outcomes", graph.Coverage.Sources)
+	}
+}
+
+func TestBuildFileGraphDoesNotFallbackAfterAuthoritativeScan(t *testing.T) {
+	root := t.TempDir()
+	writeRustCargoFixture(t, root, map[string]string{"main.go": "package main\n"})
+	loads := 0
+	graph, err := buildFileGraphWithFallback(
+		context.Background(),
+		root,
+		func(string) (ScanOutcome, error) {
+			return ScanOutcome{Sources: []ScanSourceOutcome{{Name: "ast-grep", Status: ScanSourceAuthoritative}}}, nil
+		},
+		func(context.Context, string) ([]byte, error) {
+			loads++
+			return nil, errors.New("unexpected Cargo fallback")
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loads != 0 {
+		t.Fatalf("Cargo metadata loads = %d, want 0", loads)
+	}
+	if got := requireSourceOutcome(t, graph.Coverage, "ast-grep").Status; got != ScanSourceAuthoritative {
+		t.Fatalf("ast-grep status = %q, want %q", got, ScanSourceAuthoritative)
+	}
+}
+
+func TestBuildFileGraphDoesNotFallbackForOtherScanner(t *testing.T) {
+	root, metadata := cargoFallbackFixture(t, map[string]any{
+		"name": "core", "path": "core", "kind": nil,
+	})
+	primaryErr := &IncompleteScanError{
+		Outcome: ScanSourceOutcome{Name: "tree-sitter", Status: ScanSourceFailed},
+		Err:     errors.New("primary scanner failure"),
+	}
+	loads := 0
+	_, err := buildFileGraphWithFallback(
+		context.Background(),
+		root,
+		func(string) (ScanOutcome, error) { return ScanOutcome{}, primaryErr },
+		func(context.Context, string) ([]byte, error) {
+			loads++
+			return metadata, nil
+		},
+	)
+	if err != primaryErr {
+		t.Fatalf("error = %v, want original %v", err, primaryErr)
+	}
+	if loads != 0 {
+		t.Fatalf("Cargo metadata loads = %d, want 0", loads)
+	}
+}
+
+func TestCargoFallbackRejectsUnprovenEdges(t *testing.T) {
+	for _, tt := range []struct {
+		name       string
+		dependency map[string]any
+		files      []FileInfo
+	}{
+		{
+			name: "optional dependency",
+			dependency: map[string]any{
+				"name": "core", "path": "core", "kind": nil, "optional": true,
+			},
+			files: []FileInfo{{Path: "app/src/lib.rs"}, {Path: "core/src/lib.rs"}},
+		},
+		{
+			name: "target conditioned dependency",
+			dependency: map[string]any{
+				"name": "core", "path": "core", "kind": nil, "target": "cfg(unix)",
+			},
+			files: []FileInfo{{Path: "app/src/lib.rs"}, {Path: "core/src/lib.rs"}},
+		},
+		{
+			name: "filtered dependency target",
+			dependency: map[string]any{
+				"name": "core", "path": "core", "kind": nil,
+			},
+			files: []FileInfo{{Path: "app/src/lib.rs"}},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			root, metadata := cargoFallbackFixture(t, tt.dependency)
+			_, err := buildCargoFallbackOutcome(context.Background(), root, tt.files, func(context.Context, string) ([]byte, error) {
+				return metadata, nil
+			})
+			if err == nil {
+				t.Fatal("Cargo fallback accepted an unproven edge")
+			}
+		})
+	}
+}
+
+func TestCargoFallbackFailurePreservesPrimaryError(t *testing.T) {
+	root := t.TempDir()
+	writeRustCargoFixture(t, root, map[string]string{
+		"Cargo.toml": "[package]\nname = \"app\"\nversion = \"0.1.0\"\n",
+		"src/lib.rs": "pub fn call() {}\n",
+	})
+	primaryErr := &IncompleteScanError{
+		Outcome: ScanSourceOutcome{Name: "ast-grep", Status: ScanSourceFailed, Detail: "ast-grep failed"},
+		Err:     errors.New("primary scanner failure"),
+	}
+	_, err := buildFileGraphWithFallback(
+		context.Background(),
+		root,
+		func(string) (ScanOutcome, error) { return ScanOutcome{}, primaryErr },
+		func(context.Context, string) ([]byte, error) { return []byte("not JSON"), nil },
+	)
+	if err != primaryErr {
+		t.Fatalf("error = %v, want original %v", err, primaryErr)
+	}
+}
+
+func TestCargoFallbackAttemptsMetadataOnlyOnce(t *testing.T) {
+	root := t.TempDir()
+	writeRustCargoFixture(t, root, map[string]string{
+		"a/Cargo.toml": "[package]\nname = \"a\"\nversion = \"0.1.0\"\n",
+		"a/src/lib.rs": "pub fn a() {}\n",
+		"b/Cargo.toml": "[package]\nname = \"b\"\nversion = \"0.1.0\"\n",
+		"b/src/lib.rs": "pub fn b() {}\n",
+	})
+	loads := 0
+	_, err := buildCargoFallbackOutcome(context.Background(), root, []FileInfo{
+		{Path: "a/src/lib.rs"}, {Path: "b/src/lib.rs"},
+	}, func(context.Context, string) ([]byte, error) {
+		loads++
+		return []byte("not JSON"), nil
+	})
+	if err == nil {
+		t.Fatal("Cargo fallback unexpectedly succeeded")
+	}
+	if loads != 1 {
+		t.Fatalf("Cargo metadata loads = %d, want 1", loads)
+	}
+}
+
+func TestCargoFallbackMetadataArgsAreLocked(t *testing.T) {
+	manifest := filepath.Join(t.TempDir(), "Cargo.toml")
+	got := cargoFallbackMetadataArgs(manifest)
+	if !reflect.DeepEqual(got, append(cargoMetadataArgs(manifest), "--locked")) {
+		t.Fatalf("fallback args = %#v", got)
+	}
+}
+
+func TestCargoFallbackAcceptsDevDependencyFromLibraryTarget(t *testing.T) {
+	// #98 merged all-non-build-target dev-dependency resolution; the fallback
+	// must treat dev dependencies on source targets as proven edges.
+	root, metadata := cargoFallbackFixture(t, map[string]any{
+		"name": "core", "path": "core", "kind": "dev",
+	})
+	outcome, err := buildCargoFallbackOutcome(context.Background(), root, []FileInfo{
+		{Path: "app/src/lib.rs"}, {Path: "core/src/lib.rs"},
+	}, func(context.Context, string) ([]byte, error) {
+		return metadata, nil
+	})
+	if err != nil {
+		t.Fatalf("Cargo fallback rejected a dev dependency from a library target: %v", err)
+	}
+	if len(outcome.precomputedEdges) != 1 {
+		t.Fatalf("precomputed edges = %#v, want 1", outcome.precomputedEdges)
+	}
+}

--- a/scanner/filegraph.go
+++ b/scanner/filegraph.go
@@ -33,19 +33,24 @@ type fileIndex struct {
 }
 
 // BuildFileGraph scans a project with explicit filters and builds its file
-// graph while honoring caller cancellation.
+// graph while honoring caller cancellation. When the primary scan fails with
+// an incomplete ast-grep outcome, Cargo metadata recovers what topology it can
+// and the graph is marked partial.
 func BuildFileGraph(ctx context.Context, root string, filters Filters) (*FileGraph, error) {
-	outcome, err := ScanForDeps(ctx, root, filters)
-	if err != nil {
-		return nil, err
-	}
-	return BuildFileGraphFromOutcome(ctx, root, outcome, filters)
+	return buildFileGraphWithFallbackWithFilters(ctx, root, filters, func(r string) (ScanOutcome, error) {
+		return ScanForDeps(ctx, r, filters)
+	}, loadCargoFallbackMetadata)
 }
 
 // BuildFileGraphFromOutcome builds a file graph from a scan outcome without
 // dropping scanner provenance.
 func BuildFileGraphFromOutcome(ctx context.Context, root string, outcome ScanOutcome, filters Filters) (*FileGraph, error) {
-	return buildFileGraphFromAnalysesWithCargoMetadataAndFilters(ctx, root, outcome.Analyses, filters, loadCargoMetadata, outcome.Sources...)
+	fg, err := buildFileGraphFromAnalysesWithCargoMetadataAndFilters(ctx, root, outcome.Analyses, filters, loadCargoMetadata, outcome.Sources...)
+	if err != nil {
+		return nil, err
+	}
+	applyPrecomputedFileEdges(fg, outcome.precomputedEdges)
+	return fg, nil
 }
 
 // BuildFileGraphFromAnalyses builds a file graph from pre-computed analyses
@@ -191,6 +196,16 @@ func buildFileGraphFromAnalysesWithCargoMetadataAndFilters(ctx context.Context, 
 		return nil, err
 	}
 	return fg, nil
+}
+
+func applyPrecomputedFileEdges(fg *FileGraph, edges []fileEdge) {
+	for _, edge := range edges {
+		if edge.from == "" || edge.to == "" || edge.from == edge.to {
+			continue
+		}
+		fg.Imports[edge.from] = dedupe(append(fg.Imports[edge.from], edge.to))
+		fg.Importers[edge.to] = dedupe(append(fg.Importers[edge.to], edge.from))
+	}
 }
 
 func needsJSWorkspaceResolver(analyses []FileAnalysis) bool {

--- a/scanner/outcome.go
+++ b/scanner/outcome.go
@@ -21,10 +21,17 @@ const (
 	ScanSourceFailed        = analysis.SourceFailed
 )
 
+// fileEdge is a scanner-proven file dependency that needs no fuzzy resolution.
+type fileEdge struct {
+	from string
+	to   string
+}
+
 // ScanOutcome contains dependency analyses and their provenance.
 type ScanOutcome struct {
-	Analyses []FileAnalysis    `json:"analyses"`
-	Sources  []analysis.Source `json:"sources,omitempty"`
+	Analyses         []FileAnalysis      `json:"analyses"`
+	Sources          []analysis.Source   `json:"sources,omitempty"`
+	precomputedEdges []fileEdge
 }
 
 // GraphCoverage describes graph blind spots and scanner provenance.

--- a/scanner/outcome.go
+++ b/scanner/outcome.go
@@ -29,8 +29,8 @@ type fileEdge struct {
 
 // ScanOutcome contains dependency analyses and their provenance.
 type ScanOutcome struct {
-	Analyses         []FileAnalysis      `json:"analyses"`
-	Sources          []analysis.Source   `json:"sources,omitempty"`
+	Analyses         []FileAnalysis    `json:"analyses"`
+	Sources          []analysis.Source `json:"sources,omitempty"`
 	precomputedEdges []fileEdge
 }
 

--- a/scanner/rustcargo.go
+++ b/scanner/rustcargo.go
@@ -34,10 +34,12 @@ type cargoMetadataTarget struct {
 }
 
 type cargoMetadataDependency struct {
-	Name   string `json:"name"`
-	Rename string `json:"rename"`
-	Path   string `json:"path"`
-	Kind   string `json:"kind"`
+	Name     string          `json:"name"`
+	Rename   string          `json:"rename"`
+	Path     string          `json:"path"`
+	Kind     string          `json:"kind"`
+	Optional bool            `json:"optional"`
+	Target   json.RawMessage `json:"target"`
 }
 
 type pendingRustDependency struct {
@@ -47,13 +49,21 @@ type pendingRustDependency struct {
 }
 
 func loadCargoMetadata(ctx context.Context, manifestPath string) ([]byte, error) {
+	return runCargoMetadata(ctx, manifestPath, cargoMetadataArgs(manifestPath))
+}
+
+func loadCargoFallbackMetadata(ctx context.Context, manifestPath string) ([]byte, error) {
+	return runCargoMetadata(ctx, manifestPath, cargoFallbackMetadataArgs(manifestPath))
+}
+
+func runCargoMetadata(ctx context.Context, manifestPath string, args []string) ([]byte, error) {
 	cargo, err := exec.LookPath("cargo")
 	if err != nil {
 		return nil, err
 	}
 	ctx, cancel := context.WithTimeout(ctx, cargoMetadataTimeout)
 	defer cancel()
-	cmd := exec.CommandContext(ctx, cargo, cargoMetadataArgs(manifestPath)...)
+	cmd := exec.CommandContext(ctx, cargo, args...)
 	cmd.Dir = filepath.Dir(manifestPath)
 	output, err := cmd.Output()
 	if ctx.Err() != nil {
@@ -67,6 +77,10 @@ func cargoMetadataArgs(manifestPath string) []string {
 		"metadata", "--no-deps", "--format-version", "1", "--offline",
 		"--manifest-path", manifestPath,
 	}
+}
+
+func cargoFallbackMetadataArgs(manifestPath string) []string {
+	return append(cargoMetadataArgs(manifestPath), "--locked")
 }
 
 func parseCargoMetadata(data []byte) (cargoMetadata, error) {

--- a/scanner/rustcargo.go
+++ b/scanner/rustcargo.go
@@ -85,8 +85,18 @@ func cargoFallbackMetadataArgs(manifestPath string) []string {
 
 func parseCargoMetadata(data []byte) (cargoMetadata, error) {
 	var metadata cargoMetadata
-	err := json.Unmarshal(data, &metadata)
-	return metadata, err
+	if err := json.Unmarshal(data, &metadata); err != nil {
+		return metadata, err
+	}
+	for packageIndex := range metadata.Packages {
+		for dependencyIndex := range metadata.Packages[packageIndex].Dependencies {
+			dependency := &metadata.Packages[packageIndex].Dependencies[dependencyIndex]
+			if strings.TrimSpace(string(dependency.Target)) == "null" {
+				dependency.Target = nil
+			}
+		}
+	}
+	return metadata, nil
 }
 
 func buildRustWorkspaceIndex(ctx context.Context, root string, analyses []FileAnalysis, files []FileInfo, loader cargoMetadataLoader) (*rustWorkspaceIndex, *ScanSourceOutcome) {


### PR DESCRIPTION
## What does this PR do?

When ast-grep fails or times out, the scanner recovers the Rust dependency graph from `cargo metadata` instead of failing hard:

- `buildFileGraphWithFallback` runs the primary scan, and on an `ast-grep` `IncompleteScanError` builds a fallback `ScanOutcome` from `cargo metadata` (`buildCargoFallbackOutcome`).
- The fallback outcome carries honest provenance (`Sources: [{name: "ast-grep", status: timeout|failed}, {name: "rust-cargo", status: fallback}]`) so coverage and fail-closed behavior stay consistent with the scan contract.
- Conditional dependencies are identified (`cargoDependencyIsConditional`) and reported as conditional edges.

## Review follow-ups included

- `fix(scanner): Normalize null Cargo targets` — `cargo metadata` entries with null target fields no longer crash or produce malformed edges.
- `fix(scanner): return context.Canceled when the fallback file scan fails on a pre-cancelled context` — a pre-cancelled caller receives `context.Canceled` (the primary error is still preserved for real scan failures).

## CLI / MCP surface

No new CLI commands or arguments, and no new MCP tools. Behavior of existing surface:

- `codemap --deps <path>` on a Rust repository returns the recovered graph with `rust-cargo` fallback provenance instead of a hard error when ast-grep is unavailable or times out.
- MCP `get_dependencies` returns the same fallback outcome with its provenance.

## Coverage provenance notes

The fallback only engages on an `ast-grep` failure; a successful scan remains authoritative. Degraded outcomes are bounded and deterministic, matching the fail-closed contract.

Developed with carefully directed, manually reviewed AI assistance.