### PR TITLE
feat(context): Resolve bounded lexical file mentions

### DIFF
--- a/cmd/context.go
+++ b/cmd/context.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
 	"time"
@@ -147,8 +148,9 @@ func buildContextEnvelopeWithDeps(parent context.Context, root, prompt string, c
 	// Intent classification (if prompt provided)
 	if prompt != "" {
 		topK := projCfg.RoutingTopKOrDefault()
-		files := resolveContextFiles(prompt, inputs.files, projCfg, topK)
-		intent := classifyIntent(prompt, files, inputs.info, projCfg)
+		resolution := resolveContextFileResolutionWithCase(prompt, inputs.files, projCfg, topK, runtime.GOOS == "windows")
+		files := resolution.files
+		intent := classifyIntentWithResolution(prompt, resolution, inputs.info, projCfg)
 		envelope.Intent = &intent
 
 		// Match skills against intent

--- a/cmd/context.go
+++ b/cmd/context.go
@@ -147,8 +147,7 @@ func buildContextEnvelopeWithDeps(parent context.Context, root, prompt string, c
 	// Intent classification (if prompt provided)
 	if prompt != "" {
 		topK := projCfg.RoutingTopKOrDefault()
-		mentions := extractMentionedFiles(strings.ReplaceAll(prompt, `\`, "/"), topK)
-		files := resolveExactConfiguredFiles(mentions, inputs.fileSet)
+		files := resolveContextFiles(prompt, inputs.files, projCfg, topK)
 		intent := classifyIntent(prompt, files, inputs.info, projCfg)
 		envelope.Intent = &intent
 

--- a/cmd/context_evidence.go
+++ b/cmd/context_evidence.go
@@ -149,7 +149,7 @@ func sortedGraphHubs(importers map[string][]string) []string {
 }
 
 func normalizeContextPath(file string) string {
-	return normalizeContextPathWithVolumeGuard(file, true)
+	return normalizeContextPathWithVolumeGuard(strings.TrimSpace(file), true)
 }
 
 func normalizeContextInventoryPath(file string) string {
@@ -157,7 +157,7 @@ func normalizeContextInventoryPath(file string) string {
 }
 
 func normalizeContextPathWithVolumeGuard(file string, rejectVolume bool) string {
-	file = strings.TrimSpace(strings.ReplaceAll(file, `\`, "/"))
+	file = strings.ReplaceAll(file, `\`, "/")
 	volumePath := isContextVolumePath(file)
 	file = strings.TrimPrefix(pathpkg.Clean(file), "./")
 	if file == "." || file == "" || strings.HasPrefix(file, "../") || file == ".." || pathpkg.IsAbs(file) || (rejectVolume && volumePath) {

--- a/cmd/context_evidence.go
+++ b/cmd/context_evidence.go
@@ -44,7 +44,6 @@ type contextEnvelopeDeps struct {
 type contextRequestInputs struct {
 	state      *watch.State
 	files      []scanner.FileInfo
-	fileSet    map[string]string
 	info       *hubInfo
 	evidence   GraphEvidence
 	fileScanOK bool
@@ -67,7 +66,6 @@ func defaultContextEnvelopeDeps() contextEnvelopeDeps {
 func loadContextRequestInputs(ctx context.Context, root string, deps contextEnvelopeDeps) contextRequestInputs {
 	inputs := contextRequestInputs{
 		state:    deps.readState(root),
-		fileSet:  make(map[string]string),
 		evidence: unavailableGraphEvidence(graphEvidenceScanFailed),
 	}
 
@@ -78,12 +76,6 @@ func loadContextRequestInputs(ctx context.Context, root string, deps contextEnve
 	}
 	inputs.files = files
 	inputs.fileScanOK = true
-	for _, file := range files {
-		normalized := normalizeContextPath(file.Path)
-		if normalized != "" {
-			inputs.fileSet[normalized] = file.Path
-		}
-	}
 
 	if len(files) == 0 {
 		inputs.info = &hubInfo{Importers: map[string][]string{}, Imports: map[string][]string{}}
@@ -157,9 +149,18 @@ func sortedGraphHubs(importers map[string][]string) []string {
 }
 
 func normalizeContextPath(file string) string {
+	return normalizeContextPathWithVolumeGuard(file, true)
+}
+
+func normalizeContextInventoryPath(file string) string {
+	return normalizeContextPathWithVolumeGuard(file, false)
+}
+
+func normalizeContextPathWithVolumeGuard(file string, rejectVolume bool) string {
 	file = strings.TrimSpace(strings.ReplaceAll(file, `\`, "/"))
+	volumePath := isContextVolumePath(file)
 	file = strings.TrimPrefix(pathpkg.Clean(file), "./")
-	if file == "." || file == "" || strings.HasPrefix(file, "../") || file == ".." || pathpkg.IsAbs(file) || isContextVolumePath(file) {
+	if file == "." || file == "" || strings.HasPrefix(file, "../") || file == ".." || pathpkg.IsAbs(file) || (rejectVolume && volumePath) {
 		return ""
 	}
 	return file

--- a/cmd/context_evidence.go
+++ b/cmd/context_evidence.go
@@ -159,26 +159,13 @@ func sortedGraphHubs(importers map[string][]string) []string {
 func normalizeContextPath(file string) string {
 	file = strings.TrimSpace(strings.ReplaceAll(file, `\`, "/"))
 	file = strings.TrimPrefix(pathpkg.Clean(file), "./")
-	if file == "." || file == "" || strings.HasPrefix(file, "../") || file == ".." || pathpkg.IsAbs(file) {
+	if file == "." || file == "" || strings.HasPrefix(file, "../") || file == ".." || pathpkg.IsAbs(file) || isContextVolumePath(file) {
 		return ""
 	}
 	return file
 }
 
-func resolveExactConfiguredFiles(mentions []string, fileSet map[string]string) []string {
-	resolved := make([]string, 0, len(mentions))
-	seen := make(map[string]struct{})
-	for _, mention := range mentions {
-		normalized := normalizeContextPath(mention)
-		actual, ok := fileSet[normalized]
-		if !ok {
-			continue
-		}
-		if _, duplicate := seen[actual]; duplicate {
-			continue
-		}
-		seen[actual] = struct{}{}
-		resolved = append(resolved, actual)
-	}
-	return resolved
+func isContextVolumePath(file string) bool {
+	return strings.HasPrefix(file, "//") ||
+		(len(file) >= 2 && file[1] == ':' && ((file[0] >= 'a' && file[0] <= 'z') || (file[0] >= 'A' && file[0] <= 'Z')))
 }

--- a/cmd/context_routing.go
+++ b/cmd/context_routing.go
@@ -1,0 +1,217 @@
+package cmd
+
+import (
+	pathpkg "path"
+	"regexp"
+	"runtime"
+	"sort"
+	"strings"
+
+	"codemap/config"
+	"codemap/scanner"
+)
+
+var contextRoutingTokenPattern = regexp.MustCompile(`[A-Za-z0-9_@./\\-]*[A-Za-z0-9_@]`)
+
+type contextFileIndex struct {
+	caseInsensitive bool
+	paths           []string
+	exact           map[string][]string
+	basenames       map[string][]string
+	stems           map[string][]string
+}
+
+func resolveContextFiles(prompt string, files []scanner.FileInfo, cfg config.ProjectConfig, topK int) []string {
+	return resolveContextFilesWithCase(prompt, files, cfg, topK, runtime.GOOS == "windows")
+}
+
+func resolveContextFilesWithCase(prompt string, files []scanner.FileInfo, cfg config.ProjectConfig, topK int, caseInsensitive bool) []string {
+	if topK <= 0 || len(files) == 0 {
+		return nil
+	}
+	index := newContextFileIndex(files, caseInsensitive)
+	tokens := contextRoutingTokens(prompt)
+	result := make([]string, 0, topK)
+	seen := make(map[string]struct{})
+	add := func(path string) bool {
+		if path == "" {
+			return false
+		}
+		if _, duplicate := seen[path]; duplicate {
+			return false
+		}
+		seen[path] = struct{}{}
+		result = append(result, path)
+		return len(result) >= topK
+	}
+
+	// Exact normalized repository-relative paths always win.
+	for _, token := range tokens {
+		normalized := normalizeContextPath(token)
+		matches := index.exact[index.key(normalized)]
+		if normalized != "" && len(matches) == 1 && add(matches[0]) {
+			return result
+		}
+	}
+
+	// Then accept a unique basename that includes its extension.
+	for _, token := range tokens {
+		normalized := normalizeContextPath(token)
+		if strings.Contains(normalized, "/") {
+			continue
+		}
+		base := pathpkg.Base(normalized)
+		if pathpkg.Ext(base) == "" {
+			continue
+		}
+		matches := index.basenames[index.key(base)]
+		if len(matches) == 1 && add(matches[0]) {
+			return result
+		}
+	}
+
+	// Finally accept unique extensionless file stems.
+	for _, token := range tokens {
+		normalized := normalizeContextPath(token)
+		if normalized == "" || strings.Contains(normalized, "/") || pathpkg.Ext(normalized) != "" {
+			continue
+		}
+		matches := index.stems[index.key(normalized)]
+		if len(matches) == 1 && add(matches[0]) {
+			return result
+		}
+	}
+
+	// Configured subsystem routes are bounded last-resort file candidates.
+	for _, subsystemIndex := range contextSubsystemMatches(prompt, cfg, len(cfg.Routing.Subsystems)) {
+		subsystem := cfg.Routing.Subsystems[subsystemIndex]
+		for _, prefix := range subsystem.Paths {
+			prefix = normalizeContextPath(prefix)
+			if prefix == "" {
+				continue
+			}
+			prefixKey := index.key(prefix)
+			for _, path := range index.paths {
+				pathKey := index.key(path)
+				if (pathKey == prefixKey || strings.HasPrefix(pathKey, prefixKey+"/")) && add(path) {
+					return result
+				}
+			}
+		}
+	}
+	return result
+}
+
+func newContextFileIndex(files []scanner.FileInfo, caseInsensitive bool) contextFileIndex {
+	index := contextFileIndex{
+		caseInsensitive: caseInsensitive,
+		exact:           make(map[string][]string, len(files)),
+		basenames:       make(map[string][]string),
+		stems:           make(map[string][]string),
+	}
+	for _, file := range files {
+		path := normalizeContextPath(file.Path)
+		if path == "" {
+			continue
+		}
+		if _, duplicate := index.exact[path]; duplicate && !caseInsensitive {
+			continue
+		}
+		pathKey := index.key(path)
+		duplicate := false
+		for _, existing := range index.exact[pathKey] {
+			if existing == path {
+				duplicate = true
+				break
+			}
+		}
+		if duplicate {
+			continue
+		}
+		index.paths = append(index.paths, path)
+		index.exact[pathKey] = append(index.exact[pathKey], path)
+		base := pathpkg.Base(path)
+		index.basenames[index.key(base)] = append(index.basenames[index.key(base)], path)
+		stem := strings.TrimSuffix(base, pathpkg.Ext(base))
+		if stem != "" {
+			index.stems[index.key(stem)] = append(index.stems[index.key(stem)], path)
+		}
+	}
+	sort.Strings(index.paths)
+	return index
+}
+
+func (i contextFileIndex) key(value string) string {
+	if i.caseInsensitive {
+		return strings.ToLower(value)
+	}
+	return value
+}
+
+func contextRoutingTokens(prompt string) []string {
+	matches := contextRoutingTokenPattern.FindAllString(strings.ReplaceAll(prompt, `\`, "/"), -1)
+	tokens := make([]string, 0, len(matches))
+	for _, match := range matches {
+		if match != "" {
+			tokens = append(tokens, match)
+		}
+	}
+	return tokens
+}
+
+type contextSubsystemMatch struct {
+	index int
+	id    string
+	score int
+}
+
+func contextSubsystemMatches(prompt string, cfg config.ProjectConfig, topK int) []int {
+	if topK <= 0 || cfg.RoutingStrategyOrDefault() != "keyword" {
+		return nil
+	}
+
+	promptLower := strings.ToLower(prompt)
+	matches := make([]contextSubsystemMatch, 0, len(cfg.Routing.Subsystems))
+	for index, subsystem := range cfg.Routing.Subsystems {
+		score := 0
+		for _, keyword := range subsystem.Keywords {
+			keyword = strings.TrimSpace(strings.ToLower(keyword))
+			if keyword != "" && strings.Contains(promptLower, keyword) {
+				score++
+			}
+		}
+		for _, pathHint := range subsystem.Paths {
+			pathHint = strings.TrimSpace(strings.ToLower(pathHint))
+			if pathHint != "" && strings.Contains(promptLower, pathHint) {
+				score++
+			}
+		}
+		if score == 0 {
+			continue
+		}
+		id := strings.TrimSpace(subsystem.ID)
+		if id == "" {
+			id = "(unnamed)"
+		}
+		matches = append(matches, contextSubsystemMatch{index: index, id: id, score: score})
+	}
+
+	sort.SliceStable(matches, func(i, j int) bool {
+		if matches[i].score != matches[j].score {
+			return matches[i].score > matches[j].score
+		}
+		if matches[i].id != matches[j].id {
+			return matches[i].id < matches[j].id
+		}
+		return matches[i].index < matches[j].index
+	})
+	if len(matches) > topK {
+		matches = matches[:topK]
+	}
+
+	indices := make([]int, len(matches))
+	for i, match := range matches {
+		indices[i] = match.index
+	}
+	return indices
+}

--- a/cmd/context_routing.go
+++ b/cmd/context_routing.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	pathpkg "path"
 	"regexp"
-	"runtime"
 	"sort"
 	"strings"
 
@@ -18,22 +17,27 @@ type contextFileIndex struct {
 	paths           []string
 	exact           map[string][]string
 	basenames       map[string][]string
-	stems           map[string][]string
 }
 
-func resolveContextFiles(prompt string, files []scanner.FileInfo, cfg config.ProjectConfig, topK int) []string {
-	return resolveContextFilesWithCase(prompt, files, cfg, topK, runtime.GOOS == "windows")
+type contextFileResolution struct {
+	files         []string
+	explicitFiles []string
+	inferredFiles []string
 }
 
 func resolveContextFilesWithCase(prompt string, files []scanner.FileInfo, cfg config.ProjectConfig, topK int, caseInsensitive bool) []string {
+	return resolveContextFileResolutionWithCase(prompt, files, cfg, topK, caseInsensitive).files
+}
+
+func resolveContextFileResolutionWithCase(prompt string, files []scanner.FileInfo, cfg config.ProjectConfig, topK int, caseInsensitive bool) contextFileResolution {
 	if topK <= 0 || len(files) == 0 {
-		return nil
+		return contextFileResolution{}
 	}
 	index := newContextFileIndex(files, caseInsensitive)
 	tokens := contextRoutingTokens(prompt)
-	result := make([]string, 0, topK)
+	resolution := contextFileResolution{files: make([]string, 0, topK)}
 	seen := make(map[string]struct{})
-	add := func(path string) bool {
+	add := func(path string, inferred bool) bool {
 		if path == "" {
 			return false
 		}
@@ -41,16 +45,21 @@ func resolveContextFilesWithCase(prompt string, files []scanner.FileInfo, cfg co
 			return false
 		}
 		seen[path] = struct{}{}
-		result = append(result, path)
-		return len(result) >= topK
+		resolution.files = append(resolution.files, path)
+		if inferred {
+			resolution.inferredFiles = append(resolution.inferredFiles, path)
+		} else {
+			resolution.explicitFiles = append(resolution.explicitFiles, path)
+		}
+		return len(resolution.files) >= topK
 	}
 
 	// Exact normalized repository-relative paths always win.
 	for _, token := range tokens {
 		normalized := normalizeContextPath(token)
 		matches := index.exact[index.key(normalized)]
-		if normalized != "" && len(matches) == 1 && add(matches[0]) {
-			return result
+		if normalized != "" && len(matches) == 1 && add(matches[0], false) {
+			return resolution
 		}
 	}
 
@@ -65,25 +74,13 @@ func resolveContextFilesWithCase(prompt string, files []scanner.FileInfo, cfg co
 			continue
 		}
 		matches := index.basenames[index.key(base)]
-		if len(matches) == 1 && add(matches[0]) {
-			return result
-		}
-	}
-
-	// Finally accept unique extensionless file stems.
-	for _, token := range tokens {
-		normalized := normalizeContextPath(token)
-		if normalized == "" || strings.Contains(normalized, "/") || pathpkg.Ext(normalized) != "" {
-			continue
-		}
-		matches := index.stems[index.key(normalized)]
-		if len(matches) == 1 && add(matches[0]) {
-			return result
+		if len(matches) == 1 && add(matches[0], false) {
+			return resolution
 		}
 	}
 
 	// Configured subsystem routes are bounded last-resort file candidates.
-	for _, subsystemIndex := range contextSubsystemMatches(prompt, cfg, len(cfg.Routing.Subsystems)) {
+	for _, subsystemIndex := range contextSubsystemMatches(prompt, cfg, cfg.RoutingTopKOrDefault()) {
 		subsystem := cfg.Routing.Subsystems[subsystemIndex]
 		for _, prefix := range subsystem.Paths {
 			prefix = normalizeContextPath(prefix)
@@ -93,13 +90,13 @@ func resolveContextFilesWithCase(prompt string, files []scanner.FileInfo, cfg co
 			prefixKey := index.key(prefix)
 			for _, path := range index.paths {
 				pathKey := index.key(path)
-				if (pathKey == prefixKey || strings.HasPrefix(pathKey, prefixKey+"/")) && add(path) {
-					return result
+				if (pathKey == prefixKey || strings.HasPrefix(pathKey, prefixKey+"/")) && add(path, true) {
+					return resolution
 				}
 			}
 		}
 	}
-	return result
+	return resolution
 }
 
 func newContextFileIndex(files []scanner.FileInfo, caseInsensitive bool) contextFileIndex {
@@ -107,10 +104,9 @@ func newContextFileIndex(files []scanner.FileInfo, caseInsensitive bool) context
 		caseInsensitive: caseInsensitive,
 		exact:           make(map[string][]string, len(files)),
 		basenames:       make(map[string][]string),
-		stems:           make(map[string][]string),
 	}
 	for _, file := range files {
-		path := normalizeContextPath(file.Path)
+		path := normalizeContextInventoryPath(file.Path)
 		if path == "" {
 			continue
 		}
@@ -132,10 +128,6 @@ func newContextFileIndex(files []scanner.FileInfo, caseInsensitive bool) context
 		index.exact[pathKey] = append(index.exact[pathKey], path)
 		base := pathpkg.Base(path)
 		index.basenames[index.key(base)] = append(index.basenames[index.key(base)], path)
-		stem := strings.TrimSuffix(base, pathpkg.Ext(base))
-		if stem != "" {
-			index.stems[index.key(stem)] = append(index.stems[index.key(stem)], path)
-		}
 	}
 	sort.Strings(index.paths)
 	return index
@@ -159,59 +151,15 @@ func contextRoutingTokens(prompt string) []string {
 	return tokens
 }
 
-type contextSubsystemMatch struct {
-	index int
-	id    string
-	score int
-}
-
 func contextSubsystemMatches(prompt string, cfg config.ProjectConfig, topK int) []int {
-	if topK <= 0 || cfg.RoutingStrategyOrDefault() != "keyword" {
+	matches := matchSubsystemRoutes(prompt, cfg, topK)
+	if len(matches) == 0 {
 		return nil
-	}
-
-	promptLower := strings.ToLower(prompt)
-	matches := make([]contextSubsystemMatch, 0, len(cfg.Routing.Subsystems))
-	for index, subsystem := range cfg.Routing.Subsystems {
-		score := 0
-		for _, keyword := range subsystem.Keywords {
-			keyword = strings.TrimSpace(strings.ToLower(keyword))
-			if keyword != "" && strings.Contains(promptLower, keyword) {
-				score++
-			}
-		}
-		for _, pathHint := range subsystem.Paths {
-			pathHint = strings.TrimSpace(strings.ToLower(pathHint))
-			if pathHint != "" && strings.Contains(promptLower, pathHint) {
-				score++
-			}
-		}
-		if score == 0 {
-			continue
-		}
-		id := strings.TrimSpace(subsystem.ID)
-		if id == "" {
-			id = "(unnamed)"
-		}
-		matches = append(matches, contextSubsystemMatch{index: index, id: id, score: score})
-	}
-
-	sort.SliceStable(matches, func(i, j int) bool {
-		if matches[i].score != matches[j].score {
-			return matches[i].score > matches[j].score
-		}
-		if matches[i].id != matches[j].id {
-			return matches[i].id < matches[j].id
-		}
-		return matches[i].index < matches[j].index
-	})
-	if len(matches) > topK {
-		matches = matches[:topK]
 	}
 
 	indices := make([]int, len(matches))
 	for i, match := range matches {
-		indices[i] = match.index
+		indices[i] = match.Index
 	}
 	return indices
 }

--- a/cmd/context_routing_test.go
+++ b/cmd/context_routing_test.go
@@ -1,0 +1,144 @@
+package cmd
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"codemap/config"
+	"codemap/scanner"
+)
+
+func TestContextLexicalRouting(t *testing.T) {
+	t.Run("exact path wins before stem", func(t *testing.T) {
+		files := routingFiles("cmd/context.go", "internal/helper.go")
+		got := resolveContextFilesWithCase("inspect cmd/context.go and context", files, config.ProjectConfig{}, 3, false)
+		if want := []string{"cmd/context.go"}; !reflect.DeepEqual(got, want) {
+			t.Fatalf("files = %#v, want %#v", got, want)
+		}
+	})
+
+	t.Run("unique extension basename and Rust stem", func(t *testing.T) {
+		files := routingFiles("mcp/server.go", "src/final_build.rs")
+		got := resolveContextFilesWithCase("connect server.go to final_build", files, config.ProjectConfig{}, 3, false)
+		if want := []string{"mcp/server.go", "src/final_build.rs"}; !reflect.DeepEqual(got, want) {
+			t.Fatalf("files = %#v, want %#v", got, want)
+		}
+	})
+
+	t.Run("ambiguous basename and stem stay unresolved", func(t *testing.T) {
+		files := routingFiles("cmd/context.go", "internal/context.go", "src/graph.rs", "mcp/graph.go")
+		got := resolveContextFilesWithCase("inspect context.go and graph", files, config.ProjectConfig{}, 4, false)
+		if len(got) != 0 {
+			t.Fatalf("ambiguous files = %#v, want none", got)
+		}
+	})
+
+	t.Run("Windows separators and case are normalized", func(t *testing.T) {
+		files := routingFiles("Cmd/Context.go")
+		got := resolveContextFilesWithCase(`inspect cmd\context.go`, files, config.ProjectConfig{}, 1, true)
+		if want := []string{"Cmd/Context.go"}; !reflect.DeepEqual(got, want) {
+			t.Fatalf("files = %#v, want %#v", got, want)
+		}
+		if got := resolveContextFilesWithCase(`inspect cmd\context.go`, files, config.ProjectConfig{}, 1, false); len(got) != 0 {
+			t.Fatalf("case-sensitive routing = %#v, want none", got)
+		}
+	})
+
+	t.Run("traversal tokens stay unresolved", func(t *testing.T) {
+		files := routingFiles("foo.go")
+		got := resolveContextFilesWithCase("inspect ../foo.go and ../../foo.go", files, config.ProjectConfig{}, 2, false)
+		if len(got) != 0 {
+			t.Fatalf("traversal files = %#v, want none", got)
+		}
+	})
+
+	t.Run("normalized duplicates resolve once", func(t *testing.T) {
+		files := routingFiles("./cmd/context.go", "cmd/context.go", "internal/context.go")
+		got := resolveContextFilesWithCase("inspect cmd/./context.go and context", files, config.ProjectConfig{}, 2, false)
+		if want := []string{"cmd/context.go"}; !reflect.DeepEqual(got, want) {
+			t.Fatalf("normalized files = %#v, want %#v", got, want)
+		}
+	})
+
+	t.Run("absolute and volume paths stay unresolved", func(t *testing.T) {
+		files := routingFiles("/tmp/target.go", "C:/tmp/target.go", "//server/share.go")
+		got := resolveContextFilesWithCase("inspect /tmp/target.go C:\\tmp\\target.go //server/share.go", files, config.ProjectConfig{}, 3, true)
+		if len(got) != 0 {
+			t.Fatalf("absolute files = %#v, want none", got)
+		}
+	})
+
+	t.Run("case-folded exact collisions stay unresolved", func(t *testing.T) {
+		files := routingFiles("Cmd/Foo.go", "cmd/foo.go")
+		got := resolveContextFilesWithCase(`inspect CMD\FOO.GO`, files, config.ProjectConfig{}, 2, true)
+		if len(got) != 0 {
+			t.Fatalf("case-collision files = %#v, want none", got)
+		}
+	})
+
+	t.Run("top k bounds lexical matches", func(t *testing.T) {
+		files := routingFiles("src/alpha.go", "src/beta.go", "src/gamma.go")
+		got := resolveContextFilesWithCase("alpha beta gamma", files, config.ProjectConfig{}, 2, false)
+		if want := []string{"src/alpha.go", "src/beta.go"}; !reflect.DeepEqual(got, want) {
+			t.Fatalf("files = %#v, want %#v", got, want)
+		}
+	})
+
+	t.Run("subsystem paths are deterministic and bounded", func(t *testing.T) {
+		files := routingFiles("src/build/c.go", "src/build/a.go", "src/build/b.go", "src/other.go")
+		cfg := config.ProjectConfig{Routing: config.RoutingConfig{
+			Subsystems: []config.Subsystem{{ID: "build", Keywords: []string{"overdrive"}, Paths: []string{"src/build"}}},
+		}}
+		got := resolveContextFilesWithCase("speed up overdrive", files, cfg, 2, false)
+		if want := []string{"src/build/a.go", "src/build/b.go"}; !reflect.DeepEqual(got, want) {
+			t.Fatalf("files = %#v, want %#v", got, want)
+		}
+	})
+
+	t.Run("duplicate subsystem ids retain each path", func(t *testing.T) {
+		files := routingFiles("alpha/a.go", "beta/b.go")
+		cfg := config.ProjectConfig{Routing: config.RoutingConfig{Subsystems: []config.Subsystem{
+			{ID: "shared", Keywords: []string{"overdrive"}, Paths: []string{"alpha"}},
+			{ID: "shared", Keywords: []string{"overdrive"}, Paths: []string{"beta"}},
+		}}}
+		got := resolveContextFilesWithCase("inspect overdrive", files, cfg, 2, false)
+		if want := []string{"alpha/a.go", "beta/b.go"}; !reflect.DeepEqual(got, want) {
+			t.Fatalf("files = %#v, want %#v", got, want)
+		}
+	})
+
+	t.Run("mixed lexical and subsystem routes", func(t *testing.T) {
+		files := routingFiles("mcp/server.go", "src/final_build.rs", "src/graph.rs", "docs/design.md")
+		cfg := config.ProjectConfig{Routing: config.RoutingConfig{
+			Subsystems: []config.Subsystem{{ID: "mcp", Keywords: []string{"mcp"}, Paths: []string{"mcp"}}},
+		}}
+		got := resolveContextFilesWithCase("trace mcp -> final_build -> graph", files, cfg, 3, false)
+		want := []string{"src/final_build.rs", "src/graph.rs", "mcp/server.go"}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("files = %#v, want %#v", got, want)
+		}
+	})
+
+	t.Run("resolved stem drives intent risk", func(t *testing.T) {
+		files := routingFiles("src/final_build.rs", "a.rs", "b.rs", "c.rs")
+		graph := &scanner.FileGraph{
+			Imports: map[string][]string{
+				"a.rs": {"src/final_build.rs"}, "b.rs": {"src/final_build.rs"}, "c.rs": {"src/final_build.rs"},
+			},
+			Importers: map[string][]string{"src/final_build.rs": {"a.rs", "b.rs", "c.rs"}},
+		}
+		envelope := buildContextEnvelopeWithDeps(context.Background(), t.TempDir(), "refactor final_build", true, testContextEnvelopeDeps(files, graph))
+		if envelope.Intent == nil || !reflect.DeepEqual(envelope.Intent.Files, []string{"src/final_build.rs"}) || envelope.Intent.RiskLevel != "medium" {
+			t.Fatalf("intent = %#v", envelope.Intent)
+		}
+	})
+}
+
+func routingFiles(paths ...string) []scanner.FileInfo {
+	files := make([]scanner.FileInfo, len(paths))
+	for i, path := range paths {
+		files[i] = scanner.FileInfo{Path: path}
+	}
+	return files
+}

--- a/cmd/context_routing_test.go
+++ b/cmd/context_routing_test.go
@@ -69,6 +69,14 @@ func TestContextLexicalRouting(t *testing.T) {
 		}
 	})
 
+	t.Run("inventory keeps significant whitespace", func(t *testing.T) {
+		files := routingFiles(" foo.go", "bar.go ")
+		got := resolveContextFilesWithCase("inspect foo.go and bar.go", files, config.ProjectConfig{}, 2, false)
+		if len(got) != 0 {
+			t.Fatalf("whitespace files = %#v, want none", got)
+		}
+	})
+
 	t.Run("absolute and volume paths stay unresolved", func(t *testing.T) {
 		files := routingFiles("/tmp/target.go", "C:/tmp/target.go", "//server/share.go")
 		got := resolveContextFilesWithCase("inspect /tmp/target.go C:\\tmp\\target.go //server/share.go", files, config.ProjectConfig{}, 3, true)

--- a/cmd/context_routing_test.go
+++ b/cmd/context_routing_test.go
@@ -10,27 +10,35 @@ import (
 )
 
 func TestContextLexicalRouting(t *testing.T) {
-	t.Run("exact path wins before stem", func(t *testing.T) {
-		files := routingFiles("cmd/context.go", "internal/helper.go")
-		got := resolveContextFilesWithCase("inspect cmd/context.go and context", files, config.ProjectConfig{}, 3, false)
-		if want := []string{"cmd/context.go"}; !reflect.DeepEqual(got, want) {
+	t.Run("exact path wins over basename regardless of token order", func(t *testing.T) {
+		files := routingFiles("cmd/context.go", "pkg/server.go")
+		got := resolveContextFilesWithCase("inspect server.go and cmd/context.go", files, config.ProjectConfig{}, 2, false)
+		if want := []string{"cmd/context.go", "pkg/server.go"}; !reflect.DeepEqual(got, want) {
 			t.Fatalf("files = %#v, want %#v", got, want)
 		}
 	})
 
-	t.Run("unique extension basename and Rust stem", func(t *testing.T) {
+	t.Run("unique extension basename resolves", func(t *testing.T) {
 		files := routingFiles("mcp/server.go", "src/final_build.rs")
-		got := resolveContextFilesWithCase("connect server.go to final_build", files, config.ProjectConfig{}, 3, false)
-		if want := []string{"mcp/server.go", "src/final_build.rs"}; !reflect.DeepEqual(got, want) {
+		got := resolveContextFilesWithCase("connect server.go", files, config.ProjectConfig{}, 3, false)
+		if want := []string{"mcp/server.go"}; !reflect.DeepEqual(got, want) {
 			t.Fatalf("files = %#v, want %#v", got, want)
 		}
 	})
 
-	t.Run("ambiguous basename and stem stay unresolved", func(t *testing.T) {
+	t.Run("ambiguous basename stays unresolved", func(t *testing.T) {
 		files := routingFiles("cmd/context.go", "internal/context.go", "src/graph.rs", "mcp/graph.go")
 		got := resolveContextFilesWithCase("inspect context.go and graph", files, config.ProjectConfig{}, 4, false)
 		if len(got) != 0 {
 			t.Fatalf("ambiguous files = %#v, want none", got)
+		}
+	})
+
+	t.Run("ordinary words do not resolve extensionless file stems", func(t *testing.T) {
+		files := routingFiles("cmd/doctor.go", "plugins/install.go", "cmd/root.go", "handoff/build.go")
+		got := resolveContextFilesWithCase("please install a new machine and root out the build problem", files, config.ProjectConfig{}, 4, false)
+		if len(got) != 0 {
+			t.Fatalf("inferred files = %#v, want none", got)
 		}
 	})
 
@@ -67,6 +75,15 @@ func TestContextLexicalRouting(t *testing.T) {
 		if len(got) != 0 {
 			t.Fatalf("absolute files = %#v, want none", got)
 		}
+		if got := normalizeContextPath(`C:\\tmp\\target.go`); got != "" {
+			t.Fatalf("drive path = %q, want empty", got)
+		}
+		if got := normalizeContextPath("//server/share.go"); got != "" {
+			t.Fatalf("UNC path = %q, want empty", got)
+		}
+		if got := normalizeContextInventoryPath("x:helper.go"); got != "x:helper.go" {
+			t.Fatalf("inventory path = %q, want x:helper.go", got)
+		}
 	})
 
 	t.Run("case-folded exact collisions stay unresolved", func(t *testing.T) {
@@ -79,7 +96,7 @@ func TestContextLexicalRouting(t *testing.T) {
 
 	t.Run("top k bounds lexical matches", func(t *testing.T) {
 		files := routingFiles("src/alpha.go", "src/beta.go", "src/gamma.go")
-		got := resolveContextFilesWithCase("alpha beta gamma", files, config.ProjectConfig{}, 2, false)
+		got := resolveContextFilesWithCase("alpha.go beta.go gamma.go", files, config.ProjectConfig{}, 2, false)
 		if want := []string{"src/alpha.go", "src/beta.go"}; !reflect.DeepEqual(got, want) {
 			t.Fatalf("files = %#v, want %#v", got, want)
 		}
@@ -113,14 +130,14 @@ func TestContextLexicalRouting(t *testing.T) {
 		cfg := config.ProjectConfig{Routing: config.RoutingConfig{
 			Subsystems: []config.Subsystem{{ID: "mcp", Keywords: []string{"mcp"}, Paths: []string{"mcp"}}},
 		}}
-		got := resolveContextFilesWithCase("trace mcp -> final_build -> graph", files, cfg, 3, false)
+		got := resolveContextFilesWithCase("trace mcp -> final_build.rs -> graph.rs", files, cfg, 3, false)
 		want := []string{"src/final_build.rs", "src/graph.rs", "mcp/server.go"}
 		if !reflect.DeepEqual(got, want) {
 			t.Fatalf("files = %#v, want %#v", got, want)
 		}
 	})
 
-	t.Run("resolved stem drives intent risk", func(t *testing.T) {
+	t.Run("explicit basename drives intent risk", func(t *testing.T) {
 		files := routingFiles("src/final_build.rs", "a.rs", "b.rs", "c.rs")
 		graph := &scanner.FileGraph{
 			Imports: map[string][]string{
@@ -128,8 +145,42 @@ func TestContextLexicalRouting(t *testing.T) {
 			},
 			Importers: map[string][]string{"src/final_build.rs": {"a.rs", "b.rs", "c.rs"}},
 		}
-		envelope := buildContextEnvelopeWithDeps(context.Background(), t.TempDir(), "refactor final_build", true, testContextEnvelopeDeps(files, graph))
+		envelope := buildContextEnvelopeWithDeps(context.Background(), t.TempDir(), "refactor final_build.rs", true, testContextEnvelopeDeps(files, graph))
 		if envelope.Intent == nil || !reflect.DeepEqual(envelope.Intent.Files, []string{"src/final_build.rs"}) || envelope.Intent.RiskLevel != "medium" {
+			t.Fatalf("intent = %#v", envelope.Intent)
+		}
+		if envelope.Intent.FileConfidence != "explicit" {
+			t.Fatalf("file confidence = %q, want explicit", envelope.Intent.FileConfidence)
+		}
+	})
+
+	t.Run("inferred candidates do not affect explicit scope or risk", func(t *testing.T) {
+		files := routingFiles("README.md", "src/build/a.go", "src/build/b.go")
+		cfg := config.ProjectConfig{Routing: config.RoutingConfig{
+			Subsystems: []config.Subsystem{{ID: "build", Keywords: []string{"overdrive"}, Paths: []string{"src/build"}}},
+		}}
+		graph := &scanner.FileGraph{Importers: map[string][]string{
+			"README.md":      {},
+			"src/build/a.go": {"one.go", "two.go", "three.go"},
+		}}
+		root := t.TempDir()
+		writeProjectConfig(t, root, cfg)
+		envelope := buildContextEnvelopeWithDeps(context.Background(), root, "inspect README.md during overdrive", true, testContextEnvelopeDeps(files, graph))
+		if envelope.Intent == nil || len(envelope.Intent.Files) != 3 || envelope.Intent.FileConfidence != "mixed" || envelope.Intent.Scope != "single-file" || envelope.Intent.RiskLevel != "low" {
+			t.Fatalf("intent = %#v", envelope.Intent)
+		}
+	})
+
+	t.Run("inferred subsystem candidates do not set scope or risk", func(t *testing.T) {
+		files := routingFiles("src/build/a.go", "src/build/b.go", "src/other.go")
+		cfg := config.ProjectConfig{Routing: config.RoutingConfig{
+			Subsystems: []config.Subsystem{{ID: "build", Keywords: []string{"overdrive"}, Paths: []string{"src/build"}}},
+		}}
+		graph := &scanner.FileGraph{Importers: map[string][]string{"src/build/a.go": {"src/other.go", "src/other.go", "src/other.go"}}}
+		root := t.TempDir()
+		writeProjectConfig(t, root, cfg)
+		envelope := buildContextEnvelopeWithDeps(context.Background(), root, "speed up overdrive", true, testContextEnvelopeDeps(files, graph))
+		if envelope.Intent == nil || len(envelope.Intent.Files) != 2 || envelope.Intent.FileConfidence != "inferred" || envelope.Intent.Scope != "unknown" || envelope.Intent.RiskLevel != "unknown" {
 			t.Fatalf("intent = %#v", envelope.Intent)
 		}
 	})

--- a/cmd/hooks.go
+++ b/cmd/hooks.go
@@ -1267,6 +1267,7 @@ func extractMentionedFiles(prompt string, limit int) []string {
 type subsystemRouteMatch struct {
 	ID           string   `json:"id"`
 	Score        int      `json:"score"`
+	Index        int      `json:"-"`
 	Docs         []string `json:"docs,omitempty"`
 	Agents       []string `json:"agents,omitempty"`
 	Instructions string   `json:"instructions,omitempty"`
@@ -1279,7 +1280,7 @@ func matchSubsystemRoutes(prompt string, cfg config.ProjectConfig, topK int) []s
 
 	promptLower := strings.ToLower(prompt)
 	var matches []subsystemRouteMatch
-	for _, subsystem := range cfg.Routing.Subsystems {
+	for index, subsystem := range cfg.Routing.Subsystems {
 		score := 0
 		for _, keyword := range subsystem.Keywords {
 			keyword = strings.TrimSpace(strings.ToLower(keyword))
@@ -1304,6 +1305,7 @@ func matchSubsystemRoutes(prompt string, cfg config.ProjectConfig, topK int) []s
 		matches = append(matches, subsystemRouteMatch{
 			ID:           id,
 			Score:        score,
+			Index:        index,
 			Docs:         subsystem.Docs,
 			Agents:       subsystem.Agents,
 			Instructions: subsystem.Instructions,
@@ -1312,6 +1314,9 @@ func matchSubsystemRoutes(prompt string, cfg config.ProjectConfig, topK int) []s
 
 	sort.Slice(matches, func(i, j int) bool {
 		if matches[i].Score == matches[j].Score {
+			if matches[i].ID == matches[j].ID {
+				return matches[i].Index < matches[j].Index
+			}
 			return matches[i].ID < matches[j].ID
 		}
 		return matches[i].Score > matches[j].Score

--- a/cmd/intent.go
+++ b/cmd/intent.go
@@ -10,13 +10,14 @@ import (
 
 // TaskIntent represents a parsed understanding of what the user wants to do.
 type TaskIntent struct {
-	Category           string              `json:"category"`    // "refactor", "feature", "bugfix", "explore", "test", "docs"
-	Confidence         float64             `json:"confidence"`  // 0.0-1.0 confidence in category
-	Files              []string            `json:"files"`       // mentioned files
-	Subsystems         []string            `json:"subsystems"`  // matched subsystem IDs
-	Scope              string              `json:"scope"`       // "single-file", "package", "cross-cutting"
-	RiskLevel          string              `json:"risk"`        // "unknown", "low", "medium", "high"
-	Suggestions        []ContextSuggestion `json:"suggestions"` // what to read/check next
+	Category           string              `json:"category"`                  // "refactor", "feature", "bugfix", "explore", "test", "docs"
+	Confidence         float64             `json:"confidence"`                // 0.0-1.0 confidence in category
+	Files              []string            `json:"files"`                     // files named or inferred from the request
+	FileConfidence     string              `json:"file_confidence,omitempty"` // explicit, inferred, or mixed
+	Subsystems         []string            `json:"subsystems"`                // matched subsystem IDs
+	Scope              string              `json:"scope"`                     // "single-file", "package", "cross-cutting"
+	RiskLevel          string              `json:"risk"`                      // "unknown", "low", "medium", "high"
+	Suggestions        []ContextSuggestion `json:"suggestions"`               // what to read/check next
 	DependencyCoverage string              `json:"dependency_coverage,omitempty"`
 	CoverageNotes      []string            `json:"coverage_notes,omitempty"`
 }
@@ -110,11 +111,48 @@ var categoryDefs = []categoryDef{
 
 // classifyIntent analyzes a user prompt against code intelligence to determine task intent.
 func classifyIntent(prompt string, files []string, info *hubInfo, cfg config.ProjectConfig) TaskIntent {
+	return classifyIntentWithEvidence(prompt, files, info, cfg, false)
+}
+
+func classifyIntentWithEvidence(prompt string, files []string, info *hubInfo, cfg config.ProjectConfig, inferredOnly bool) TaskIntent {
+	riskFiles := files
+	if inferredOnly {
+		riskFiles = nil
+	}
+	confidence := ""
+	if len(files) > 0 {
+		if inferredOnly {
+			confidence = "inferred"
+		} else {
+			confidence = "explicit"
+		}
+	}
+	return classifyIntentWithFiles(prompt, files, riskFiles, info, cfg, confidence, inferredOnly)
+}
+
+func classifyIntentWithResolution(prompt string, resolution contextFileResolution, info *hubInfo, cfg config.ProjectConfig) TaskIntent {
+	confidence := ""
+	switch {
+	case len(resolution.explicitFiles) > 0 && len(resolution.inferredFiles) > 0:
+		confidence = "mixed"
+	case len(resolution.explicitFiles) > 0:
+		confidence = "explicit"
+	case len(resolution.inferredFiles) > 0:
+		confidence = "inferred"
+	}
+	inferredOnly := len(resolution.explicitFiles) == 0 && len(resolution.inferredFiles) > 0
+	return classifyIntentWithFiles(prompt, resolution.files, resolution.explicitFiles, info, cfg, confidence, inferredOnly)
+}
+
+func classifyIntentWithFiles(prompt string, files, riskFiles []string, info *hubInfo, cfg config.ProjectConfig, confidence string, inferredOnly bool) TaskIntent {
 	intent := TaskIntent{
 		Category:  "feature", // default
 		Files:     files,
 		RiskLevel: "unknown",
 		Scope:     "single-file",
+	}
+	if confidence != "" {
+		intent.FileConfidence = confidence
 	}
 	if info != nil {
 		intent.DependencyCoverage = string(info.Coverage.Status)
@@ -153,7 +191,7 @@ func classifyIntent(prompt string, files []string, info *hubInfo, cfg config.Pro
 	}
 
 	// Compute scope from file distribution
-	intent.Scope = computeScope(files)
+	intent.Scope = computeScopeWithEvidence(riskFiles, inferredOnly)
 
 	// Match subsystems
 	if len(cfg.Routing.Subsystems) > 0 {
@@ -164,8 +202,15 @@ func classifyIntent(prompt string, files []string, info *hubInfo, cfg config.Pro
 	}
 
 	// Compute risk level and generate suggestions from hub analysis
-	if info != nil && len(files) > 0 {
-		intent.RiskLevel, intent.Suggestions = analyzeRisk(files, info, intent.Category)
+	if info != nil && len(riskFiles) > 0 {
+		intent.RiskLevel, intent.Suggestions = analyzeRiskWithEvidence(riskFiles, info, intent.Category, false)
+	} else if inferredOnly {
+		intent.RiskLevel = "unknown"
+		intent.Suggestions = []ContextSuggestion{{
+			Type:   "check-deps",
+			Target: ".",
+			Reason: "risk is unknown without an explicit file mention",
+		}}
 	} else {
 		intent.Suggestions = []ContextSuggestion{{
 			Type:   "check-deps",
@@ -179,6 +224,13 @@ func classifyIntent(prompt string, files []string, info *hubInfo, cfg config.Pro
 
 // computeScope determines whether the task touches one file, one package, or crosses packages.
 func computeScope(files []string) string {
+	return computeScopeWithEvidence(files, false)
+}
+
+func computeScopeWithEvidence(files []string, inferredOnly bool) string {
+	if inferredOnly {
+		return "unknown"
+	}
 	if len(files) == 0 {
 		return "unknown"
 	}
@@ -199,6 +251,13 @@ func computeScope(files []string) string {
 
 // analyzeRisk evaluates hub involvement and generates context suggestions.
 func analyzeRisk(files []string, info *hubInfo, category string) (string, []ContextSuggestion) {
+	return analyzeRiskWithEvidence(files, info, category, false)
+}
+
+func analyzeRiskWithEvidence(files []string, info *hubInfo, category string, inferredOnly bool) (string, []ContextSuggestion) {
+	if inferredOnly {
+		return "unknown", nil
+	}
 	risk := "low"
 	var suggestions []ContextSuggestion
 


### PR DESCRIPTION
## What does this PR do?

- Resolves exact paths, unique extension basenames, unique stems, and configured subsystem paths.
- Normalizes repository-relative paths across slash styles and rejects traversal, absolute, volume, or ambiguous case-folded matches.
- Feeds resolved files into the existing evidence-backed intent risk model.

This makes common agentic coding prompts such as `refactor final_build` useful without fuzzy dependency false positives.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] New language support
- [ ] Documentation
- [ ] Other

## Checklist

- [x] Tested locally with Go 1.27.0: `go test ./...`
- [x] Verified traversal, ambiguity, case, duplicate subsystem, and top-k boundaries
- [x] Verified with `go vet ./...`

## Additional notes

Routing is inventory-only and performs no semantic search or unbounded expansion.