### PR TITLE
fix(context): Report bounded graph evidence honestly

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,7 +398,7 @@ codemap context --for "refactor auth" # with pre-classified intent + matched ski
 codemap context --compact             # minimal, for token-constrained agents
 ```
 
-Returns a `ContextEnvelope` with project metadata, intent classification, working set, matched skills, and a handoff reference. Anything that can shell out gets code-aware context.
+Returns a `ContextEnvelope` with project metadata, dependency-graph evidence, intent classification, working set, matched skills, and a handoff reference. If fresh graph evidence is unavailable, hub counts are `null` and risk is `unknown` instead of being inferred from stale state. Anything that can shell out gets code-aware context.
 
 ## HTTP API
 

--- a/cmd/context.go
+++ b/cmd/context.go
@@ -17,7 +17,6 @@ import (
 	"codemap/handoff"
 	"codemap/scanner"
 	"codemap/skills"
-	"codemap/watch"
 )
 
 // ContextEnvelope is the standardized output format that any AI tool can consume.
@@ -34,12 +33,13 @@ type ContextEnvelope struct {
 
 // ProjectContext contains high-level project metadata.
 type ProjectContext struct {
-	Root      string   `json:"root"`
-	Branch    string   `json:"branch"`
-	FileCount int      `json:"file_count"`
-	Languages []string `json:"languages"`
-	HubCount  int      `json:"hub_count"`
-	TopHubs   []string `json:"top_hubs,omitempty"`
+	Root          string        `json:"root"`
+	Branch        string        `json:"branch"`
+	FileCount     int           `json:"file_count"`
+	Languages     []string      `json:"languages"`
+	HubCount      *int          `json:"hub_count"`
+	TopHubs       []string      `json:"top_hubs,omitempty"`
+	GraphEvidence GraphEvidence `json:"graph_evidence"`
 }
 
 // WorkingSetContext is a summary of the current working set.
@@ -110,21 +110,37 @@ func RunContext(args []string, root string) {
 }
 
 func buildContextEnvelope(root, prompt string, compact bool) ContextEnvelope {
+	return buildContextEnvelopeContext(context.Background(), root, prompt, compact)
+}
+
+func buildContextEnvelopeContext(ctx context.Context, root, prompt string, compact bool) ContextEnvelope {
+	return buildContextEnvelopeWithDeps(ctx, root, prompt, compact, defaultContextEnvelopeDeps())
+}
+
+func buildContextEnvelopeWithDeps(parent context.Context, root, prompt string, compact bool, deps contextEnvelopeDeps) ContextEnvelope {
+	timeout := deps.graphTimeout
+	if timeout <= 0 {
+		timeout = defaultContextGraphTimeout
+	}
+	ctx, cancel := context.WithTimeout(parent, timeout)
+	defer cancel()
+
 	projCfg := config.Load(root)
-	info := getHubInfoNoFallback(root)
+	inputs := loadContextRequestInputs(ctx, root, deps)
 
 	envelope := ContextEnvelope{
-		Version:     1,
-		GeneratedAt: time.Now(),
-		Project:     buildProjectContext(root, info),
+		Version:     2,
+		GeneratedAt: deps.now(),
+		Project:     buildProjectContext(root, inputs),
 		Budget:      BudgetInfo{Compact: compact},
 	}
 
 	// Intent classification (if prompt provided)
 	if prompt != "" {
 		topK := projCfg.RoutingTopKOrDefault()
-		files := extractMentionedFiles(prompt, topK)
-		intent := classifyIntent(prompt, files, info, projCfg)
+		mentions := extractMentionedFiles(strings.ReplaceAll(prompt, `\`, "/"), topK)
+		files := resolveExactConfiguredFiles(mentions, inputs.fileSet)
+		intent := classifyIntent(prompt, files, inputs.info, projCfg)
 		envelope.Intent = &intent
 
 		// Match skills against intent
@@ -148,23 +164,29 @@ func buildContextEnvelope(root, prompt string, compact bool) ContextEnvelope {
 		}
 	}
 
-	// Working set from daemon
-	if state := watch.ReadState(root); state != nil && state.WorkingSet != nil {
+	// Working-set activity comes from the daemon, but structural labels must be
+	// recomputed from this request's fresh graph evidence.
+	if state := inputs.state; inputs.evidence.Status == graphEvidenceAvailable && inputs.info != nil && state != nil && state.WorkingSet != nil {
 		ws := state.WorkingSet
 		wsCtx := &WorkingSetContext{
 			FileCount: ws.Size(),
-			HubCount:  ws.HubCount(),
+		}
+		for path := range ws.Files {
+			if len(inputs.info.Importers[path]) >= 3 {
+				wsCtx.HubCount++
+			}
 		}
 		limit := 10
 		if compact {
 			limit = 3
 		}
 		for _, wf := range ws.HotFiles(limit) {
+			isHub := len(inputs.info.Importers[wf.Path]) >= 3
 			wsCtx.TopFiles = append(wsCtx.TopFiles, WorkingFileContext{
 				Path:      wf.Path,
 				EditCount: wf.EditCount,
 				NetDelta:  wf.NetDelta,
-				IsHub:     wf.IsHub,
+				IsHub:     isHub,
 			})
 		}
 		envelope.WorkingSet = wsCtx
@@ -190,59 +212,42 @@ func buildContextEnvelope(root, prompt string, compact bool) ContextEnvelope {
 	return envelope
 }
 
-func buildProjectContext(root string, info *hubInfo) ProjectContext {
+func buildProjectContext(root string, inputs contextRequestInputs) ProjectContext {
 	ctx := ProjectContext{
-		Root: root,
+		Root:          root,
+		FileCount:     len(inputs.files),
+		GraphEvidence: inputs.evidence,
 	}
-	configuredFileCountKnown := false
 
 	// Get branch
 	if branch, ok := gitCurrentBranch(root); ok {
 		ctx.Branch = branch
 	}
 
-	// Count files and detect languages from daemon state
-	if state := watch.ReadState(root); state != nil {
-		if count, ok := state.ConfiguredCount(); ok {
-			ctx.FileCount = count
-			configuredFileCountKnown = true
+	if inputs.evidence.Status == graphEvidenceAvailable {
+		count := 0
+		if inputs.info != nil {
+			count = len(inputs.info.Hubs)
+			if count > 5 {
+				ctx.TopHubs = append([]string(nil), inputs.info.Hubs[:5]...)
+			} else {
+				ctx.TopHubs = append([]string(nil), inputs.info.Hubs...)
+			}
 		}
-		ctx.HubCount = len(state.Hubs)
-		if len(state.Hubs) > 5 {
-			ctx.TopHubs = state.Hubs[:5]
-		} else {
-			ctx.TopHubs = state.Hubs
-		}
+		ctx.HubCount = &count
 	}
 
 	// Detect languages from multiple sources
 	langSet := make(map[string]bool)
 
-	// Source 1: dependency graph (importers + imports)
-	if info != nil {
-		for file := range info.Importers {
-			if lang := scanner.DetectLanguage(file); lang != "" {
-				langSet[lang] = true
-			}
-		}
-		for file := range info.Imports {
-			if lang := scanner.DetectLanguage(file); lang != "" {
-				langSet[lang] = true
-			}
-		}
-	}
-
-	// Source 2: hubs
-	for _, hub := range ctx.TopHubs {
-		if lang := scanner.DetectLanguage(hub); lang != "" {
+	for _, file := range inputs.files {
+		if lang := scanner.DetectLanguage(file.Path); lang != "" {
 			langSet[lang] = true
 		}
 	}
 
-	// Source 3: cheap fallback — scan for manifest files and top-level source files.
-	// This runs when daemon isn't active and dep graph is empty.
 	if len(langSet) == 0 {
-		langSet = detectLanguagesFromFiles(root)
+		langSet = detectManifestLanguages(root)
 	}
 
 	for lang := range langSet {
@@ -250,12 +255,24 @@ func buildProjectContext(root string, info *hubInfo) ProjectContext {
 	}
 	sort.Strings(ctx.Languages)
 
-	// Fallback file count from quick scan if daemon wasn't available
-	if !configuredFileCountKnown && ctx.FileCount == 0 && len(ctx.Languages) > 0 {
-		ctx.FileCount = countSourceFiles(root)
-	}
-
 	return ctx
+}
+
+func detectManifestLanguages(root string) map[string]bool {
+	langs := make(map[string]bool)
+	manifests := map[string][]string{
+		"go.mod": {"go"}, "package.json": {"javascript"}, "Cargo.toml": {"rust"},
+		"pyproject.toml": {"python"}, "Package.swift": {"swift"},
+		"build.gradle": {"java"}, "build.gradle.kts": {"kotlin", "java"},
+	}
+	for file, signalLangs := range manifests {
+		if _, err := os.Stat(filepath.Join(root, file)); err == nil {
+			for _, lang := range signalLangs {
+				langs[lang] = true
+			}
+		}
+	}
+	return langs
 }
 
 // detectLanguagesFromFiles does a quick scan for language signals.
@@ -313,21 +330,16 @@ func detectLanguagesFromFiles(root string) map[string]bool {
 		applyMakefileHeuristics(filepath.Join(root, "Makefile"), addLang)
 	}
 
-	// Include subdirectory source files. Reuse the scan result for countSourceFiles too.
+	// Include subdirectory source files.
 	gitCache := scanner.NewGitIgnoreCache(root)
 	if files, err := scanner.ScanConfiguredFiles(context.Background(), root, gitCache); err == nil {
 		for _, f := range files {
 			addLang(scanner.DetectLanguage(f.Path))
 		}
-		// Cache file count to avoid a second scan in countSourceFiles
-		cachedFileCount = len(files)
 	}
 
 	return langs
 }
-
-// cachedFileCount avoids a second ScanFiles walk in countSourceFiles.
-var cachedFileCount = -1
 
 func applyMakefileHeuristics(path string, addLang func(string)) {
 	f, err := os.Open(path)
@@ -350,20 +362,4 @@ func applyMakefileHeuristics(path string, addLang func(string)) {
 		(strings.Contains(content, "clang") && !strings.Contains(content, "clang++")) {
 		addLang("c")
 	}
-}
-
-// countSourceFiles does a quick count of source files in the project.
-// Uses cached result from detectLanguagesFromFiles if available.
-func countSourceFiles(root string) int {
-	if cachedFileCount >= 0 {
-		count := cachedFileCount
-		cachedFileCount = -1 // reset for next call
-		return count
-	}
-	gitCache := scanner.NewGitIgnoreCache(root)
-	files, err := scanner.ScanConfiguredFiles(context.Background(), root, gitCache)
-	if err != nil {
-		return 0
-	}
-	return len(files)
 }

--- a/cmd/context_evidence.go
+++ b/cmd/context_evidence.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"codemap/analysis"
 	"codemap/limits"
 	"codemap/scanner"
 	"codemap/watch"
@@ -99,7 +100,16 @@ func loadContextRequestInputs(ctx context.Context, root string, deps contextEnve
 		inputs.evidence = unavailableGraphEvidence(graphErrorReason(ctx, err))
 		return inputs
 	}
-	if graph == nil || (len(graph.Imports) == 0 && len(graph.Importers) == 0) {
+	if graph == nil {
+		inputs.evidence = unavailableGraphEvidence(graphEvidenceScanIncomplete)
+		return inputs
+	}
+	// An edge-free graph is still authoritative when its coverage is complete
+	// (the zero coverage status is the production graph's complete default).
+	// Explicitly unavailable provenance remains fail-closed, even if stale or
+	// partial edge maps happen to contain entries.
+	if graph.Coverage.Status == analysis.CoverageUnavailable ||
+		(len(graph.Coverage.Sources) > 0 && scanner.CoverageFromSources(graph.Coverage.Sources).Status == analysis.CoverageUnavailable) {
 		inputs.evidence = unavailableGraphEvidence(graphEvidenceScanIncomplete)
 		return inputs
 	}

--- a/cmd/context_evidence.go
+++ b/cmd/context_evidence.go
@@ -1,0 +1,174 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	pathpkg "path"
+	"sort"
+	"strings"
+	"time"
+
+	"codemap/limits"
+	"codemap/scanner"
+	"codemap/watch"
+)
+
+const (
+	graphEvidenceAvailable       = "available"
+	graphEvidenceUnavailable     = "unavailable"
+	graphEvidenceFreshScan       = "fresh_scan"
+	graphEvidenceLargeRepository = "large_repository"
+	graphEvidenceCancelled       = "cancelled"
+	graphEvidenceDeadline        = "deadline"
+	graphEvidenceScanFailed      = "scan_failed"
+	graphEvidenceScanIncomplete  = "scan_incomplete"
+	defaultContextGraphTimeout   = 8 * time.Second
+)
+
+// GraphEvidence describes whether dependency conclusions are supported.
+type GraphEvidence struct {
+	Status string `json:"status"`
+	Source string `json:"source,omitempty"`
+	Reason string `json:"reason,omitempty"`
+}
+
+type contextEnvelopeDeps struct {
+	readState           func(string) *watch.State
+	scanConfiguredFiles func(context.Context, string) ([]scanner.FileInfo, error)
+	buildFileGraph      func(context.Context, string) (*scanner.FileGraph, error)
+	now                 func() time.Time
+	graphTimeout        time.Duration
+}
+
+type contextRequestInputs struct {
+	state      *watch.State
+	files      []scanner.FileInfo
+	fileSet    map[string]string
+	info       *hubInfo
+	evidence   GraphEvidence
+	fileScanOK bool
+}
+
+func defaultContextEnvelopeDeps() contextEnvelopeDeps {
+	return contextEnvelopeDeps{
+		readState: watch.ReadState,
+		scanConfiguredFiles: func(ctx context.Context, root string) ([]scanner.FileInfo, error) {
+			return scanner.ScanConfiguredFiles(ctx, root, scanner.NewGitIgnoreCache(root))
+		},
+		buildFileGraph: func(ctx context.Context, root string) (*scanner.FileGraph, error) {
+			return scanner.BuildFileGraph(ctx, root, scanner.ConfiguredFilters(root))
+		},
+		now:          time.Now,
+		graphTimeout: defaultContextGraphTimeout,
+	}
+}
+
+func loadContextRequestInputs(ctx context.Context, root string, deps contextEnvelopeDeps) contextRequestInputs {
+	inputs := contextRequestInputs{
+		state:    deps.readState(root),
+		fileSet:  make(map[string]string),
+		evidence: unavailableGraphEvidence(graphEvidenceScanFailed),
+	}
+
+	files, err := deps.scanConfiguredFiles(ctx, root)
+	if err != nil {
+		inputs.evidence = unavailableGraphEvidence(graphErrorReason(ctx, err))
+		return inputs
+	}
+	inputs.files = files
+	inputs.fileScanOK = true
+	for _, file := range files {
+		normalized := normalizeContextPath(file.Path)
+		if normalized != "" {
+			inputs.fileSet[normalized] = file.Path
+		}
+	}
+
+	if len(files) == 0 {
+		inputs.info = &hubInfo{Importers: map[string][]string{}, Imports: map[string][]string{}}
+		inputs.evidence = GraphEvidence{Status: graphEvidenceAvailable, Source: graphEvidenceFreshScan}
+		return inputs
+	}
+	if len(files) > limits.LargeRepoFileCount {
+		inputs.evidence = unavailableGraphEvidence(graphEvidenceLargeRepository)
+		return inputs
+	}
+
+	graph, err := deps.buildFileGraph(ctx, root)
+	if err != nil {
+		inputs.evidence = unavailableGraphEvidence(graphErrorReason(ctx, err))
+		return inputs
+	}
+	if graph == nil || (len(graph.Imports) == 0 && len(graph.Importers) == 0) {
+		inputs.evidence = unavailableGraphEvidence(graphEvidenceScanIncomplete)
+		return inputs
+	}
+
+	hubs := sortedGraphHubs(graph.Importers)
+	inputs.info = &hubInfo{
+		Hubs:      hubs,
+		Importers: graph.Importers,
+		Imports:   graph.Imports,
+		Coverage:  graph.Coverage,
+	}
+	inputs.evidence = GraphEvidence{Status: graphEvidenceAvailable, Source: graphEvidenceFreshScan}
+	return inputs
+}
+
+func unavailableGraphEvidence(reason string) GraphEvidence {
+	return GraphEvidence{Status: graphEvidenceUnavailable, Reason: reason}
+}
+
+func graphErrorReason(ctx context.Context, err error) string {
+	if errors.Is(err, context.Canceled) || errors.Is(ctx.Err(), context.Canceled) {
+		return graphEvidenceCancelled
+	}
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		return graphEvidenceDeadline
+	}
+	return graphEvidenceScanFailed
+}
+
+func sortedGraphHubs(importers map[string][]string) []string {
+	hubs := make([]string, 0)
+	for file, dependents := range importers {
+		if len(dependents) >= 3 {
+			hubs = append(hubs, file)
+		}
+	}
+	sort.Slice(hubs, func(i, j int) bool {
+		left, right := len(importers[hubs[i]]), len(importers[hubs[j]])
+		if left != right {
+			return left > right
+		}
+		return normalizeContextPath(hubs[i]) < normalizeContextPath(hubs[j])
+	})
+	return hubs
+}
+
+func normalizeContextPath(file string) string {
+	file = strings.TrimSpace(strings.ReplaceAll(file, `\`, "/"))
+	file = strings.TrimPrefix(pathpkg.Clean(file), "./")
+	if file == "." || file == "" || strings.HasPrefix(file, "../") || file == ".." || pathpkg.IsAbs(file) {
+		return ""
+	}
+	return file
+}
+
+func resolveExactConfiguredFiles(mentions []string, fileSet map[string]string) []string {
+	resolved := make([]string, 0, len(mentions))
+	seen := make(map[string]struct{})
+	for _, mention := range mentions {
+		normalized := normalizeContextPath(mention)
+		actual, ok := fileSet[normalized]
+		if !ok {
+			continue
+		}
+		if _, duplicate := seen[actual]; duplicate {
+			continue
+		}
+		seen[actual] = struct{}{}
+		resolved = append(resolved, actual)
+	}
+	return resolved
+}

--- a/cmd/context_evidence_test.go
+++ b/cmd/context_evidence_test.go
@@ -1,0 +1,330 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"codemap/scanner"
+	"codemap/watch"
+)
+
+func TestContextGraphEvidenceTrueHubAndDeterministicOrder(t *testing.T) {
+	files := []scanner.FileInfo{
+		{Path: "cmd/context.go"}, {Path: "cmd/alpha.go"},
+		{Path: "a.go"}, {Path: "b.go"}, {Path: "c.go"},
+	}
+	graph := &scanner.FileGraph{
+		Imports: map[string][]string{
+			"a.go": {"cmd/context.go", "cmd/alpha.go"},
+			"b.go": {"cmd/context.go", "cmd/alpha.go"},
+			"c.go": {"cmd/context.go", "cmd/alpha.go"},
+		},
+		Importers: map[string][]string{
+			"cmd/context.go": {"a.go", "b.go", "c.go"},
+			"cmd/alpha.go":   {"a.go", "b.go", "c.go"},
+		},
+	}
+
+	envelope := buildContextEnvelopeWithDeps(context.Background(), t.TempDir(), "refactor cmd/context.go", true, testContextEnvelopeDeps(files, graph))
+
+	if envelope.Version != 2 {
+		t.Fatalf("version = %d, want 2", envelope.Version)
+	}
+	if envelope.Project.GraphEvidence.Status != graphEvidenceAvailable || envelope.Project.GraphEvidence.Source != graphEvidenceFreshScan {
+		t.Fatalf("graph evidence = %#v", envelope.Project.GraphEvidence)
+	}
+	if envelope.Project.HubCount == nil || *envelope.Project.HubCount != 2 {
+		t.Fatalf("hub count = %#v, want 2", envelope.Project.HubCount)
+	}
+	if want := []string{"cmd/alpha.go", "cmd/context.go"}; !reflect.DeepEqual(envelope.Project.TopHubs, want) {
+		t.Fatalf("top hubs = %#v, want %#v", envelope.Project.TopHubs, want)
+	}
+	if envelope.Intent == nil || envelope.Intent.RiskLevel != "medium" {
+		t.Fatalf("intent = %#v, want medium risk", envelope.Intent)
+	}
+}
+
+func TestContextEnvelopeV2UnavailableShape(t *testing.T) {
+	files := []scanner.FileInfo{{Path: "main.go"}}
+	graph := &scanner.FileGraph{
+		Packages:  map[string][]string{"main": {"main.go"}},
+		Imports:   map[string][]string{},
+		Importers: map[string][]string{},
+	}
+	envelope := buildContextEnvelopeWithDeps(context.Background(), t.TempDir(), "refactor main.go", true, testContextEnvelopeDeps(files, graph))
+
+	data, err := json.Marshal(envelope)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	project := decoded["project"].(map[string]any)
+	if project["hub_count"] != nil {
+		t.Fatalf("hub_count = %#v, want null", project["hub_count"])
+	}
+	if _, ok := project["top_hubs"]; ok {
+		t.Fatalf("top_hubs must be omitted: %s", data)
+	}
+	evidence := project["graph_evidence"].(map[string]any)
+	if evidence["reason"] != graphEvidenceScanIncomplete {
+		t.Fatalf("evidence = %#v, want scan_incomplete", evidence)
+	}
+	if envelope.Intent == nil || envelope.Intent.RiskLevel != "unknown" {
+		t.Fatalf("intent = %#v, want unknown risk", envelope.Intent)
+	}
+}
+
+func TestContextGraphEvidenceLargeRepositorySkipsGraph(t *testing.T) {
+	files := make([]scanner.FileInfo, 5001)
+	for i := range files {
+		files[i].Path = "pkg/file.go"
+	}
+	deps := testContextEnvelopeDeps(files, nil)
+	graphCalls := 0
+	deps.buildFileGraph = func(context.Context, string) (*scanner.FileGraph, error) {
+		graphCalls++
+		return nil, errors.New("must not run")
+	}
+
+	envelope := buildContextEnvelopeWithDeps(context.Background(), t.TempDir(), "refactor pkg/file.go", true, deps)
+
+	if graphCalls != 0 {
+		t.Fatalf("graph calls = %d, want 0", graphCalls)
+	}
+	if envelope.Project.GraphEvidence.Reason != graphEvidenceLargeRepository || envelope.Project.HubCount != nil {
+		t.Fatalf("project = %#v", envelope.Project)
+	}
+}
+
+func TestContextGraphEvidenceZeroConfiguredFilesProvesEmpty(t *testing.T) {
+	deps := testContextEnvelopeDeps(nil, nil)
+	graphCalls := 0
+	deps.buildFileGraph = func(context.Context, string) (*scanner.FileGraph, error) {
+		graphCalls++
+		return nil, nil
+	}
+
+	envelope := buildContextEnvelopeWithDeps(context.Background(), t.TempDir(), "inspect project", true, deps)
+
+	if graphCalls != 0 {
+		t.Fatalf("graph calls = %d, want 0", graphCalls)
+	}
+	if envelope.Project.HubCount == nil || *envelope.Project.HubCount != 0 {
+		t.Fatalf("hub count = %#v, want numeric zero", envelope.Project.HubCount)
+	}
+	if envelope.Project.GraphEvidence.Status != graphEvidenceAvailable {
+		t.Fatalf("evidence = %#v", envelope.Project.GraphEvidence)
+	}
+}
+
+func TestContextGraphEvidenceCancellationAndDeadline(t *testing.T) {
+	t.Run("cancelled before inventory", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		deps := testContextEnvelopeDeps(nil, nil)
+		deps.scanConfiguredFiles = func(ctx context.Context, _ string) ([]scanner.FileInfo, error) {
+			return nil, ctx.Err()
+		}
+		envelope := buildContextEnvelopeWithDeps(ctx, t.TempDir(), "refactor main.go", true, deps)
+		if envelope.Project.GraphEvidence.Reason != graphEvidenceCancelled {
+			t.Fatalf("evidence = %#v, want cancelled", envelope.Project.GraphEvidence)
+		}
+	})
+
+	t.Run("aggregate deadline", func(t *testing.T) {
+		deps := testContextEnvelopeDeps(nil, nil)
+		deps.graphTimeout = time.Millisecond
+		deps.scanConfiguredFiles = func(ctx context.Context, _ string) ([]scanner.FileInfo, error) {
+			<-ctx.Done()
+			return nil, ctx.Err()
+		}
+		envelope := buildContextEnvelopeWithDeps(context.Background(), t.TempDir(), "refactor main.go", true, deps)
+		if envelope.Project.GraphEvidence.Reason != graphEvidenceDeadline {
+			t.Fatalf("evidence = %#v, want deadline", envelope.Project.GraphEvidence)
+		}
+	})
+}
+
+func TestContextExactPathResolution(t *testing.T) {
+	files := []scanner.FileInfo{{Path: "cmd/context.go"}, {Path: "cmd/nonhub.go"}}
+	graph := &scanner.FileGraph{
+		Imports: map[string][]string{
+			"cmd/nonhub.go": {"cmd/context.go"},
+		},
+		Importers: map[string][]string{
+			"cmd/context.go": {"cmd/nonhub.go"},
+		},
+	}
+	deps := testContextEnvelopeDeps(files, graph)
+
+	for _, tt := range []struct {
+		name     string
+		prompt   string
+		wantFile string
+		wantRisk string
+	}{
+		{name: "present", prompt: "refactor cmd/context.go", wantFile: "cmd/context.go", wantRisk: "low"},
+		{name: "separator normalized", prompt: `refactor cmd\context.go`, wantFile: "cmd/context.go", wantRisk: "low"},
+		{name: "absent", prompt: "refactor cmd/missing.go", wantRisk: "unknown"},
+		{name: "excluded", prompt: "refactor generated/context.go", wantRisk: "unknown"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			envelope := buildContextEnvelopeWithDeps(context.Background(), t.TempDir(), tt.prompt, true, deps)
+			if envelope.Intent == nil {
+				t.Fatal("missing intent")
+			}
+			if envelope.Intent.RiskLevel != tt.wantRisk {
+				t.Fatalf("risk = %q, want %q", envelope.Intent.RiskLevel, tt.wantRisk)
+			}
+			if tt.wantFile == "" {
+				if len(envelope.Intent.Files) != 0 {
+					t.Fatalf("files = %#v, want none", envelope.Intent.Files)
+				}
+			} else if !reflect.DeepEqual(envelope.Intent.Files, []string{tt.wantFile}) {
+				t.Fatalf("files = %#v, want %q", envelope.Intent.Files, tt.wantFile)
+			}
+		})
+	}
+}
+
+func TestHookPromptSubmitDoesNotClaimRiskFromCachedGraph(t *testing.T) {
+	root := t.TempDir()
+	writeWatchState(t, root, watch.State{
+		UpdatedAt: time.Now(),
+		Importers: map[string][]string{
+			"pkg/types.go": {"a.go", "b.go", "c.go"},
+		},
+	})
+
+	withStdinInput(t, mustJSONInput(t, map[string]string{
+		"prompt": "refactor pkg/types.go",
+	}), func() {
+		out := captureOutput(func() {
+			if err := hookPromptSubmit(root); err != nil {
+				t.Fatalf("hookPromptSubmit() error: %v", err)
+			}
+		})
+		if !strings.Contains(out, `"risk":"unknown"`) {
+			t.Fatalf("missing unknown-risk marker:\n%s", out)
+		}
+		if !strings.Contains(out, "pkg/types.go is a HUB") {
+			t.Fatalf("cached display context should remain available:\n%s", out)
+		}
+	})
+
+	status, err := os.ReadFile(filepath.Join(root, ".codemap", "status"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasSuffix(string(status), " unknown") {
+		t.Fatalf("status = %q, want unknown risk", status)
+	}
+}
+
+func TestContextHTTPHandlerPropagatesRequestCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	request := httptest.NewRequest("GET", "/api/context?intent=inspect&compact=true", nil).WithContext(ctx)
+	response := httptest.NewRecorder()
+
+	var observed error
+	handler := newContextHandler(t.TempDir(), func(ctx context.Context, _ string, _ string, _ bool) ContextEnvelope {
+		observed = ctx.Err()
+		return ContextEnvelope{Version: 2}
+	})
+	handler.ServeHTTP(response, request)
+
+	if !errors.Is(observed, context.Canceled) {
+		t.Fatalf("builder context error = %v, want canceled", observed)
+	}
+}
+
+func TestContextRequestsKeepInventoryLocal(t *testing.T) {
+	type result struct {
+		count int
+		langs []string
+	}
+	results := make(chan result, 2)
+	requests := []contextEnvelopeDeps{
+		testContextEnvelopeDeps([]scanner.FileInfo{{Path: "main.go"}}, &scanner.FileGraph{Imports: map[string][]string{"main.go": {"dep.go"}}}),
+		testContextEnvelopeDeps([]scanner.FileInfo{{Path: "src/lib.rs"}, {Path: "src/main.rs"}}, &scanner.FileGraph{Imports: map[string][]string{"src/main.rs": {"src/lib.rs"}}}),
+	}
+
+	for _, deps := range requests {
+		deps := deps
+		go func() {
+			envelope := buildContextEnvelopeWithDeps(context.Background(), t.TempDir(), "inspect", true, deps)
+			results <- result{count: envelope.Project.FileCount, langs: envelope.Project.Languages}
+		}()
+	}
+
+	got := []result{<-results, <-results}
+	if got[0].count > got[1].count {
+		got[0], got[1] = got[1], got[0]
+	}
+	if got[0].count != 1 || !reflect.DeepEqual(got[0].langs, []string{"go"}) {
+		t.Fatalf("one-file request = %#v", got[0])
+	}
+	if got[1].count != 2 || !reflect.DeepEqual(got[1].langs, []string{"rust"}) {
+		t.Fatalf("two-file request = %#v", got[1])
+	}
+}
+
+func TestContextWorkingSetRequiresFreshGraphEvidence(t *testing.T) {
+	cached := watch.NewWorkingSet()
+	cached.Touch("pkg/types.go", 3, true, 9)
+	foreignState := &watch.State{WorkingSet: cached}
+
+	t.Run("foreign setup-root state cannot leak hub claims", func(t *testing.T) {
+		deps := testContextEnvelopeDeps([]scanner.FileInfo{{Path: "pkg/types.go"}}, nil)
+		deps.readState = func(string) *watch.State { return foreignState }
+		envelope := buildContextEnvelopeWithDeps(context.Background(), t.TempDir(), "inspect", true, deps)
+		if envelope.Project.GraphEvidence.Status != graphEvidenceUnavailable {
+			t.Fatalf("evidence = %#v", envelope.Project.GraphEvidence)
+		}
+		if envelope.WorkingSet != nil {
+			t.Fatalf("working set leaked stale structural claims: %#v", envelope.WorkingSet)
+		}
+	})
+
+	t.Run("fresh graph recomputes cached labels", func(t *testing.T) {
+		graph := &scanner.FileGraph{
+			Imports:   map[string][]string{"pkg/types.go": {"dep.go"}},
+			Importers: map[string][]string{"pkg/types.go": {}},
+		}
+		deps := testContextEnvelopeDeps([]scanner.FileInfo{{Path: "pkg/types.go"}}, graph)
+		deps.readState = func(string) *watch.State { return foreignState }
+		envelope := buildContextEnvelopeWithDeps(context.Background(), t.TempDir(), "inspect", true, deps)
+		if envelope.WorkingSet == nil || envelope.WorkingSet.HubCount != 0 {
+			t.Fatalf("working set = %#v, want fresh zero hubs", envelope.WorkingSet)
+		}
+		if len(envelope.WorkingSet.TopFiles) != 1 || envelope.WorkingSet.TopFiles[0].IsHub {
+			t.Fatalf("working files retained cached hub label: %#v", envelope.WorkingSet.TopFiles)
+		}
+	})
+}
+
+func testContextEnvelopeDeps(files []scanner.FileInfo, graph *scanner.FileGraph) contextEnvelopeDeps {
+	return contextEnvelopeDeps{
+		readState: func(string) *watch.State { return nil },
+		scanConfiguredFiles: func(context.Context, string) ([]scanner.FileInfo, error) {
+			return append([]scanner.FileInfo(nil), files...), nil
+		},
+		buildFileGraph: func(context.Context, string) (*scanner.FileGraph, error) {
+			return graph, nil
+		},
+		now:          func() time.Time { return time.Unix(1, 0).UTC() },
+		graphTimeout: time.Second,
+	}
+}

--- a/cmd/context_evidence_test.go
+++ b/cmd/context_evidence_test.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"net/http/httptest"
 	"os"
@@ -12,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"codemap/analysis"
 	"codemap/scanner"
 	"codemap/watch"
 )
@@ -52,7 +52,7 @@ func TestContextGraphEvidenceTrueHubAndDeterministicOrder(t *testing.T) {
 	}
 }
 
-func TestContextEnvelopeV2UnavailableShape(t *testing.T) {
+func TestContextGraphEvidenceZeroEdgesProvesEmpty(t *testing.T) {
 	files := []scanner.FileInfo{{Path: "main.go"}}
 	graph := &scanner.FileGraph{
 		Packages:  map[string][]string{"main": {"main.go"}},
@@ -61,24 +61,53 @@ func TestContextEnvelopeV2UnavailableShape(t *testing.T) {
 	}
 	envelope := buildContextEnvelopeWithDeps(context.Background(), t.TempDir(), "refactor main.go", true, testContextEnvelopeDeps(files, graph))
 
-	data, err := json.Marshal(envelope)
-	if err != nil {
-		t.Fatal(err)
+	if envelope.Project.GraphEvidence != (GraphEvidence{Status: graphEvidenceAvailable, Source: graphEvidenceFreshScan}) {
+		t.Fatalf("graph evidence = %#v, want fresh available", envelope.Project.GraphEvidence)
 	}
-	var decoded map[string]any
-	if err := json.Unmarshal(data, &decoded); err != nil {
-		t.Fatal(err)
+	if envelope.Project.HubCount == nil || *envelope.Project.HubCount != 0 {
+		t.Fatalf("hub count = %#v, want numeric zero", envelope.Project.HubCount)
 	}
-	project := decoded["project"].(map[string]any)
-	if project["hub_count"] != nil {
-		t.Fatalf("hub_count = %#v, want null", project["hub_count"])
+	if envelope.Intent == nil || envelope.Intent.RiskLevel != "low" {
+		t.Fatalf("intent = %#v, want low risk", envelope.Intent)
 	}
-	if _, ok := project["top_hubs"]; ok {
-		t.Fatalf("top_hubs must be omitted: %s", data)
+}
+
+func TestContextGraphEvidenceUnavailableCoverageFailsClosed(t *testing.T) {
+	files := []scanner.FileInfo{{Path: "main.go"}}
+	graph := &scanner.FileGraph{
+		Imports:   map[string][]string{"main.go": {"dep.go"}},
+		Importers: map[string][]string{"dep.go": {"main.go"}},
+		Coverage:  scanner.GraphCoverage{Status: analysis.CoverageUnavailable},
 	}
-	evidence := project["graph_evidence"].(map[string]any)
-	if evidence["reason"] != graphEvidenceScanIncomplete {
-		t.Fatalf("evidence = %#v, want scan_incomplete", evidence)
+	envelope := buildContextEnvelopeWithDeps(context.Background(), t.TempDir(), "refactor main.go", true, testContextEnvelopeDeps(files, graph))
+
+	if envelope.Project.GraphEvidence.Status != graphEvidenceUnavailable || envelope.Project.GraphEvidence.Reason != graphEvidenceScanIncomplete {
+		t.Fatalf("graph evidence = %#v, want unavailable scan_incomplete", envelope.Project.GraphEvidence)
+	}
+	if envelope.Project.HubCount != nil {
+		t.Fatalf("hub count = %#v, want null", envelope.Project.HubCount)
+	}
+	if envelope.Intent == nil || envelope.Intent.RiskLevel != "unknown" {
+		t.Fatalf("intent = %#v, want unknown risk", envelope.Intent)
+	}
+}
+
+func TestContextGraphEvidenceFailedOnlyCoverageFailsClosed(t *testing.T) {
+	files := []scanner.FileInfo{{Path: "main.go"}}
+	graph := &scanner.FileGraph{
+		Imports:   map[string][]string{"main.go": {"dep.go"}},
+		Importers: map[string][]string{"dep.go": {"main.go"}},
+		Coverage: scanner.GraphCoverage{Sources: []analysis.Source{{
+			Name: "go", Status: analysis.SourceFailed,
+		}}},
+	}
+	envelope := buildContextEnvelopeWithDeps(context.Background(), t.TempDir(), "refactor main.go", true, testContextEnvelopeDeps(files, graph))
+
+	if envelope.Project.GraphEvidence.Status != graphEvidenceUnavailable || envelope.Project.GraphEvidence.Reason != graphEvidenceScanIncomplete {
+		t.Fatalf("graph evidence = %#v, want unavailable scan_incomplete", envelope.Project.GraphEvidence)
+	}
+	if envelope.Project.HubCount != nil {
+		t.Fatalf("hub count = %#v, want null", envelope.Project.HubCount)
 	}
 	if envelope.Intent == nil || envelope.Intent.RiskLevel != "unknown" {
 		t.Fatalf("intent = %#v, want unknown risk", envelope.Intent)

--- a/cmd/context_test.go
+++ b/cmd/context_test.go
@@ -53,8 +53,6 @@ func TestBuildContextEnvelopeRespectsConfiguredFilters(t *testing.T) {
 	mustWriteFile(t, filepath.Join(root, "schema.ts"), "export const schema = 1\n")
 	mustWriteFile(t, filepath.Join(root, "generated", "hidden.go"), "package generated\n")
 
-	cachedFileCount = -1
-	t.Cleanup(func() { cachedFileCount = -1 })
 	envelope := buildContextEnvelope(root, "", true)
 
 	if envelope.Project.FileCount != 1 {
@@ -62,16 +60,6 @@ func TestBuildContextEnvelopeRespectsConfiguredFilters(t *testing.T) {
 	}
 	if !reflect.DeepEqual(envelope.Project.Languages, []string{"go"}) {
 		t.Fatalf("languages = %#v, want [go]", envelope.Project.Languages)
-	}
-}
-
-func TestCountSourceFilesReturnsZeroWhenConfiguredScanFails(t *testing.T) {
-	cachedFileCount = -1
-	t.Cleanup(func() { cachedFileCount = -1 })
-
-	missingRoot := filepath.Join(t.TempDir(), "missing")
-	if got := countSourceFiles(missingRoot); got != 0 {
-		t.Fatalf("countSourceFiles(missing root) = %d, want 0", got)
 	}
 }
 
@@ -90,8 +78,6 @@ func TestBuildContextEnvelopeFallsBackToConfiguredScanForLegacyState(t *testing.
 	}
 	mustWriteFile(t, filepath.Join(root, ".codemap", "state.json"), string(legacyState))
 
-	cachedFileCount = -1
-	t.Cleanup(func() { cachedFileCount = -1 })
 	envelope := buildContextEnvelope(root, "", true)
 
 	if envelope.Project.FileCount != 1 {

--- a/cmd/hooks.go
+++ b/cmd/hooks.go
@@ -811,7 +811,7 @@ func hookPromptSubmit(root string) error {
 
 	// Extract mentioned files and classify intent
 	filesMentioned := extractMentionedFiles(prompt, topK)
-	intent := classifyIntent(prompt, filesMentioned, info, projCfg)
+	intent := classifyIntent(prompt, filesMentioned, nil, projCfg)
 
 	// Emit structured intent marker (machine-readable for tools) only when the
 	// classification is trustworthy — a zero/low-confidence category is a

--- a/cmd/intent.go
+++ b/cmd/intent.go
@@ -15,7 +15,7 @@ type TaskIntent struct {
 	Files              []string            `json:"files"`       // mentioned files
 	Subsystems         []string            `json:"subsystems"`  // matched subsystem IDs
 	Scope              string              `json:"scope"`       // "single-file", "package", "cross-cutting"
-	RiskLevel          string              `json:"risk"`        // "low", "medium", "high"
+	RiskLevel          string              `json:"risk"`        // "unknown", "low", "medium", "high"
 	Suggestions        []ContextSuggestion `json:"suggestions"` // what to read/check next
 	DependencyCoverage string              `json:"dependency_coverage,omitempty"`
 	CoverageNotes      []string            `json:"coverage_notes,omitempty"`
@@ -113,7 +113,7 @@ func classifyIntent(prompt string, files []string, info *hubInfo, cfg config.Pro
 	intent := TaskIntent{
 		Category:  "feature", // default
 		Files:     files,
-		RiskLevel: "low",
+		RiskLevel: "unknown",
 		Scope:     "single-file",
 	}
 	if info != nil {
@@ -164,8 +164,14 @@ func classifyIntent(prompt string, files []string, info *hubInfo, cfg config.Pro
 	}
 
 	// Compute risk level and generate suggestions from hub analysis
-	if info != nil {
+	if info != nil && len(files) > 0 {
 		intent.RiskLevel, intent.Suggestions = analyzeRisk(files, info, intent.Category)
+	} else {
+		intent.Suggestions = []ContextSuggestion{{
+			Type:   "check-deps",
+			Target: ".",
+			Reason: "risk is unknown without a configured file and available dependency graph",
+		}}
 	}
 
 	return intent

--- a/cmd/intent_test.go
+++ b/cmd/intent_test.go
@@ -235,8 +235,8 @@ func TestClassifyIntent_SubsystemMatching(t *testing.T) {
 func TestClassifyIntent_NilInfoSafe(t *testing.T) {
 	// Should not panic with nil hubInfo
 	intent := classifyIntent("refactor everything", []string{"main.go"}, nil, config.ProjectConfig{})
-	if intent.RiskLevel != "low" {
-		t.Errorf("expected low risk with nil info, got %q", intent.RiskLevel)
+	if intent.RiskLevel != "unknown" {
+		t.Errorf("expected unknown risk with nil info, got %q", intent.RiskLevel)
 	}
 	if intent.Category != "refactor" {
 		t.Errorf("expected refactor category, got %q", intent.Category)

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -39,12 +40,7 @@ func RunServe(args []string, root string) {
 	mux := http.NewServeMux()
 
 	// GET /api/context — full context envelope
-	mux.HandleFunc("/api/context", func(w http.ResponseWriter, r *http.Request) {
-		prompt := r.URL.Query().Get("intent")
-		compact := r.URL.Query().Get("compact") == "true"
-		envelope := buildContextEnvelope(absRoot, prompt, compact)
-		writeJSON(w, envelope)
-	})
+	mux.HandleFunc("/api/context", newContextHandler(absRoot, buildContextEnvelopeContext))
 
 	// GET /api/skills — list available skills
 	mux.HandleFunc("/api/skills", func(w http.ResponseWriter, r *http.Request) {
@@ -149,6 +145,16 @@ func RunServe(args []string, root string) {
 	if err := server.ListenAndServe(); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
+	}
+}
+
+type contextEnvelopeBuilder func(context.Context, string, string, bool) ContextEnvelope
+
+func newContextHandler(root string, build contextEnvelopeBuilder) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		prompt := r.URL.Query().Get("intent")
+		compact := r.URL.Query().Get("compact") == "true"
+		writeJSON(w, build(r.Context(), root, prompt, compact))
 	}
 }
 

--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -249,7 +249,7 @@ Or if it's a hub:
 
 ### When You Mention a File (Prompt Submit)
 
-The prompt-submit hook now performs **intent classification** — it analyzes what you're trying to do and surfaces relevant code intelligence.
+The prompt-submit hook performs **intent classification** and surfaces relevant code intelligence. Cached hub context may still be displayed, but hook risk is `unknown` unless a request has fresh dependency evidence.
 
 ```
 <!-- codemap:intent {"category":"refactor","confidence":1,"risk":"high",...} -->
@@ -295,6 +295,7 @@ Next codemap:
 
 | Level | Meaning |
 |-------|---------|
+| `unknown` | Fresh dependency evidence is unavailable |
 | `low` | No hub files involved |
 | `medium` | 1 hub file in scope |
 | `high` | 2+ hub files, or a hub with 8+ importers |


### PR DESCRIPTION
## What does this PR do?

- Builds one bounded request-local dependency graph for CLI and HTTP context.
- Reports unavailable evidence and unknown risk instead of false zero hubs or low risk.
- Keeps prompt hooks scan-free and propagates HTTP cancellation.

This prevents agentic coding workflows from treating missing graph evidence as a safe change.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] New language support
- [x] Documentation
- [ ] Other

## Checklist

- [x] Tested locally with `GOENV_VERSION=1.26.5 go test ./cmd ./scanner ./watch -count=1`
- [x] Verified with full vet and race tests
- [x] Updated context and hook documentation

## Additional notes

The JSON envelope is version 2: hub counts are nullable and graph availability is explicit.

Developed with carefully directed, manually reviewed AI assistance.