### PR TITLE
fix(scanner): Resolve literal Rust includes

### DIFF
--- a/scanner/astgrep.go
+++ b/scanner/astgrep.go
@@ -324,7 +324,7 @@ func (s *AstGrepScanner) scanDirectory(parent context.Context, root string) ([]F
 			}
 		}
 
-		if m.RuleID == "rust-mod-imports" || m.RuleID == "rust-path-module-imports" || m.RuleID == "rust-path-imports" || m.RuleID == "rust-use-imports" || m.RuleID == "rust-askama-template-imports" {
+		if m.RuleID == "rust-mod-imports" || m.RuleID == "rust-path-module-imports" || m.RuleID == "rust-path-imports" || m.RuleID == "rust-use-imports" || m.RuleID == "rust-askama-template-imports" || m.RuleID == "rust-include-imports" {
 			var path string
 			var explicitTarget string
 			kind := "rust-path"
@@ -355,6 +355,12 @@ func (s *AstGrepScanner) scanDirectory(parent context.Context, root string) ([]F
 						path = targetVar.Text
 						explicitTarget = targetVar.Text
 					}
+				}
+			case "rust-include-imports":
+				kind = "rust-include"
+				if pathVar, ok := m.MetaVariables.Single["PATH"]; ok {
+					explicitTarget = pathVar.Text
+					path, _ = parseRustStringLiteral(explicitTarget)
 				}
 			}
 			if path != "" {

--- a/scanner/rustgraph.go
+++ b/scanner/rustgraph.go
@@ -501,6 +501,26 @@ func resolveRustExplicitModule(root, declaringFile, literal string) string {
 	return filepath.Clean(rel)
 }
 
+// resolveRustInclude resolves include!(...) relative to the declaring file.
+// byExact also indexes files under their extension-stripped key, so accept
+// only when the target itself is indexed exactly once.
+func resolveRustInclude(root, declaringFile, literal string, idx *fileIndex) string {
+	target := resolveRustExplicitModule(root, declaringFile, literal)
+	if target == "" {
+		return ""
+	}
+	exact := 0
+	for _, file := range idx.byExact[target] {
+		if file == target {
+			exact++
+		}
+	}
+	if exact != 1 {
+		return ""
+	}
+	return target
+}
+
 func parseRustStringLiteral(literal string) (string, bool) {
 	literal = strings.TrimSpace(literal)
 	if strings.HasPrefix(literal, "r") {
@@ -649,6 +669,10 @@ func resolveRustReferences(root string, analysis FileAnalysis, idx *fileIndex, w
 			}
 		case "rust-askama-template":
 			if target := resolveRustAskamaTemplate(root, analysis.Path, ref.ExplicitTarget, idx, workspace); target != "" && target != analysis.Path {
+				resolved = append(resolved, target)
+			}
+		case "rust-include":
+			if target := resolveRustInclude(root, analysis.Path, ref.ExplicitTarget, idx); target != "" && target != analysis.Path {
 				resolved = append(resolved, target)
 			}
 		}

--- a/scanner/rustinclude_test.go
+++ b/scanner/rustinclude_test.go
@@ -1,0 +1,109 @@
+package scanner
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"testing"
+)
+
+func TestAstGrepRustLiteralIncludeExtraction(t *testing.T) {
+	astScanner, err := NewAstGrepScanner()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(astScanner.Close)
+	if !astScanner.Available() {
+		t.Skip("ast-grep not available")
+	}
+
+	root := t.TempDir()
+	source := `include!("generated.rs");
+include!(r#"nested/raw.rs"#);
+const VALUE: i32 = include!("nested/value.rs");
+include!(concat!("generated", ".rs"));
+include_str!("data.txt");
+include_bytes!("data.bin");
+`
+	if err := os.WriteFile(filepath.Join(root, "lib.rs"), []byte(source), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	outcome, err := astScanner.ScanDirectory(context.Background(), root)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var got []ImportReference
+	var imports []string
+	for _, analysis := range outcome.Analyses {
+		imports = append(imports, analysis.Imports...)
+		for _, ref := range analysis.References {
+			if ref.Kind == "rust-include" {
+				ref.Line = 0
+				got = append(got, ref)
+			}
+		}
+	}
+	sort.Slice(got, func(i, j int) bool { return got[i].Path < got[j].Path })
+	want := []ImportReference{
+		{Path: "generated.rs", Kind: "rust-include", ExplicitTarget: `"generated.rs"`},
+		{Path: "nested/raw.rs", Kind: "rust-include", ExplicitTarget: `r#"nested/raw.rs"#`},
+		{Path: "nested/value.rs", Kind: "rust-include", ExplicitTarget: `"nested/value.rs"`},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("literal Rust include references = %#v, want %#v", got, want)
+	}
+	sort.Strings(imports)
+	if want := []string{"generated.rs", "nested/raw.rs", "nested/value.rs"}; !reflect.DeepEqual(imports, want) {
+		t.Fatalf("literal Rust include imports = %#v, want %#v", imports, want)
+	}
+}
+
+func TestRustLiteralIncludesResolveConservatively(t *testing.T) {
+	root := t.TempDir()
+	writeRustCargoFixture(t, root, map[string]string{
+		"Cargo.toml":       "[package]\nname = \"app\"\nversion = \"0.1.0\"\n",
+		"src/lib.rs":       "pub fn root() {}\n",
+		"src/generated.rs": "pub fn generated() {}\n",
+		"shared/raw.rs":    "pub fn raw() {}\n",
+		"src/non_rust.txt": "not Rust\n",
+	})
+	analyses := []FileAnalysis{
+		{Path: "src/lib.rs", Language: "rust", References: []ImportReference{
+			{Path: "generated.rs", Kind: "rust-include", ExplicitTarget: `"generated.rs"`},
+			{Path: "../shared/raw.rs", Kind: "rust-include", ExplicitTarget: `r#"../shared/raw.rs"#`},
+			{Path: "lib.rs", Kind: "rust-include", ExplicitTarget: `"lib.rs"`},
+			{Path: "missing.rs", Kind: "rust-include", ExplicitTarget: `"missing.rs"`},
+			{Path: "../../outside.rs", Kind: "rust-include", ExplicitTarget: `"../../outside.rs"`},
+			{Path: "non_rust.txt", Kind: "rust-include", ExplicitTarget: `"non_rust.txt"`},
+			{Path: "dynamic", Kind: "rust-include", ExplicitTarget: `concat!("generated", ".rs")`},
+		}},
+		{Path: "src/generated.rs", Language: "rust"},
+		{Path: "shared/raw.rs", Language: "rust"},
+	}
+	graph, err := buildFileGraphFromAnalysesWithCargoMetadata(context.Background(), root, analyses, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"shared/raw.rs", "src/generated.rs"}
+	if got := sortedImports(graph, "src/lib.rs"); !reflect.DeepEqual(got, want) {
+		t.Fatalf("literal include imports = %#v, want %#v", got, want)
+	}
+}
+
+func TestResolveRustIncludeRequiresRealIndexedFile(t *testing.T) {
+	root := t.TempDir()
+	// bindings.rs.in is indexed under the bindings.rs key though no such
+	// file exists; the include must stay unresolved.
+	idx := buildFileIndex([]FileInfo{{Path: "src/bindings.rs.in"}, {Path: "src/main.rs"}}, "")
+	if target := resolveRustInclude(root, "src/main.rs", `"bindings.rs"`, idx); target != "" {
+		t.Fatalf("phantom include target = %q, want unresolved", target)
+	}
+	// With both files present, the edge to the real file survives.
+	idx = buildFileIndex([]FileInfo{{Path: "src/bindings.rs"}, {Path: "src/bindings.rs.in"}, {Path: "src/main.rs"}}, "")
+	if target := resolveRustInclude(root, "src/main.rs", `"bindings.rs"`, idx); target != "src/bindings.rs" {
+		t.Fatalf("include target = %q, want src/bindings.rs", target)
+	}
+}

--- a/scanner/sg-rules/rust.yml
+++ b/scanner/sg-rules/rust.yml
@@ -53,6 +53,11 @@ rule:
           struct __CONTEXT__;
         selector: attribute_item
 ---
+id: rust-include-imports
+language: rust
+rule:
+  pattern: include!($PATH)
+---
 id: rust-functions
 language: rust
 rule:


### PR DESCRIPTION
## What does this PR do?

Record direct Rust source dependencies introduced by literal `include!` calls. Paths are decoded with the existing Rust literal parser, resolved relative to the including file, and accepted only when the path itself is indexed exactly once (a `bindings.rs.in` template must not fabricate a `bindings.rs` target). Dynamic, missing, external, non-Rust, ambiguous, and self targets remain unresolved.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] New language support
- [ ] Documentation
- [ ] Other (describe below)

## Checklist

- [x] I've tested this locally with `go build && ./codemap .`
- [x] I've read `CONTRIBUTING.md`; this does not add a new language.
- [x] Documentation is unchanged because this corrects existing Rust scanning.

## Additional notes

Maintainer review addressed: the resolver requires the indexed file itself, so a gitignored, build-time-generated `bindings.rs` beside `bindings.rs.in` no longer fabricates an edge, and a real file keeps its edge when a template shares its key. Extraction and conservative-resolution tests, `go vet ./...`, the full suite, and the scanner race suite are GREEN on macOS Go 1.26.5.

Worktrunk's alternate `git-wt` binary uses `include!("main.rs")`; this change adds the missing `src/git_wt.rs` to `src/main.rs` dependency edge. The inspected GitButler, Codanna, and Worktrunk corpora contain no other literal source includes, so this is intentionally presented as a narrow correctness fix.

`include_str!` and `include_bytes!` are not matched; resolving their non-Rust assets remains a documented follow-up.

This branch targets main and contains no generic proc-macro, Cargo-topology, configuration, or non-Rust changes.

Developed with carefully directed, manually reviewed AI assistance.