### PR TITLE
fix(setup): reconcile duplicate Codex hooks

### DIFF
--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -76,6 +76,7 @@ type ensureHooksResult struct {
 	CreatedFile    bool
 	WroteFile      bool
 	AddedHooks     int
+	RemovedHooks   int
 	ExistingHooks  int
 	TotalCodemap   int
 	TargetIsGlobal bool
@@ -326,10 +327,12 @@ func configureHooks(label string, pathFor func(string, bool) (string, error), en
 		fmt.Fprintf(os.Stderr, "%s hooks: failed (%v)\n", label, err)
 		return err
 	}
-	if result.AddedHooks == 0 {
+	if result.AddedHooks == 0 && result.RemovedHooks == 0 {
 		fmt.Printf("%s hooks: already configured (%s)\n", label, result.SettingsPath)
 	} else if result.CreatedFile {
 		fmt.Printf("%s hooks: created %s (+%d codemap hooks)\n", label, result.SettingsPath, result.AddedHooks)
+	} else if result.RemovedHooks > 0 {
+		fmt.Printf("%s hooks: reconciled %s (+%d, -%d stale codemap hooks)\n", label, result.SettingsPath, result.AddedHooks, result.RemovedHooks)
 	} else {
 		fmt.Printf("%s hooks: updated %s (+%d codemap hooks)\n", label, result.SettingsPath, result.AddedHooks)
 	}
@@ -537,11 +540,17 @@ func ensureClaudeHooksWithExecutable(settingsPath string, global bool, executabl
 
 func ensureCodexHooksWithExecutable(settingsPath string, global bool, executable string) (ensureHooksResult, error) {
 	specs := generatedCodexHooks(executable)
-	return ensureHooks(settingsPath, global, specs, codexHookCommandAliases(specs))
+	return ensureHooksWithReconciler(settingsPath, global, specs, codexHookCommandAliases(specs), reconcileCodexHooks)
 }
 
 func codexHookCommandAliases(specs []claudeHookSpec) map[string]string {
-	return map[string]string{
+	aliases := map[string]string{
+		"codemap hook session-start":                        specs[0].Command,
+		"codemap hook pre-edit":                             specs[1].Command,
+		"codemap hook post-edit":                            specs[2].Command,
+		"codemap hook prompt-submit":                        specs[3].Command,
+		"codemap hook pre-compact":                          specs[4].Command,
+		"codemap hook session-stop":                         specs[5].Command,
 		"CODEX=1 codemap hook session-start":                specs[0].Command,
 		"CODEX=1 codemap hook pre-edit":                     specs[1].Command,
 		"CODEX=1 codemap hook post-edit":                    specs[2].Command,
@@ -553,9 +562,106 @@ func codexHookCommandAliases(specs []claudeHookSpec) map[string]string {
 		"CODEX=1 codemap hook session-stop 2> /dev/null":    specs[5].Command,
 		"CODEX=1 codemap hook session-stop >/dev/null 2>&1": specs[5].Command,
 	}
+	return aliases
+}
+
+// reconcileCodexHooks removes Codex-owned legacy, misplaced, and duplicate
+// commands while retaining one exact canonical hook for each event/matcher.
+// Non-command and non-Codex hooks, including hooks sharing an entry, remain
+// untouched.
+func reconcileCodexHooks(hooksByEvent map[string]any, specs []claudeHookSpec) (bool, int, error) {
+	aliases := codexHookCommandAliases(specs)
+	canonicalSeen := make([]bool, len(specs))
+	changed := false
+	removed := 0
+
+	for event := range hooksByEvent {
+		entries, err := rawHookEntries(hooksByEvent, event)
+		if err != nil {
+			return false, 0, err
+		}
+		keptEntries := make([]any, 0, len(entries))
+		for entryIndex, rawEntry := range entries {
+			entry, ok := rawEntry.(map[string]any)
+			if !ok {
+				return false, 0, fmt.Errorf("event %q entry %d must be an object", event, entryIndex)
+			}
+			rawHooks, exists := entry["hooks"]
+			if !exists || rawHooks == nil {
+				keptEntries = append(keptEntries, rawEntry)
+				continue
+			}
+			hooks, ok := rawHooks.([]any)
+			if !ok {
+				return false, 0, fmt.Errorf("event %q entry %d hooks must be an array", event, entryIndex)
+			}
+			keptHooks := make([]any, 0, len(hooks))
+			removedFromEntry := false
+			for hookIndex, rawHook := range hooks {
+				hook, ok := rawHook.(map[string]any)
+				if !ok {
+					return false, 0, fmt.Errorf("event %q entry %d hook %d must be an object", event, entryIndex, hookIndex)
+				}
+				typeName, _ := hook["type"].(string)
+				if !strings.EqualFold(strings.TrimSpace(typeName), "command") {
+					keptHooks = append(keptHooks, rawHook)
+					continue
+				}
+				command, _ := hook["command"].(string)
+				specIndex := codexOwnedHookSpecIndex(strings.TrimSpace(command), aliases, specs)
+				if specIndex < 0 {
+					keptHooks = append(keptHooks, rawHook)
+					continue
+				}
+				spec := specs[specIndex]
+				matcher, _ := entry["matcher"].(string)
+				canonical := event == spec.Event && strings.EqualFold(strings.TrimSpace(matcher), strings.TrimSpace(spec.Matcher)) && strings.TrimSpace(command) == strings.TrimSpace(spec.Command)
+				if canonical && !canonicalSeen[specIndex] {
+					canonicalSeen[specIndex] = true
+					keptHooks = append(keptHooks, rawHook)
+				} else {
+					changed = true
+					removed++
+					removedFromEntry = true
+				}
+			}
+			if len(keptHooks) == 0 && removedFromEntry {
+				changed = true
+				continue
+			}
+			entry["hooks"] = keptHooks
+			keptEntries = append(keptEntries, rawEntry)
+		}
+		if len(keptEntries) != len(entries) {
+			hooksByEvent[event] = keptEntries
+		}
+	}
+	return changed, removed, nil
+}
+
+func codexOwnedHookSpecIndex(command string, aliases map[string]string, specs []claudeHookSpec) int {
+	if target, ok := aliases[command]; ok {
+		for index, spec := range specs {
+			if target == spec.Command {
+				return index
+			}
+		}
+	}
+	for index, spec := range specs {
+		if _, ok := migrateOwnedHookCommand(command, spec.Command); ok {
+			return index
+		}
+	}
+	return -1
 }
 
 func ensureHooks(settingsPath string, global bool, specs []claudeHookSpec, commandAliases map[string]string) (ensureHooksResult, error) {
+	return ensureHooksWithReconciler(settingsPath, global, specs, commandAliases, nil)
+}
+
+type hookReconciler func(map[string]any, []claudeHookSpec) (changed bool, removed int, err error)
+
+func ensureHooksWithReconciler(settingsPath string, global bool, specs []claudeHookSpec, commandAliases map[string]string, reconcile hookReconciler) (ensureHooksResult, error) {
 	result := ensureHooksResult{
 		SettingsPath:   settingsPath,
 		TotalCodemap:   len(specs),
@@ -591,7 +697,14 @@ func ensureHooks(settingsPath string, global bool, specs []claudeHookSpec, comma
 			return result, fmt.Errorf("parse hooks in %s: hooks must be an object", settingsPath)
 		}
 	}
-	migrated, err := migrateRawHookCommands(hooksByEvent, commandAliases, specs)
+	migrated := false
+	if reconcile != nil {
+		var removed int
+		migrated, removed, err = reconcile(hooksByEvent, specs)
+		result.RemovedHooks = removed
+	} else {
+		migrated, err = migrateRawHookCommands(hooksByEvent, commandAliases, specs)
+	}
 	if err != nil {
 		return result, fmt.Errorf("parse hooks in %s: %w", settingsPath, err)
 	}

--- a/cmd/setup_test.go
+++ b/cmd/setup_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -174,6 +175,174 @@ func TestEnsureClaudeHooksAddsMatcherScopedHookWhenMatcherMissing(t *testing.T) 
 	if !foundRecommended {
 		t.Fatal("expected setup to add matcher-scoped PreToolUse codemap hook")
 	}
+}
+
+func TestEnsureCodexHooksReconcilesMixedLegacyAndCanonicalConfig(t *testing.T) {
+	settingsPath := filepath.Join(t.TempDir(), ".codex", "hooks.json")
+	executable := "/tmp/codemap-test"
+	specs := generatedCodexHooks(executable)
+	fixture := map[string]any{
+		"unknown": json.Number("9007199254740993123"),
+		"hooks": map[string]any{
+			"SessionStart":     []any{hookTestEntry("", "codemap hook session-start"), hookTestEntry("", specs[0].Command)},
+			"UserPromptSubmit": []any{hookTestEntry("", "codemap hook prompt-submit"), hookTestEntry("", specs[3].Command)},
+			"PreCompact":       []any{hookTestEntry("", "codemap hook pre-compact"), hookTestEntry("", specs[4].Command)},
+			"PreToolUse":       []any{hookTestEntry("Edit|Write", "codemap hook pre-edit"), hookTestEntry("apply_patch|Edit|Write", specs[1].Command)},
+			"PostToolUse": []any{
+				hookTestEntry("Edit|Write", "codemap hook post-edit"),
+				map[string]any{"matcher": "apply_patch|Edit|Write", "hooks": []any{
+					map[string]any{"type": "command", "command": specs[2].Command},
+					map[string]any{"type": "command", "command": "screenshot --capture"},
+				}},
+			},
+			"SessionEnd": []any{hookTestEntry("", "codemap hook session-stop")},
+			"Stop":       []any{hookTestEntry("", specs[5].Command)},
+		},
+	}
+	writeCodexHookFixture(t, settingsPath, fixture)
+
+	result, err := ensureCodexHooksWithExecutable(settingsPath, false, executable)
+	if err != nil {
+		t.Fatalf("ensureCodexHooksWithExecutable: %v", err)
+	}
+	if result.AddedHooks != 0 || result.RemovedHooks != 6 || !result.WroteFile {
+		t.Fatalf("result = %+v, want AddedHooks=0 RemovedHooks=6 WroteFile=true", result)
+	}
+	settings := readSettingsFile(t, settingsPath)
+	precisionSettings, err := decodeJSONObject(mustReadFile(t, settingsPath))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, ok := precisionSettings["unknown"].(json.Number); !ok || got.String() != "9007199254740993123" {
+		t.Fatalf("unknown precision changed: %#v", precisionSettings["unknown"])
+	}
+	assertCodexCanonicalHooks(t, readHooksMap(t, settings), specs)
+	if entries := readHooksMap(t, settings)["SessionEnd"]; len(entries) != 0 {
+		for _, entry := range entries {
+			for _, hook := range entry.Hooks {
+				if strings.Contains(hook.Command, "codemap") {
+					t.Fatalf("legacy SessionEnd Codemap hook remains: %q", hook.Command)
+				}
+			}
+		}
+	}
+	if !hookCommandExists(readHooksMap(t, settings)["PostToolUse"], "screenshot --capture") {
+		t.Fatal("unrelated screenshot hook was not preserved")
+	}
+
+	second, err := ensureCodexHooksWithExecutable(settingsPath, false, executable)
+	if err != nil {
+		t.Fatalf("second ensureCodexHooksWithExecutable: %v", err)
+	}
+	if second.AddedHooks != 0 || second.RemovedHooks != 0 || second.WroteFile {
+		t.Fatalf("second result = %+v, want zero additions/removals and no write", second)
+	}
+}
+
+func TestEnsureCodexHooksMigratesLegacyOnlyConfig(t *testing.T) {
+	settingsPath := filepath.Join(t.TempDir(), ".codex", "hooks.json")
+	executable := "/tmp/codemap-test"
+	specs := generatedCodexHooks(executable)
+	fixture := map[string]any{"hooks": map[string]any{
+		"SessionStart":     []any{hookTestEntry("", "codemap hook session-start")},
+		"PreToolUse":       []any{hookTestEntry("Edit|Write", "codemap hook pre-edit")},
+		"PostToolUse":      []any{hookTestEntry("Edit|Write", "codemap hook post-edit")},
+		"UserPromptSubmit": []any{hookTestEntry("", "codemap hook prompt-submit")},
+		"PreCompact":       []any{hookTestEntry("", "codemap hook pre-compact")},
+		"SessionEnd":       []any{hookTestEntry("", "codemap hook session-stop")},
+	}}
+	writeCodexHookFixture(t, settingsPath, fixture)
+
+	result, err := ensureCodexHooksWithExecutable(settingsPath, false, executable)
+	if err != nil {
+		t.Fatalf("ensureCodexHooksWithExecutable: %v", err)
+	}
+	if result.AddedHooks != 6 || result.RemovedHooks != 6 || !result.WroteFile {
+		t.Fatalf("result = %+v, want AddedHooks=6 RemovedHooks=6 WroteFile=true", result)
+	}
+	settings := readSettingsFile(t, settingsPath)
+	assertCodexCanonicalHooks(t, readHooksMap(t, settings), specs)
+	if len(readHooksMap(t, settings)["SessionEnd"]) != 0 {
+		t.Fatal("legacy SessionEnd event was not removed")
+	}
+	second, err := ensureCodexHooksWithExecutable(settingsPath, false, executable)
+	if err != nil {
+		t.Fatalf("second ensureCodexHooksWithExecutable: %v", err)
+	}
+	if second.AddedHooks != 0 || second.RemovedHooks != 0 || second.WroteFile {
+		t.Fatalf("second result = %+v, want zero additions/removals and no write", second)
+	}
+}
+
+func hookTestEntry(matcher, command string) map[string]any {
+	entry := map[string]any{"hooks": []any{map[string]any{"type": "command", "command": command}}}
+	if matcher != "" {
+		entry["matcher"] = matcher
+	}
+	return entry
+}
+
+func writeCodexHookFixture(t *testing.T, path string, fixture map[string]any) {
+	t.Helper()
+	data, err := json.MarshalIndent(fixture, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, append(data, '\n'), 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func mustReadFile(t *testing.T, path string) []byte {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return data
+}
+
+func assertCodexCanonicalHooks(t *testing.T, hooks map[string][]claudeHookEntry, specs []claudeHookSpec) {
+	t.Helper()
+	for _, spec := range specs {
+		count := 0
+		for _, entry := range hooks[spec.Event] {
+			if strings.TrimSpace(entry.Matcher) != strings.TrimSpace(spec.Matcher) {
+				continue
+			}
+			for _, hook := range entry.Hooks {
+				if strings.TrimSpace(hook.Command) == spec.Command {
+					count++
+				}
+			}
+		}
+		if count != 1 {
+			t.Errorf("canonical %s hook count = %d, want 1", spec.Event, count)
+		}
+	}
+	for event, entries := range hooks {
+		for _, entry := range entries {
+			for _, hook := range entry.Hooks {
+				if strings.Contains(hook.Command, "codemap hook") && !strings.Contains(hook.Command, "--integration=codex-setup") {
+					t.Errorf("legacy Codemap command remains in %s: %q", event, hook.Command)
+				}
+			}
+		}
+	}
+}
+
+func hookCommandExists(entries []claudeHookEntry, command string) bool {
+	for _, entry := range entries {
+		for _, hook := range entry.Hooks {
+			if hook.Command == command {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func readSettingsFile(t *testing.T, path string) map[string]interface{} {


### PR DESCRIPTION
## What changed

- Reconcile legacy, misplaced, wrong-matcher, and duplicate Codemap hooks during Codex setup.
- Keep exactly one canonical managed hook for each Codex lifecycle event.
- Move legacy session-stop registration from SessionEnd to Stop.
- Preserve unrelated hooks and unknown configuration fields.
- Report stale-hook removals in setup output.

## Root cause

Older plain Codemap registrations and newer managed registrations could coexist. Setup migrated some command strings but did not remove duplicate entries, correct old matchers, or move the legacy stop event, so Codex executed the same hook twice.

## Verification

- Focused Codex hook reconciliation tests
- Full `go test ./... -count=1`
- Focused race test
- `git diff --check`

The regression fixture matches the duplicate global configuration reproduced in a live Codex session and proves a second setup run is a no-write operation.
