### PR TITLE
fix(topology): Don't let non-applicable providers force partial coverage

### DIFF
--- a/topology/graph.go
+++ b/topology/graph.go
@@ -34,7 +34,19 @@ func MergeFragments(root string, fragments []Fragment) *Graph {
 	var issues []Issue
 	invalidIDs := make(map[ID]bool)
 	complete := true
+	sawNotApplicable := false
 	for _, fragment := range fragments {
+		// A provider that found none of its manifests reports Unavailable with
+		// nothing to say: "not applicable here", not "incomplete". Such a
+		// fragment must not drag down a graph that other providers answered
+		// fully, but it does mean an empty graph is unavailable rather than
+		// completely known. A provider that declares Complete, or that carries
+		// nodes, edges or issues, always counts toward completeness.
+		if fragment.Coverage.Status == CoverageUnavailable && len(fragment.Nodes) == 0 &&
+			len(fragment.Edges) == 0 && len(fragment.Coverage.Issues) == 0 && len(fragment.Members) == 0 {
+			sawNotApplicable = true
+			continue
+		}
 		if fragment.Coverage.Status != CoverageComplete {
 			complete = false
 		}
@@ -155,7 +167,7 @@ func MergeFragments(root string, fragments []Fragment) *Graph {
 
 	issues = uniqueSortedIssues(issues)
 	switch {
-	case len(graph.Nodes) == 0 && !complete:
+	case len(graph.Nodes) == 0 && (!complete || sawNotApplicable):
 		graph.Coverage.Status = CoverageUnavailable
 	case complete && len(issues) == 0:
 		graph.Coverage.Status = CoverageComplete

--- a/topology/graph_test.go
+++ b/topology/graph_test.go
@@ -295,3 +295,42 @@ func TestExpandReferenceRejectsAmbiguityWithoutEdges(t *testing.T) {
 		t.Fatalf("candidates = %#v, want sorted unique IDs", issue.Candidates)
 	}
 }
+
+func TestMergeFragmentsIgnoresNonApplicableProviders(t *testing.T) {
+	root := t.TempDir()
+	answered := Fragment{
+		Provider: "test",
+		Nodes:    []Node{testNode("test:settings.gradle.kts:app", "app")},
+		Coverage: Coverage{Status: CoverageComplete},
+	}
+	// Providers whose manifests are absent report Unavailable with nothing to say.
+	notApplicable := []Fragment{
+		{Provider: "jvm", Coverage: Coverage{Status: CoverageUnavailable}},
+		{Provider: "swiftpm", Coverage: Coverage{Status: CoverageUnavailable}},
+	}
+
+	graph := MergeFragments(root, append([]Fragment{answered}, notApplicable...))
+	if graph.Coverage.Status != CoverageComplete {
+		t.Fatalf("coverage = %q, want %q when the only applicable provider answered fully",
+			graph.Coverage.Status, CoverageComplete)
+	}
+
+	// Nothing applied anywhere: topology has nothing to report.
+	if graph := MergeFragments(root, notApplicable); graph.Coverage.Status != CoverageUnavailable {
+		t.Fatalf("coverage = %q, want %q when no provider produced a module",
+			graph.Coverage.Status, CoverageUnavailable)
+	}
+
+	// A provider that genuinely failed carries an Issue and still counts.
+	failed := Fragment{
+		Provider: "jvm",
+		Coverage: Coverage{
+			Status: CoverageUnavailable,
+			Issues: []Issue{{Provider: "jvm", Code: "provider-failed", Message: "boom"}},
+		},
+	}
+	if graph := MergeFragments(root, []Fragment{answered, failed}); graph.Coverage.Status != CoveragePartial {
+		t.Fatalf("coverage = %q, want %q when an applicable provider failed",
+			graph.Coverage.Status, CoveragePartial)
+	}
+}


### PR DESCRIPTION
## What does this PR do?

Fixes a coverage-reporting defect I let through while merging #165: **every repo without JVM or SwiftPM manifests reports `partial` coverage with no issue explaining why.**

`MergeFragments` computed completeness as:

```go
if fragment.Coverage.Status != CoverageComplete { complete = false }
```

The JVM and SwiftPM providers correctly return `Unavailable` with no nodes, edges or issues when their manifests are absent — meaning *"not applicable to this repo"*. The aggregation read that as *"could not fully understand this repo"* and downgraded the whole graph. Measured on current main:

| repo | before | after |
|---|---|---|
| clean PEP 621 Python project | `partial` (no issues) | `complete` |
| Maven-only | `complete` | `complete` |
| SwiftPM-only | `partial` (no issues) | `complete` |
| no manifests at all | `unavailable` | `unavailable` |
| Python with a real layout issue | `partial` + issue | `partial` + issue |
| polyglot (Python + Maven) | `partial` (no issues) | `complete` |

Coverage errs safe today rather than overclaiming, so nothing was ever reported as more certain than it is — but `partial` firing on nearly every repo with nothing to point at makes the signal unusable, which defeats the purpose of the contract #160 established.

## The fix

A fragment that declares `Unavailable` **and** carries no nodes, edges, issues or members is treated as not-applicable: neutral for completeness. Two properties are deliberately preserved:

- An otherwise-empty graph still reports `unavailable` rather than "complete knowledge of nothing" — that's what the `sawNotApplicable` flag protects.
- A provider that declares `Complete` with no nodes ("I looked, there is genuinely nothing here") still counts as complete and stays cacheable, and a real `provider-failed` fragment carries an issue so it still degrades coverage.

That last distinction came out of `TestBuildGraphUsesProjectRuntimeCache`: my first attempt made *any* empty graph unavailable, which made legitimately-empty results uncacheable and rebuilt the graph on every call. The narrower rule keeps that test passing on its own terms.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] New language support
- [ ] Documentation
- [ ] Other (describe below)

## Checklist

- [x] I've tested this locally with `go build && ./codemap .`
- [ ] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) (for new language support)
- [x] I've updated documentation if needed

## Additional notes

`TestMergeFragmentsIgnoresNonApplicableProviders` covers all three branches and is load-bearing — against unmodified `graph.go` it fails with `coverage = "partial", want "complete"`. Verified end-to-end with a built binary across the six repo shapes in the table above. `go vet ./...` clean; full `go test ./...` at the main baseline (only the three known root-environment permission failures).

The affected code is @reneleonhardt's from #160 and #165 — flagging since this adjusts the aggregation semantics they designed, and I'm happy to defer if you'd rather shape it differently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PEUvjGsJemDFSV8nbxvxBo

---
_Generated by [Claude Code](https://claude.ai/code/session_01PEUvjGsJemDFSV8nbxvxBo)_