### PR TITLE
fix(setup): Keep Codemap state locally ignored

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -80,7 +80,7 @@ func configInit(root string) {
 	}
 
 	fmt.Printf("Created %s\n", result.Path)
-	reportEnsureIgnored(os.Stdout, root, ignoreTracked)
+	reportEnsureIgnored(os.Stdout, root)
 	fmt.Println()
 	if len(result.TopExts) == 0 {
 		fmt.Println("No code extensions detected — wrote empty config.")

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -112,6 +112,9 @@ func RunDoctor(args []string, defaultRoot string) int {
 	}
 
 	checkFile("project config", config.ConfigPath(root), validateJSONFile)
+	if isGitWorkTree(root) {
+		doctorCheckLocalCodemapIgnore(root, &failures)
+	}
 	claudeSettings, claudeSettingsErr := claudeSettingsPath(root, *global)
 	claudeMCP, claudeMCPErr := claudeMCPPath(root, *global)
 	codexHooks, codexHooksErr := codexHooksPath(root, *global)
@@ -172,6 +175,31 @@ func RunDoctor(args []string, defaultRoot string) int {
 	}
 	fmt.Println("\nCodemap integration prerequisites are valid.")
 	return 0
+}
+
+// doctorCheckLocalCodemapIgnore verifies .codemap/ is ignored in this working
+// tree. Git's check-ignore reflects the rules that actually apply, so it is
+// the authority: report OK when the directory is ignored and MISS only when
+// it genuinely is not, naming the local exclude and a minimal repair hint.
+func doctorCheckLocalCodemapIgnore(root string, failures *int) {
+	ignored, mechanism, err := gitCheckIgnoreVerbose(root, ignoreEntry)
+	if err != nil {
+		fmt.Printf("MISS local Codemap ignore: %v\n", err)
+		*failures++
+		return
+	}
+	if ignored {
+		fmt.Printf("OK   local Codemap ignore: effective via %s\n", mechanism)
+		return
+	}
+	path, _, err := localCodemapIgnore(root)
+	if err != nil {
+		fmt.Printf("MISS local Codemap ignore: %v\n", err)
+		*failures++
+		return
+	}
+	fmt.Printf("MISS local Codemap ignore: %s does not ignore %s; repair with `codemap setup --no-hooks --no-mcp --no-config %s`\n", path, ignoreEntry, root)
+	*failures++
 }
 
 func reportCodexRuntimeVersions(cliPath string) bool {

--- a/cmd/gitignore.go
+++ b/cmd/gitignore.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"bufio"
 	"bytes"
 	"fmt"
 	"io"
@@ -11,29 +10,14 @@ import (
 	"strings"
 )
 
-// ignoreMode selects where ensureCodemapIgnored writes a rule when one is
-// needed.
-type ignoreMode int
-
-const (
-	// ignoreTracked writes ".codemap/" to the repo's tracked .gitignore so the
-	// whole team (and every future clone) ignores it. This creates a diff.
-	ignoreTracked ignoreMode = iota
-	// ignoreLocal writes ".codemap/" to .git/info/exclude, which is local to
-	// this clone and never tracked — no diff, no surprise for collaborators.
-	ignoreLocal
-)
-
-// ignoreEntry is the rule we add. The trailing slash scopes it to the
-// directory, matching how codemap's own repo ignores its runtime state.
+// ignoreEntry keeps the runtime-state directory out of git. The trailing
+// slash scopes the rule to the directory.
 const ignoreEntry = ".codemap/"
 
 // reportEnsureIgnored ensures .codemap/ is ignored for root and reports the
-// outcome to w: a one-line notice when a rule was added, a warning when the
-// check/write failed, and nothing when git already ignored it (or root is not
-// a git repo). Both "config init" and "setup" funnel through here.
-func reportEnsureIgnored(w io.Writer, root string, mode ignoreMode) {
-	wrote, err := ensureCodemapIgnored(root, mode)
+// outcome to w (notice, warning, or nothing).
+func reportEnsureIgnored(w io.Writer, root string) {
+	wrote, err := ensureCodemapIgnored(root)
 	if err != nil {
 		fmt.Fprintf(w, "Warning: could not update ignore rules: %v\n", err)
 		return
@@ -42,45 +26,47 @@ func reportEnsureIgnored(w io.Writer, root string, mode ignoreMode) {
 		return
 	}
 	rel := wrote
-	if r, relErr := filepath.Rel(root, wrote); relErr == nil {
+	if r, relErr := filepath.Rel(root, wrote); relErr == nil && !strings.HasPrefix(r, "..") {
 		rel = r
 	}
 	fmt.Fprintf(w, "Added %s to %s\n", ignoreEntry, rel)
 }
 
-// ensureCodemapIgnored makes sure the .codemap/ directory at the given git root
-// is ignored by git. It is a no-op when git already ignores .codemap through
-// any mechanism (a global exclude, an existing .gitignore, a parent rule), and
-// a silent no-op when root is not inside a git working tree.
-//
-// It returns the path of the file it wrote to, or "" when nothing was written.
-func ensureCodemapIgnored(root string, mode ignoreMode) (string, error) {
+// ensureCodemapIgnored ensures .codemap/ is ignored for root by writing
+// ignoreEntry to the clone-local info/exclude. It returns the file written,
+// or "" when the entry already exists or root is not a git work tree.
+func ensureCodemapIgnored(root string) (string, error) {
 	if !isGitWorkTree(root) {
 		return "", nil
 	}
-
-	ignored, err := gitCheckIgnore(root, ignoreEntry)
+	target, present, err := localCodemapIgnore(root)
 	if err != nil {
 		return "", err
 	}
-	if ignored {
+	if present {
 		return "", nil
 	}
-
-	var target string
-	if mode == ignoreLocal {
-		target, err = infoExcludePath(root)
-		if err != nil {
-			return "", err
-		}
-	} else {
-		target = filepath.Join(root, ".gitignore")
-	}
-
 	if err := appendIgnoreEntry(target, ignoreEntry); err != nil {
 		return "", err
 	}
 	return target, nil
+}
+
+// localCodemapIgnore reports whether root's info/exclude already lists
+// ignoreEntry.
+func localCodemapIgnore(root string) (string, bool, error) {
+	target, err := infoExcludePath(root)
+	if err != nil {
+		return "", false, err
+	}
+	data, err := os.ReadFile(target)
+	if os.IsNotExist(err) {
+		return target, false, nil
+	}
+	if err != nil {
+		return "", false, err
+	}
+	return target, hasIgnoreLine(data, ignoreEntry), nil
 }
 
 // isGitWorkTree reports whether root sits inside a git working tree.
@@ -91,23 +77,29 @@ func isGitWorkTree(root string) bool {
 	return err == nil && strings.TrimSpace(string(out)) == "true"
 }
 
-// gitCheckIgnore reports whether git would ignore the given path at root.
-func gitCheckIgnore(root, path string) (bool, error) {
-	cmd := exec.Command("git", "check-ignore", "-q", path)
+// gitCheckIgnoreVerbose reports whether git would ignore path at root and, if
+// so, the <source>:<line>:<pattern> rule that matched, across every ignore
+// source (tracked .gitignore, local exclude, global excludes, parent repos).
+func gitCheckIgnoreVerbose(root, path string) (bool, string, error) {
+	cmd := exec.Command("git", "check-ignore", "-v", path)
 	cmd.Dir = root
-	err := cmd.Run()
+	out, err := cmd.Output()
 	if err == nil {
-		return true, nil
+		line := strings.TrimSpace(string(out))
+		if i := strings.IndexByte(line, '\t'); i >= 0 {
+			line = line[:i]
+		}
+		return true, line, nil
 	}
 	// Exit code 1 means "not ignored"; anything else is a real error.
 	if exit, ok := err.(*exec.ExitError); ok && exit.ExitCode() == 1 {
-		return false, nil
+		return false, "", nil
 	}
-	return false, fmt.Errorf("git check-ignore: %w", err)
+	return false, "", fmt.Errorf("git check-ignore: %w", err)
 }
 
-// infoExcludePath resolves <git-common-dir>/info/exclude for root, so all
-// worktrees of a repo share one local exclude file.
+// infoExcludePath resolves <git-common-dir>/info/exclude for root, so every
+// worktree of a repo shares one local exclude file.
 func infoExcludePath(root string) (string, error) {
 	cmd := exec.Command("git", "rev-parse", "--git-common-dir")
 	cmd.Dir = root
@@ -122,10 +114,10 @@ func infoExcludePath(root string) (string, error) {
 	return filepath.Join(commonDir, "info", "exclude"), nil
 }
 
-// appendIgnoreEntry adds entry as its own line in the ignore file at path,
-// creating the file (and its parent dir) if needed. It leaves the file
-// untouched if entry is already present verbatim, and guarantees the entry
-// lands on a fresh line even when the file lacks a trailing newline.
+// appendIgnoreEntry adds entry on its own line to the ignore file at path,
+// creating the file if needed. No-op when entry is already listed; never
+// glues onto a partial last line. Atomic write, so a symlinked exclude is
+// replaced rather than written through.
 func appendIgnoreEntry(path, entry string) error {
 	existing, err := os.ReadFile(path)
 	if err != nil && !os.IsNotExist(err) {
@@ -147,15 +139,14 @@ func appendIgnoreEntry(path, entry string) error {
 	buf.WriteString(entry)
 	buf.WriteByte('\n')
 
-	return os.WriteFile(path, buf.Bytes(), 0644)
+	return writeFileAtomic(path, buf.Bytes(), 0644)
 }
 
-// hasIgnoreLine reports whether data already contains entry as a standalone,
-// non-comment line.
+// hasIgnoreLine reports whether data lists entry as a standalone, uncommented
+// line.
 func hasIgnoreLine(data []byte, entry string) bool {
-	scanner := bufio.NewScanner(bytes.NewReader(data))
-	for scanner.Scan() {
-		if strings.TrimSpace(scanner.Text()) == entry {
+	for _, line := range bytes.Split(data, []byte("\n")) {
+		if strings.TrimSpace(string(line)) == entry {
 			return true
 		}
 	}

--- a/cmd/gitignore_test.go
+++ b/cmd/gitignore_test.go
@@ -38,84 +38,10 @@ func TestEnsureCodemapIgnored(t *testing.T) {
 		t.Skip("git not available")
 	}
 
-	t.Run("writes to tracked gitignore when not ignored", func(t *testing.T) {
+	t.Run("writes to info/exclude and not gitignore", func(t *testing.T) {
 		root := makeGitRepo(t)
 
-		path, err := ensureCodemapIgnored(root, ignoreTracked)
-		if err != nil {
-			t.Fatalf("ensureCodemapIgnored: %v", err)
-		}
-		want := filepath.Join(root, ".gitignore")
-		if path != want {
-			t.Fatalf("path = %q, want %q", path, want)
-		}
-		data, err := os.ReadFile(want)
-		if err != nil {
-			t.Fatalf("read .gitignore: %v", err)
-		}
-		if !strings.Contains(string(data), ".codemap/") {
-			t.Fatalf(".gitignore missing .codemap/ entry:\n%s", data)
-		}
-		if !gitIgnoresCodemap(t, root) {
-			t.Fatal("git still does not ignore .codemap after write")
-		}
-	})
-
-	t.Run("no-op when already ignored", func(t *testing.T) {
-		root := makeGitRepo(t)
-		gi := filepath.Join(root, ".gitignore")
-		if err := os.WriteFile(gi, []byte("node_modules/\n.codemap/\n"), 0644); err != nil {
-			t.Fatal(err)
-		}
-		before, _ := os.ReadFile(gi)
-
-		path, err := ensureCodemapIgnored(root, ignoreTracked)
-		if err != nil {
-			t.Fatalf("ensureCodemapIgnored: %v", err)
-		}
-		if path != "" {
-			t.Fatalf("path = %q, want empty (nothing written)", path)
-		}
-		after, _ := os.ReadFile(gi)
-		if string(before) != string(after) {
-			t.Fatalf(".gitignore was modified:\nbefore:\n%s\nafter:\n%s", before, after)
-		}
-	})
-
-	t.Run("creates gitignore when missing", func(t *testing.T) {
-		root := makeGitRepo(t)
-		if _, err := ensureCodemapIgnored(root, ignoreTracked); err != nil {
-			t.Fatalf("ensureCodemapIgnored: %v", err)
-		}
-		if _, err := os.Stat(filepath.Join(root, ".gitignore")); err != nil {
-			t.Fatalf(".gitignore not created: %v", err)
-		}
-	})
-
-	t.Run("appends preserving existing content and trailing newline", func(t *testing.T) {
-		root := makeGitRepo(t)
-		gi := filepath.Join(root, ".gitignore")
-		// No trailing newline on purpose.
-		if err := os.WriteFile(gi, []byte("build/\n*.log"), 0644); err != nil {
-			t.Fatal(err)
-		}
-		if _, err := ensureCodemapIgnored(root, ignoreTracked); err != nil {
-			t.Fatalf("ensureCodemapIgnored: %v", err)
-		}
-		data, _ := os.ReadFile(gi)
-		got := string(data)
-		if !strings.Contains(got, "build/") || !strings.Contains(got, "*.log") {
-			t.Fatalf("existing content lost:\n%s", got)
-		}
-		if !strings.Contains(got, "\n.codemap/\n") {
-			t.Fatalf(".codemap/ not on its own line:\n%q", got)
-		}
-	})
-
-	t.Run("ignoreLocal writes to info/exclude and not gitignore", func(t *testing.T) {
-		root := makeGitRepo(t)
-
-		path, err := ensureCodemapIgnored(root, ignoreLocal)
+		path, err := ensureCodemapIgnored(root)
 		if err != nil {
 			t.Fatalf("ensureCodemapIgnored: %v", err)
 		}
@@ -130,16 +56,62 @@ func TestEnsureCodemapIgnored(t *testing.T) {
 			t.Fatalf("info/exclude missing .codemap/:\n%s", data)
 		}
 		if _, err := os.Stat(filepath.Join(root, ".gitignore")); !os.IsNotExist(err) {
-			t.Fatal("ignoreLocal must not create a tracked .gitignore")
+			t.Fatal("must not create a tracked .gitignore")
 		}
 		if !gitIgnoresCodemap(t, root) {
 			t.Fatal("git does not ignore .codemap after info/exclude write")
 		}
 	})
 
+	t.Run("no-op when already ignored", func(t *testing.T) {
+		root := makeGitRepo(t)
+		exclude, err := infoExcludePath(root)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(exclude, []byte("node_modules/\n.codemap/\n"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		before, _ := os.ReadFile(exclude)
+
+		path, err := ensureCodemapIgnored(root)
+		if err != nil {
+			t.Fatalf("ensureCodemapIgnored: %v", err)
+		}
+		if path != "" {
+			t.Fatalf("path = %q, want empty (nothing written)", path)
+		}
+		after, _ := os.ReadFile(exclude)
+		if string(before) != string(after) {
+			t.Fatalf("exclude was modified:\nbefore:\n%s\nafter:\n%s", before, after)
+		}
+	})
+
+	t.Run("records the local rule even when tracked ignore is effective", func(t *testing.T) {
+		root := makeGitRepo(t)
+		if err := os.WriteFile(filepath.Join(root, ".gitignore"), []byte(".codemap/\n"), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		path, err := ensureCodemapIgnored(root)
+		if err != nil {
+			t.Fatalf("ensureCodemapIgnored: %v", err)
+		}
+		if path == "" {
+			t.Fatal("must record its own entry, not rely on .gitignore")
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read exclude: %v", err)
+		}
+		if !hasIgnoreLine(data, ignoreEntry) {
+			t.Fatalf("info/exclude missing %q:\n%s", ignoreEntry, data)
+		}
+	})
+
 	t.Run("skips silently when not a git repo", func(t *testing.T) {
 		root := t.TempDir()
-		path, err := ensureCodemapIgnored(root, ignoreTracked)
+		path, err := ensureCodemapIgnored(root)
 		if err != nil {
 			t.Fatalf("ensureCodemapIgnored on non-git dir: %v", err)
 		}
@@ -152,6 +124,79 @@ func TestEnsureCodemapIgnored(t *testing.T) {
 	})
 }
 
+// TestEnsureCodemapIgnoredLocalAppends locks the append path: whatever the
+// existing exclude content (line endings, missing final newline, oversized
+// lines, other rules), .codemap/ lands on its own line exactly once and the
+// existing bytes are preserved.
+func TestEnsureCodemapIgnoredLocalAppends(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	longLine := strings.Repeat("x", 70*1024) // beyond bufio.Scanner's 64KiB limit
+	cases := []struct {
+		name    string
+		pre     string // pre-existing info/exclude content
+		already bool   // pre already lists .codemap/
+	}{
+		{name: "empty file"},
+		{name: "pre-populated entries", pre: "build/\n*.log\n"},
+		{name: "no trailing newline", pre: "build/\n*.log"},
+		{name: "crlf", pre: "build/\r\n*.log\r\n"},
+		{name: "crlf no trailing newline", pre: "build/\r\n*.log"},
+		{name: "long first line", pre: longLine + "\n"},
+		{name: "already listed after long line", pre: longLine + "\n.codemap/\n", already: true},
+		{name: "already listed mid-file", pre: "node_modules/\n.codemap/\n*.log\n", already: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			root := makeGitRepo(t)
+			exclude, err := infoExcludePath(root)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(exclude, []byte(tc.pre), 0644); err != nil {
+				t.Fatal(err)
+			}
+
+			path, err := ensureCodemapIgnored(root)
+			if err != nil {
+				t.Fatalf("ensureCodemapIgnored: %v", err)
+			}
+			if tc.already {
+				if path != "" {
+					t.Fatalf("path = %q, want empty (nothing written)", path)
+				}
+				data, err := os.ReadFile(exclude)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if string(data) != tc.pre {
+					t.Fatalf("exclude changed when entry present:\n%q", data)
+				}
+			} else {
+				if path == "" {
+					t.Fatal("expected the ignore entry to be written")
+				}
+				want := tc.pre
+				if want != "" && !strings.HasSuffix(want, "\n") {
+					want += "\n"
+				}
+				want += ".codemap/\n"
+				data, err := os.ReadFile(exclude)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if string(data) != want {
+					t.Fatalf("exclude = %q, want %q", data, want)
+				}
+			}
+			if !gitIgnoresCodemap(t, root) {
+				t.Fatal("git does not ignore .codemap after write")
+			}
+		})
+	}
+}
+
 func TestReportEnsureIgnored(t *testing.T) {
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git not available")
@@ -161,10 +206,10 @@ func TestReportEnsureIgnored(t *testing.T) {
 		root := makeGitRepo(t)
 		var buf bytes.Buffer
 
-		reportEnsureIgnored(&buf, root, ignoreTracked)
+		reportEnsureIgnored(&buf, root)
 
 		out := buf.String()
-		if !strings.Contains(out, "Added .codemap/ to .gitignore") {
+		if !strings.Contains(out, "Added .codemap/ to .git/info/exclude") {
 			t.Fatalf("notice missing or malformed:\n%s", out)
 		}
 		if !gitIgnoresCodemap(t, root) {
@@ -174,12 +219,16 @@ func TestReportEnsureIgnored(t *testing.T) {
 
 	t.Run("prints nothing when already ignored", func(t *testing.T) {
 		root := makeGitRepo(t)
-		if err := os.WriteFile(filepath.Join(root, ".gitignore"), []byte(".codemap/\n"), 0644); err != nil {
+		exclude, err := infoExcludePath(root)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(exclude, []byte(".codemap/\n"), 0644); err != nil {
 			t.Fatal(err)
 		}
 		var buf bytes.Buffer
 
-		reportEnsureIgnored(&buf, root, ignoreTracked)
+		reportEnsureIgnored(&buf, root)
 
 		if buf.Len() != 0 {
 			t.Fatalf("expected no output, got:\n%s", buf.String())
@@ -190,10 +239,103 @@ func TestReportEnsureIgnored(t *testing.T) {
 		root := t.TempDir()
 		var buf bytes.Buffer
 
-		reportEnsureIgnored(&buf, root, ignoreTracked)
+		reportEnsureIgnored(&buf, root)
 
 		if buf.Len() != 0 {
 			t.Fatalf("expected no output for non-git dir, got:\n%s", buf.String())
 		}
 	})
+
+	// In a linked worktree the shared exclude lives in the main repo, outside
+	// the worktree root, so the notice must print the absolute path rather
+	// than an escaping relative one like ../<main>/.git/info/exclude.
+	t.Run("prints absolute path for shared exclude in a linked worktree", func(t *testing.T) {
+		root := makeRepoOnBranch(t, "main")
+		wt := filepath.Join(t.TempDir(), "wt")
+		runGitTestCmd(t, root, "worktree", "add", "-b", "wt-branch", wt)
+		// The shared exclude resolves outside the worktree root (into the main
+		// repo), so the notice must print that absolute path, not ../<main>/...
+		sharedExclude, err := infoExcludePath(wt)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var buf bytes.Buffer
+
+		reportEnsureIgnored(&buf, wt)
+
+		out := buf.String()
+		if !strings.Contains(out, "Added .codemap/ to "+sharedExclude) {
+			t.Fatalf("expected absolute path in notice, got:\n%s", out)
+		}
+		if strings.Contains(out, "../") {
+			t.Fatalf("notice must not print an escaping relative path:\n%s", out)
+		}
+		if !gitIgnoresCodemap(t, wt) {
+			t.Fatal("git does not ignore .codemap in the worktree after reportEnsureIgnored")
+		}
+	})
+
+	// A corrupt local ignore (unreadable, or unwritable) must surface as a
+	// warning instead of a silent success or a crash.
+	t.Run("warns when the exclude file cannot be read", func(t *testing.T) {
+		root := makeGitRepo(t)
+		exclude, err := infoExcludePath(root)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Remove(exclude); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.MkdirAll(exclude, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		var buf bytes.Buffer
+
+		reportEnsureIgnored(&buf, root)
+
+		if !strings.Contains(buf.String(), "Warning: could not update ignore rules") {
+			t.Fatalf("expected warning, got:\n%s", buf.String())
+		}
+	})
+}
+
+func TestEnsureCodemapIgnoredLocalModeIsIdempotent(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	root := makeGitRepo(t)
+	exclude, err := infoExcludePath(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	first, err := ensureCodemapIgnored(root)
+	if err != nil {
+		t.Fatalf("first ensureCodemapIgnored: %v", err)
+	}
+	if first == "" {
+		t.Fatal("expected the local ignore entry to be written on the first call")
+	}
+	second, err := ensureCodemapIgnored(root)
+	if err != nil {
+		t.Fatalf("second ensureCodemapIgnored: %v", err)
+	}
+	if second != "" {
+		t.Fatalf("second call wrote again (%q); local mode must be idempotent", second)
+	}
+	data, err := os.ReadFile(exclude)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n := strings.Count(string(data), ".codemap/\n"); n != 1 {
+		t.Fatalf("exclude has %d .codemap/ entries, want exactly 1:\n%s", n, data)
+	}
+}
+
+// appendIgnoreEntry must fail cleanly when the ignore file cannot be read
+// (here: a directory), not silently succeed or corrupt anything.
+func TestAppendIgnoreEntryReadError(t *testing.T) {
+	if err := appendIgnoreEntry(t.TempDir(), ignoreEntry); err == nil {
+		t.Fatal("expected an error reading a directory as an ignore file")
+	}
 }

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -268,7 +268,7 @@ func RunSetup(args []string, defaultRoot string) int {
 		}
 	}
 
-	reportEnsureIgnored(os.Stdout, absRoot, ignoreTracked)
+	reportEnsureIgnored(os.Stdout, absRoot)
 
 	if *skipHooks {
 		fmt.Println("Hooks: skipped (--no-hooks)")

--- a/cmd/setup_review_test.go
+++ b/cmd/setup_review_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -474,6 +475,28 @@ func TestRunDoctorReportsUnconfiguredProject(t *testing.T) {
 	}
 }
 
+func TestRunDoctorReportsMissingLocalCodemapIgnore(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	root := makeGitRepo(t)
+	if err := os.MkdirAll(filepath.Join(root, ".codemap"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".codemap", "config.json"), []byte("{}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var code int
+	out := captureOutput(func() { code = RunDoctor([]string{root}, ".") })
+	if code == 0 {
+		t.Fatalf("RunDoctor exit code = 0, want missing local ignore to fail\n%s", out)
+	}
+	if !strings.Contains(out, "MISS local Codemap ignore") {
+		t.Fatalf("expected missing local-ignore diagnosis, got:\n%s", out)
+	}
+}
+
 func TestDiscoverWindowsBundledCodexCLICandidates(t *testing.T) {
 	programFiles := t.TempDir()
 	t.Setenv("ProgramFiles", programFiles)
@@ -516,5 +539,59 @@ func TestDetectInstalledAgentsUsesHomeMarkers(t *testing.T) {
 	claude, codex = detectInstalledAgents()
 	if !claude || !codex {
 		t.Fatalf("detection = (%v, %v), want both", claude, codex)
+	}
+}
+
+func TestRunDoctorReportsLocalCodemapIgnorePresent(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	root := makeGitRepo(t)
+	if _, err := ensureCodemapIgnored(root); err != nil {
+		t.Fatal(err)
+	}
+	out := captureOutput(func() { RunDoctor([]string{root}, ".") })
+	if !strings.Contains(out, "OK   local Codemap ignore") {
+		t.Fatalf("expected OK local-ignore diagnosis, got:\n%s", out)
+	}
+	if strings.Contains(out, "MISS local Codemap ignore") {
+		t.Fatalf("unexpected MISS local-ignore diagnosis:\n%s", out)
+	}
+}
+
+// TestRunDoctorReportsOKWhenTrackedIgnoreIsEffective locks in the maintainer
+// case: .codemap/ ignored by a tracked .gitignore (no local exclude entry)
+// must be reported OK, since the effective configuration is what matters.
+func TestRunDoctorReportsOKWhenTrackedIgnoreIsEffective(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	root := makeGitRepo(t)
+	if err := os.WriteFile(filepath.Join(root, ".gitignore"), []byte("node_modules/\n.codemap/\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	out := captureOutput(func() { RunDoctor([]string{root}, ".") })
+	if !strings.Contains(out, "OK   local Codemap ignore: effective via") {
+		t.Fatalf("expected effective-ignore OK, got:\n%s", out)
+	}
+	if strings.Contains(out, "MISS local Codemap ignore") {
+		t.Fatalf("unexpected MISS local-ignore diagnosis:\n%s", out)
+	}
+}
+
+// The helper must fail the check (not panic) when git cannot answer at all,
+// e.g. when the root is not a repository.
+func TestDoctorCheckLocalCodemapIgnoreFailsWhenGitUnavailable(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	failures := 0
+	out := captureOutput(func() { doctorCheckLocalCodemapIgnore(t.TempDir(), &failures) })
+	if failures != 1 {
+		t.Fatalf("failures = %d, want 1", failures)
+	}
+	if !strings.Contains(out, "MISS local Codemap ignore") {
+		t.Fatalf("expected MISS local-ignore diagnosis, got:\n%s", out)
 	}
 }

--- a/cmd/setup_run_test.go
+++ b/cmd/setup_run_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -135,5 +136,31 @@ func TestRunSetupUsesNearestGitRootFromNestedDirectory(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(nested, ".codemap", "config.json")); !os.IsNotExist(err) {
 		t.Fatalf("expected nested config to be absent, got err=%v", err)
+	}
+}
+
+func TestRunSetupAddsOnlyLocalCodemapIgnore(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	root := makeGitRepo(t)
+	t.Setenv("HOME", t.TempDir())
+
+	out := captureOutput(func() {
+		RunSetup([]string{"--agent", "codex", "--no-config", "--no-mcp", root}, ".")
+	})
+	if !strings.Contains(out, "Added .codemap/ to .git/info/exclude") {
+		t.Fatalf("expected local-ignore notice, got:\n%s", out)
+	}
+	exclude, err := infoExcludePath(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(exclude)
+	if err != nil || !strings.Contains(string(data), ".codemap/\n") {
+		t.Fatalf("expected .codemap/ in %s, data=%q, err=%v", exclude, data, err)
+	}
+	if _, err := os.Stat(filepath.Join(root, ".gitignore")); !os.IsNotExist(err) {
+		t.Fatalf("setup must not create tracked .gitignore, err=%v", err)
 	}
 }


### PR DESCRIPTION
## What does this PR do?

Writes `.codemap/` to the clone-local `.git/info/exclude` (shared by linked worktrees, submodule-local) instead of a tracked `.gitignore`, so `setup` and `config init` never touch tracked files. `codemap doctor` verifies the effective ignore state: OK whenever git ignores `.codemap/` by any mechanism, MISS only when it is genuinely unignored, with a minimal repair hint.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] New language support
- [ ] Documentation
- [ ] Other (describe below)

## Checklist

- [x] I've tested this locally with `go build && ./codemap .`
- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) (for new language support)
- [x] I've updated documentation if needed

## Additional notes

- Appends to `info/exclude` only when the entry is missing: idempotent, no duplicate on re-run, never creates a `.gitignore`.
- Atomic write: a symlinked exclude is replaced, not written through; CRLF files and files without a trailing newline are preserved byte-for-byte.
- Repair hint runs `codemap setup --no-hooks --no-mcp --no-config` so fixing the ignore rule does not rewrite hooks or MCP config.
- Silent no-op outside a Git working tree.

Developed with carefully directed, manually reviewed AI assistance.