### PR TITLE
fix(scanner): Resolve Rust use trees

### DIFF
--- a/scanner/astgrep.go
+++ b/scanner/astgrep.go
@@ -348,6 +348,9 @@ func (s *AstGrepScanner) scanDirectory(parent context.Context, root string) ([]F
 				if pathVar, ok := m.MetaVariables.Single["PATH"]; ok {
 					path = pathVar.Text
 				}
+				if len(expandRustUsePaths(path)) > 0 {
+					kind = "rust-use"
+				}
 			case "rust-askama-template-imports":
 				kind = "rust-askama-template"
 				if targetVar, ok := m.MetaVariables.Single["TARGET"]; ok && !rustAttributeAssigns(m.Text, "config") {

--- a/scanner/astgrep.go
+++ b/scanner/astgrep.go
@@ -348,7 +348,11 @@ func (s *AstGrepScanner) scanDirectory(parent context.Context, root string) ([]F
 				if pathVar, ok := m.MetaVariables.Single["PATH"]; ok {
 					path = pathVar.Text
 				}
-				if len(expandRustUsePaths(path)) > 0 {
+				if len(expandRustUsePaths(path)) > 0 || strings.ContainsAny(path, "{}") {
+					// Brace trees that fail to expand (comments in the group,
+					// empty groups, external groups) stay rust-use: the
+					// resolver emits nothing instead of rust-path splitting
+					// the raw braces into a false crate-root edge.
 					kind = "rust-use"
 				}
 			case "rust-askama-template-imports":

--- a/scanner/cancellation_test.go
+++ b/scanner/cancellation_test.go
@@ -126,13 +126,16 @@ exec sleep 10
 		}
 		time.Sleep(5 * time.Millisecond)
 	}
+	// Anchor the termination budget to the deadline: it runs concurrently
+	// with the deadline, so a bare budget leaves only the spawn latency
+	// of slack after the deadline fires.
 	const terminateBudget = 5 * time.Second
 	select {
 	case err := <-done:
 		if !errors.Is(err, context.DeadlineExceeded) {
 			t.Fatalf("caller-deadline ScanDirectory error = %v, want context.DeadlineExceeded", err)
 		}
-	case <-time.After(terminateBudget):
+	case <-time.After(scanDeadline + terminateBudget):
 		t.Fatal("ScanDirectory did not terminate deadline-exceeded subprocess")
 	}
 	if elapsed := time.Since(started); elapsed > scanDeadline+terminateBudget {

--- a/scanner/rustgraph.go
+++ b/scanner/rustgraph.go
@@ -663,6 +663,12 @@ func resolveRustReferences(root string, analysis FileAnalysis, idx *fileIndex, w
 			if target := resolveRustModule(ref.Path, analysis.Path, idx, workspace); target != "" && target != analysis.Path {
 				resolved = append(resolved, target)
 			}
+		case "rust-use":
+			for _, path := range expandRustUsePaths(ref.Path) {
+				if target := resolveRustPath(path, analysis.Path, idx, workspace); target != "" && target != analysis.Path {
+					resolved = append(resolved, target)
+				}
+			}
 		case "rust-path":
 			if target := resolveRustPath(ref.Path, analysis.Path, idx, workspace); target != "" && target != analysis.Path {
 				resolved = append(resolved, target)

--- a/scanner/rustuse.go
+++ b/scanner/rustuse.go
@@ -1,0 +1,217 @@
+package scanner
+
+import (
+	"strings"
+	"unicode"
+)
+
+const maxRustUseTreeDepth = 64
+
+func expandRustUsePaths(path string) []string {
+	path = strings.TrimSpace(path)
+	root := path
+	if end := strings.IndexAny(root, ":{ 	\r\n"); end >= 0 {
+		root = root[:end]
+	}
+	if root != "crate" && root != "self" && root != "super" {
+		return nil
+	}
+
+	paths, ok := expandRustUseTree(path, "", 0)
+	if !ok {
+		return nil
+	}
+	return dedupe(paths)
+}
+
+func expandRustUseTree(tree, prefix string, depth int) ([]string, bool) {
+	if depth > maxRustUseTreeDepth {
+		return nil, false
+	}
+	tree = strings.TrimSpace(tree)
+	if tree == "" {
+		return nil, false
+	}
+
+	var ok bool
+	tree, ok = trimRustUseAlias(tree)
+	if !ok {
+		return nil, false
+	}
+
+	open := strings.IndexByte(tree, '{')
+	if open < 0 {
+		return expandRustUseLeaf(tree, prefix)
+	}
+
+	close, ok := matchingRustUseBrace(tree, open)
+	if !ok || strings.TrimSpace(tree[close+1:]) != "" {
+		return nil, false
+	}
+	head := strings.TrimSpace(strings.TrimSuffix(strings.TrimSpace(tree[:open]), "::"))
+	if strings.ContainsAny(head, "{},") {
+		return nil, false
+	}
+	if head != "" {
+		prefix = joinRustUsePath(prefix, head)
+	}
+	if prefix == "" {
+		return nil, false
+	}
+
+	items, ok := splitRustUseItems(tree[open+1 : close])
+	if !ok {
+		return nil, false
+	}
+	var paths []string
+	for _, item := range items {
+		expanded, ok := expandRustUseTree(item, prefix, depth+1)
+		if !ok {
+			return nil, false
+		}
+		paths = append(paths, expanded...)
+	}
+	return paths, true
+}
+
+func expandRustUseLeaf(leaf, prefix string) ([]string, bool) {
+	if strings.ContainsAny(leaf, "{},") {
+		return nil, false
+	}
+	if strings.HasSuffix(leaf, "::*") {
+		leaf = strings.TrimSuffix(leaf, "::*")
+	} else if leaf == "self" || leaf == "*" {
+		leaf = ""
+	}
+	path := joinRustUsePath(prefix, leaf)
+	if !validRustUsePath(path) {
+		return nil, false
+	}
+	return []string{path}, true
+}
+
+func trimRustUseAlias(tree string) (string, bool) {
+	depth := 0
+	for i := 0; i < len(tree); i++ {
+		switch tree[i] {
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth < 0 {
+				return "", false
+			}
+		default:
+			if depth == 0 && i+2 <= len(tree) && tree[i:i+2] == "as" &&
+				(i == 0 || isRustUseSpace(tree[i-1])) &&
+				(i+2 == len(tree) || isRustUseSpace(tree[i+2])) {
+				path := strings.TrimSpace(tree[:i])
+				alias := strings.TrimSpace(tree[i+2:])
+				if path == "" || !validRustUseIdentifier(alias) {
+					return "", false
+				}
+				return path, true
+			}
+		}
+	}
+	return tree, depth == 0
+}
+
+func matchingRustUseBrace(tree string, open int) (int, bool) {
+	depth := 0
+	for i := open; i < len(tree); i++ {
+		switch tree[i] {
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return i, true
+			}
+			if depth < 0 {
+				return 0, false
+			}
+		}
+	}
+	return 0, false
+}
+
+func splitRustUseItems(body string) ([]string, bool) {
+	depth := 0
+	start := 0
+	var items []string
+	for i := 0; i < len(body); i++ {
+		switch body[i] {
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth < 0 {
+				return nil, false
+			}
+		case ',':
+			if depth == 0 {
+				item := strings.TrimSpace(body[start:i])
+				if item == "" {
+					return nil, false
+				}
+				items = append(items, item)
+				start = i + 1
+			}
+		}
+	}
+	if depth != 0 {
+		return nil, false
+	}
+	if item := strings.TrimSpace(body[start:]); item != "" {
+		items = append(items, item)
+	} else if len(items) == 0 {
+		return nil, false
+	}
+	return items, true
+}
+
+func joinRustUsePath(prefix, path string) string {
+	path = strings.TrimSpace(strings.TrimPrefix(path, "::"))
+	if prefix == "" {
+		return path
+	}
+	if path == "" {
+		return prefix
+	}
+	return prefix + "::" + path
+}
+
+func validRustUsePath(path string) bool {
+	parts := strings.Split(path, "::")
+	if len(parts) == 0 {
+		return false
+	}
+	for _, part := range parts {
+		if !validRustUseIdentifier(part) {
+			return false
+		}
+	}
+	return true
+}
+
+func validRustUseIdentifier(value string) bool {
+	value = strings.TrimPrefix(value, "r#")
+	if value == "" {
+		return false
+	}
+	for i, r := range value {
+		if i == 0 {
+			if r != '_' && !unicode.IsLetter(r) {
+				return false
+			}
+		} else if r != '_' && !unicode.IsLetter(r) && !unicode.IsDigit(r) {
+			return false
+		}
+	}
+	return true
+}
+
+func isRustUseSpace(value byte) bool {
+	return value == ' ' || value == '\t' || value == '\r' || value == '\n'
+}

--- a/scanner/rustuse_test.go
+++ b/scanner/rustuse_test.go
@@ -1,0 +1,165 @@
+package scanner
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"testing"
+	"time"
+)
+
+func TestExpandRustUsePaths(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want []string
+	}{
+		{
+			name: "flat aliases",
+			path: "crate::{alpha::Thing, beta as renamed}",
+			want: []string{"crate::alpha::Thing", "crate::beta"},
+		},
+		{
+			name: "nested self and glob",
+			path: "self::{child, nested::{self, Thing}, exports::*}",
+			want: []string{"self::child", "self::nested", "self::nested::Thing", "self::exports"},
+		},
+		{
+			name: "repeated super",
+			path: "super::{super::shared, sibling as alias}",
+			want: []string{"super::super::shared", "super::sibling"},
+		},
+		{
+			name: "simple alias",
+			path: "crate::alpha as renamed",
+			want: []string{"crate::alpha"},
+		},
+		{
+			name: "external tree stays partial",
+			path: "dependency::{alpha, beta}",
+		},
+		{
+			name: "malformed tree stays partial",
+			path: "crate::{alpha, beta",
+		},
+		{
+			name: "commented leaf stays partial",
+			path: "crate::{/* note */ alpha, beta}",
+		},
+		{
+			name: "empty path segment stays partial",
+			path: "crate::{alpha::::Thing, beta}",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := expandRustUsePaths(tt.path); !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("expandRustUsePaths(%q) = %#v, want %#v", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAstGrepRustUseTreeExtraction(t *testing.T) {
+	scanner, err := NewAstGrepScanner()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(scanner.Close)
+	if !scanner.Available() {
+		t.Skip("ast-grep not available")
+	}
+
+	root := t.TempDir()
+	source := "use crate::{alpha::Thing, beta as renamed};\nuse dependency::{External, Other};\n"
+	if err := os.WriteFile(filepath.Join(root, "lib.rs"), []byte(source), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	astScanner, err := NewAstGrepScanner()
+	if err != nil {
+		t.Fatal(err)
+	}
+	outcome, err := astScanner.ScanDirectory(context.Background(), root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got []ImportReference
+	for _, analysis := range outcome.Analyses {
+		for _, ref := range analysis.References {
+			if ref.Kind == "rust-use" {
+				ref.Line = 0
+				got = append(got, ref)
+			}
+		}
+	}
+	want := []ImportReference{{Path: "crate::{alpha::Thing, beta as renamed}", Kind: "rust-use"}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("whole Rust use references = %#v, want %#v", got, want)
+	}
+}
+
+func TestRustUseReferencesResolveGroupedLocalModules(t *testing.T) {
+	root := t.TempDir()
+	writeRustCargoFixture(t, root, map[string]string{
+		"Cargo.toml":    "[package]\nname = \"grouped\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+		"src/lib.rs":    "mod alpha;\nmod beta;\nmod nested;\nmod caller;\n",
+		"src/alpha.rs":  "pub struct Thing;\n",
+		"src/beta.rs":   "pub fn run() {}\n",
+		"src/nested.rs": "pub struct Leaf;\n",
+		"src/caller.rs": "use crate::{alpha::Thing, beta as renamed, nested::{self, Leaf}};\n",
+	})
+	analyses := []FileAnalysis{
+		{Path: "src/lib.rs", Language: "rust", References: []ImportReference{
+			{Path: "alpha", Kind: "rust-module"},
+			{Path: "beta", Kind: "rust-module"},
+			{Path: "nested", Kind: "rust-module"},
+			{Path: "caller", Kind: "rust-module"},
+		}},
+		{Path: "src/alpha.rs", Language: "rust"},
+		{Path: "src/beta.rs", Language: "rust"},
+		{Path: "src/nested.rs", Language: "rust"},
+		{Path: "src/caller.rs", Language: "rust", References: []ImportReference{{
+			Path: "crate::{alpha::Thing, beta as renamed, nested::{self, Leaf}}",
+			Kind: "rust-use",
+		}}},
+	}
+	loader := func(context.Context, string) ([]byte, error) {
+		return nil, errors.New("force manifest fallback")
+	}
+	graph, err := buildFileGraphFromAnalysesWithCargoMetadata(context.Background(), root, analyses, loader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := append([]string(nil), graph.Imports["src/caller.rs"]...)
+	sort.Strings(got)
+	want := []string{"src/alpha.rs", "src/beta.rs", "src/nested.rs"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("grouped local imports = %#v, want %#v", got, want)
+	}
+}
+
+func TestExpandRustUsePathsBoundedAtMaxDepth(t *testing.T) {
+	// Past maxRustUseTreeDepth the expansion must reject instead of recursing.
+	if paths, ok := expandRustUseTree("a::{b}", "", maxRustUseTreeDepth+1); ok || paths != nil {
+		t.Fatalf("expected depth bound to reject, got ok=%v paths=%v", ok, paths)
+	}
+	// A pathological deeply nested use tree must terminate without a hang.
+	nested := "crate::a"
+	for i := 0; i < 70; i++ {
+		nested = "outer" + string(rune('a'+i%26)) + "::{" + nested + "}"
+	}
+	done := make(chan []string, 1)
+	go func() {
+		done <- expandRustUsePaths(nested)
+	}()
+	select {
+	case <-done:
+		// Requirement is termination without panic or hang.
+	case <-time.After(5 * time.Second):
+		t.Fatal("expandRustUsePaths did not terminate on deep nesting")
+	}
+}

--- a/scanner/rustuse_test.go
+++ b/scanner/rustuse_test.go
@@ -204,7 +204,6 @@ func TestExpandRustUsePathsBoundedAtMaxDepth(t *testing.T) {
 	}()
 	select {
 	case <-done:
-		// Requirement is termination without panic or hang.
 	case <-time.After(5 * time.Second):
 		t.Fatal("expandRustUsePaths did not terminate on deep nesting")
 	}

--- a/scanner/rustuse_test.go
+++ b/scanner/rustuse_test.go
@@ -50,6 +50,10 @@ func TestExpandRustUsePaths(t *testing.T) {
 			path: "crate::{/* note */ alpha, beta}",
 		},
 		{
+			name: "empty group stays partial",
+			path: "crate::{}",
+		},
+		{
 			name: "empty path segment stays partial",
 			path: "crate::{alpha::::Thing, beta}",
 		},
@@ -75,7 +79,7 @@ func TestAstGrepRustUseTreeExtraction(t *testing.T) {
 	}
 
 	root := t.TempDir()
-	source := "use crate::{alpha::Thing, beta as renamed};\nuse dependency::{External, Other};\n"
+	source := "use crate::{alpha::Thing, beta as renamed};\nuse crate::{/* note */ alpha::Thing, beta};\nuse crate::{};\nuse dependency::{External, Other};\nuse crate::exports;\npub use crate::{alpha::Thing, beta};\npub use crate::re_export;\n"
 	if err := os.WriteFile(filepath.Join(root, "lib.rs"), []byte(source), 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -96,9 +100,51 @@ func TestAstGrepRustUseTreeExtraction(t *testing.T) {
 			}
 		}
 	}
-	want := []ImportReference{{Path: "crate::{alpha::Thing, beta as renamed}", Kind: "rust-use"}}
+	want := []ImportReference{
+		{Path: "crate::{alpha::Thing, beta as renamed}", Kind: "rust-use"},
+		{Path: "crate::{/* note */ alpha::Thing, beta}", Kind: "rust-use"},
+		{Path: "crate::{}", Kind: "rust-use"},
+		{Path: "dependency::{External, Other}", Kind: "rust-use"},
+		{Path: "crate::exports", Kind: "rust-use"},
+		{Path: "crate::{alpha::Thing, beta}", Kind: "rust-use"},
+		{Path: "crate::re_export", Kind: "rust-use"},
+	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("whole Rust use references = %#v, want %#v", got, want)
+	}
+}
+
+func TestRustUseMalformedTreesDoNotEmitCrateRootEdge(t *testing.T) {
+	root := t.TempDir()
+	writeRustCargoFixture(t, root, map[string]string{
+		"Cargo.toml":    "[package]\nname = \"malformed\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+		"src/lib.rs":    "mod caller;\n",
+		"src/caller.rs": "use crate::{/* note */ alpha::Thing, beta};\nuse crate::{};\n",
+	})
+	analyses := []FileAnalysis{
+		{Path: "src/lib.rs", Language: "rust", References: []ImportReference{
+			{Path: "caller", Kind: "rust-module"},
+		}},
+		{Path: "src/caller.rs", Language: "rust", References: []ImportReference{
+			{Path: "crate::{/* note */ alpha::Thing, beta}", Kind: "rust-use"},
+			{Path: "crate::{}", Kind: "rust-use"},
+		}},
+	}
+	loader := func(context.Context, string) ([]byte, error) {
+		return nil, errors.New("force manifest fallback")
+	}
+	graph, err := buildFileGraphFromAnalysesWithCargoMetadata(context.Background(), root, analyses, loader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := graph.Imports["src/caller.rs"]
+	for _, target := range got {
+		if target == "src/lib.rs" {
+			t.Fatalf("malformed use trees emitted a false crate-root edge: %v", got)
+		}
+	}
+	if len(got) != 0 {
+		t.Fatalf("malformed use trees resolved to %v, want none", got)
 	}
 }
 

--- a/scanner/sg-rules/rust.yml
+++ b/scanner/sg-rules/rust.yml
@@ -4,6 +4,8 @@ rule:
   any:
     - pattern: use $PATH;
     - pattern: use $PATH::$$$_;
+    - pattern: pub use $PATH;
+    - pattern: pub use $PATH::$$$_;
 ---
 id: rust-mod-imports
 language: rust


### PR DESCRIPTION
## What does this PR do?

- Resolve local `crate`, `self`, and `super` use trees into per-path dependency edges: nested groups, aliases, `self`, glob module imports, and `pub` re-exports.
- Treat unexpandable brace trees conservatively (comments in a group, empty groups, external groups): resolve to nothing instead of emitting a false crate-root (or dependency-root) edge.
- Preserve the existing scanner path for non-grouped external imports.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] New language support
- [ ] Documentation
- [ ] Other (describe below)

## Checklist

- [x] I've tested this locally with `go build && ./codemap .`
- [x] I've read `CONTRIBUTING.md`; this does not add a new language.
- [x] Documentation is unchanged because this corrects existing Rust scanning.

## Additional notes

Focused parser/extraction/resolution tests, `go vet ./...`, and the full race/coverage suite are GREEN on macOS Go 1.26.5. The exact publication branch is also GREEN on Linux Go 1.24.13.

On GitButler's 978-file Rust corpus, the change adds 588 specific local-module edges and removes 75 false crate/test-root fallback edges — measured before the review follow-ups (`pub` re-exports and conservative brace handling), which shift both numbers. Non-grouped external imports are unchanged; `pub` re-export hubs now gain edges.

Developed with carefully directed, manually reviewed AI assistance.