### PR TITLE
fix(watch): Validate cached graph provenance

### DIFF
--- a/cmd/context_evidence.go
+++ b/cmd/context_evidence.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"codemap/analysis"
 	"codemap/config"
 	"codemap/limits"
 	"codemap/scanner"
@@ -105,7 +106,13 @@ func loadContextRequestInputs(ctx context.Context, root string, deps contextEnve
 		inputs.evidence = unavailableGraphEvidence(graphErrorReason(ctx, err))
 		return inputs
 	}
-	if graph == nil || (len(graph.Imports) == 0 && len(graph.Importers) == 0) {
+	if graph == nil {
+		inputs.evidence = unavailableGraphEvidence(graphEvidenceScanIncomplete)
+		return inputs
+	}
+	// Complete edge-free graphs are valid; unavailable provenance is not.
+	if graph.Coverage.Status == analysis.CoverageUnavailable ||
+		(len(graph.Coverage.Sources) > 0 && scanner.CoverageFromSources(graph.Coverage.Sources).Status == analysis.CoverageUnavailable) {
 		inputs.evidence = unavailableGraphEvidence(graphEvidenceScanIncomplete)
 		return inputs
 	}

--- a/cmd/context_evidence.go
+++ b/cmd/context_evidence.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	"codemap/analysis"
+	"codemap/config"
 	"codemap/limits"
 	"codemap/scanner"
 	"codemap/watch"
@@ -18,6 +18,7 @@ const (
 	graphEvidenceAvailable       = "available"
 	graphEvidenceUnavailable     = "unavailable"
 	graphEvidenceFreshScan       = "fresh_scan"
+	graphEvidenceWatchCache      = "watch_cache"
 	graphEvidenceLargeRepository = "large_repository"
 	graphEvidenceCancelled       = "cancelled"
 	graphEvidenceDeadline        = "deadline"
@@ -90,6 +91,10 @@ func loadContextRequestInputs(ctx context.Context, root string, deps contextEnve
 		inputs.evidence = GraphEvidence{Status: graphEvidenceAvailable, Source: graphEvidenceFreshScan}
 		return inputs
 	}
+	if graph, _ := watch.ValidateCachedGraphForInventory(inputs.state, root, config.Load(root), contextFilePaths(files)); graph != nil {
+		populateContextGraphInputs(&inputs, graph, graphEvidenceWatchCache)
+		return inputs
+	}
 	if len(files) > limits.LargeRepoFileCount {
 		inputs.evidence = unavailableGraphEvidence(graphEvidenceLargeRepository)
 		return inputs
@@ -100,20 +105,24 @@ func loadContextRequestInputs(ctx context.Context, root string, deps contextEnve
 		inputs.evidence = unavailableGraphEvidence(graphErrorReason(ctx, err))
 		return inputs
 	}
-	if graph == nil {
-		inputs.evidence = unavailableGraphEvidence(graphEvidenceScanIncomplete)
-		return inputs
-	}
-	// An edge-free graph is still authoritative when its coverage is complete
-	// (the zero coverage status is the production graph's complete default).
-	// Explicitly unavailable provenance remains fail-closed, even if stale or
-	// partial edge maps happen to contain entries.
-	if graph.Coverage.Status == analysis.CoverageUnavailable ||
-		(len(graph.Coverage.Sources) > 0 && scanner.CoverageFromSources(graph.Coverage.Sources).Status == analysis.CoverageUnavailable) {
+	if graph == nil || (len(graph.Imports) == 0 && len(graph.Importers) == 0) {
 		inputs.evidence = unavailableGraphEvidence(graphEvidenceScanIncomplete)
 		return inputs
 	}
 
+	populateContextGraphInputs(&inputs, graph, graphEvidenceFreshScan)
+	return inputs
+}
+
+func contextFilePaths(files []scanner.FileInfo) []string {
+	paths := make([]string, 0, len(files))
+	for _, file := range files {
+		paths = append(paths, file.Path)
+	}
+	return paths
+}
+
+func populateContextGraphInputs(inputs *contextRequestInputs, graph *scanner.FileGraph, source string) {
 	hubs := sortedGraphHubs(graph.Importers)
 	inputs.info = &hubInfo{
 		Hubs:      hubs,
@@ -121,8 +130,7 @@ func loadContextRequestInputs(ctx context.Context, root string, deps contextEnve
 		Imports:   graph.Imports,
 		Coverage:  graph.Coverage,
 	}
-	inputs.evidence = GraphEvidence{Status: graphEvidenceAvailable, Source: graphEvidenceFreshScan}
-	return inputs
+	inputs.evidence = GraphEvidence{Status: graphEvidenceAvailable, Source: source}
 }
 
 func unavailableGraphEvidence(reason string) GraphEvidence {

--- a/cmd/context_evidence_test.go
+++ b/cmd/context_evidence_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"codemap/analysis"
 	"codemap/config"
 	"codemap/internal/projectpath"
 	"codemap/scanner"
@@ -60,6 +61,7 @@ func TestContextEnvelopeV2ReportsUnavailableGraph(t *testing.T) {
 		Packages:  map[string][]string{"main": {"main.go"}},
 		Imports:   map[string][]string{},
 		Importers: map[string][]string{},
+		Coverage:  scanner.GraphCoverage{Status: analysis.CoverageUnavailable},
 	}
 	envelope := buildContextEnvelopeWithDeps(context.Background(), t.TempDir(), "refactor main.go", true, testContextEnvelopeDeps(files, graph))
 
@@ -84,6 +86,24 @@ func TestContextEnvelopeV2ReportsUnavailableGraph(t *testing.T) {
 	}
 	if envelope.Intent == nil || envelope.Intent.RiskLevel != "unknown" {
 		t.Fatalf("intent = %#v, want unknown risk", envelope.Intent)
+	}
+}
+
+func TestContextGraphEvidenceAcceptsCompleteEdgeFreeGraph(t *testing.T) {
+	files := []scanner.FileInfo{{Path: "main.go"}}
+	graph := &scanner.FileGraph{
+		Imports:   map[string][]string{},
+		Importers: map[string][]string{},
+		Coverage:  scanner.GraphCoverage{Status: analysis.CoverageComplete},
+	}
+
+	envelope := buildContextEnvelopeWithDeps(context.Background(), t.TempDir(), "inspect main.go", true, testContextEnvelopeDeps(files, graph))
+
+	if envelope.Project.GraphEvidence.Status != graphEvidenceAvailable || envelope.Project.GraphEvidence.Source != graphEvidenceFreshScan {
+		t.Fatalf("graph evidence = %#v, want available fresh_scan", envelope.Project.GraphEvidence)
+	}
+	if envelope.Project.HubCount == nil || *envelope.Project.HubCount != 0 {
+		t.Fatalf("hub count = %#v, want zero", envelope.Project.HubCount)
 	}
 }
 
@@ -445,7 +465,7 @@ func TestPromptHookValidatedGraphCache(t *testing.T) {
 		})
 	}
 
-	checkRisk("refactor pkg/types.go", "medium")
+	checkRisk("refactor pkg/types.go", "unknown")
 	checkRisk("refactor pkg/missing.go", "unknown")
 	checkRisk("refactor generated/deeper/ignored.go", "unknown")
 	state.Graph.BuilderRevision = "old"

--- a/cmd/context_evidence_test.go
+++ b/cmd/context_evidence_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http/httptest"
 	"os"
@@ -11,7 +12,7 @@ import (
 	"testing"
 	"time"
 
-	"codemap/analysis"
+	"codemap/config"
 	"codemap/internal/projectpath"
 	"codemap/scanner"
 	"codemap/watch"
@@ -53,7 +54,7 @@ func TestContextGraphEvidenceTrueHubAndDeterministicOrder(t *testing.T) {
 	}
 }
 
-func TestContextGraphEvidenceZeroEdgesProvesEmpty(t *testing.T) {
+func TestContextEnvelopeV2ReportsUnavailableGraph(t *testing.T) {
 	files := []scanner.FileInfo{{Path: "main.go"}}
 	graph := &scanner.FileGraph{
 		Packages:  map[string][]string{"main": {"main.go"}},
@@ -62,53 +63,24 @@ func TestContextGraphEvidenceZeroEdgesProvesEmpty(t *testing.T) {
 	}
 	envelope := buildContextEnvelopeWithDeps(context.Background(), t.TempDir(), "refactor main.go", true, testContextEnvelopeDeps(files, graph))
 
-	if envelope.Project.GraphEvidence != (GraphEvidence{Status: graphEvidenceAvailable, Source: graphEvidenceFreshScan}) {
-		t.Fatalf("graph evidence = %#v, want fresh available", envelope.Project.GraphEvidence)
+	data, err := json.Marshal(envelope)
+	if err != nil {
+		t.Fatal(err)
 	}
-	if envelope.Project.HubCount == nil || *envelope.Project.HubCount != 0 {
-		t.Fatalf("hub count = %#v, want numeric zero", envelope.Project.HubCount)
+	var decoded map[string]any
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatal(err)
 	}
-	if envelope.Intent == nil || envelope.Intent.RiskLevel != "low" {
-		t.Fatalf("intent = %#v, want low risk", envelope.Intent)
+	project := decoded["project"].(map[string]any)
+	if project["hub_count"] != nil {
+		t.Fatalf("hub_count = %#v, want null", project["hub_count"])
 	}
-}
-
-func TestContextGraphEvidenceUnavailableCoverageFailsClosed(t *testing.T) {
-	files := []scanner.FileInfo{{Path: "main.go"}}
-	graph := &scanner.FileGraph{
-		Imports:   map[string][]string{"main.go": {"dep.go"}},
-		Importers: map[string][]string{"dep.go": {"main.go"}},
-		Coverage:  scanner.GraphCoverage{Status: analysis.CoverageUnavailable},
+	if _, ok := project["top_hubs"]; ok {
+		t.Fatalf("top_hubs must be omitted: %s", data)
 	}
-	envelope := buildContextEnvelopeWithDeps(context.Background(), t.TempDir(), "refactor main.go", true, testContextEnvelopeDeps(files, graph))
-
-	if envelope.Project.GraphEvidence.Status != graphEvidenceUnavailable || envelope.Project.GraphEvidence.Reason != graphEvidenceScanIncomplete {
-		t.Fatalf("graph evidence = %#v, want unavailable scan_incomplete", envelope.Project.GraphEvidence)
-	}
-	if envelope.Project.HubCount != nil {
-		t.Fatalf("hub count = %#v, want null", envelope.Project.HubCount)
-	}
-	if envelope.Intent == nil || envelope.Intent.RiskLevel != "unknown" {
-		t.Fatalf("intent = %#v, want unknown risk", envelope.Intent)
-	}
-}
-
-func TestContextGraphEvidenceFailedOnlyCoverageFailsClosed(t *testing.T) {
-	files := []scanner.FileInfo{{Path: "main.go"}}
-	graph := &scanner.FileGraph{
-		Imports:   map[string][]string{"main.go": {"dep.go"}},
-		Importers: map[string][]string{"dep.go": {"main.go"}},
-		Coverage: scanner.GraphCoverage{Sources: []analysis.Source{{
-			Name: "go", Status: analysis.SourceFailed,
-		}}},
-	}
-	envelope := buildContextEnvelopeWithDeps(context.Background(), t.TempDir(), "refactor main.go", true, testContextEnvelopeDeps(files, graph))
-
-	if envelope.Project.GraphEvidence.Status != graphEvidenceUnavailable || envelope.Project.GraphEvidence.Reason != graphEvidenceScanIncomplete {
-		t.Fatalf("graph evidence = %#v, want unavailable scan_incomplete", envelope.Project.GraphEvidence)
-	}
-	if envelope.Project.HubCount != nil {
-		t.Fatalf("hub count = %#v, want null", envelope.Project.HubCount)
+	evidence := project["graph_evidence"].(map[string]any)
+	if evidence["reason"] != graphEvidenceScanIncomplete {
+		t.Fatalf("evidence = %#v, want scan_incomplete", evidence)
 	}
 	if envelope.Intent == nil || envelope.Intent.RiskLevel != "unknown" {
 		t.Fatalf("intent = %#v, want unknown risk", envelope.Intent)
@@ -248,8 +220,8 @@ func TestHookPromptSubmitDoesNotClaimRiskFromCachedGraph(t *testing.T) {
 		if !strings.Contains(out, `"risk":"unknown"`) {
 			t.Fatalf("missing unknown-risk marker:\n%s", out)
 		}
-		if !strings.Contains(out, "pkg/types.go is a HUB") {
-			t.Fatalf("cached display context should remain available:\n%s", out)
+		if strings.Contains(out, "pkg/types.go is a HUB") {
+			t.Fatalf("unvalidated cached hub claim leaked into display:\n%s", out)
 		}
 	})
 
@@ -343,6 +315,141 @@ func TestContextWorkingSetRequiresFreshGraphEvidence(t *testing.T) {
 			t.Fatalf("working files retained cached hub label: %#v", envelope.WorkingSet.TopFiles)
 		}
 	})
+}
+
+func TestContextValidatedGraphCache(t *testing.T) {
+	root := t.TempDir()
+	cfg := config.ProjectConfig{Only: []string{"go"}, Exclude: []string{"vendor"}}
+	writeProjectConfig(t, root, cfg)
+	state := &watch.State{
+		UpdatedAt: time.Now(),
+		Imports: map[string][]string{
+			"a.go": {"pkg/hub.go"}, "b.go": {"pkg/hub.go"}, "c.go": {"pkg/hub.go"},
+		},
+		Importers: map[string][]string{
+			"pkg/hub.go": {"a.go", "b.go", "c.go"},
+		},
+	}
+	configuredCount := 4
+	state.ConfiguredFileCount = &configuredCount
+	files := []scanner.FileInfo{{Path: "pkg/hub.go"}, {Path: "a.go"}, {Path: "b.go"}, {Path: "c.go"}}
+	graphState := watch.NewGraphState(root, cfg, watch.GraphLifecycleAvailable, time.Now(), contextFilePaths(files))
+	state.Graph = &graphState
+
+	t.Run("valid cache skips fresh graph", func(t *testing.T) {
+		deps := testContextEnvelopeDeps(files, nil)
+		deps.readState = func(string) *watch.State { return state }
+		calls := 0
+		deps.buildFileGraph = func(context.Context, string) (*scanner.FileGraph, error) {
+			calls++
+			return nil, errors.New("fresh graph must not run")
+		}
+		envelope := buildContextEnvelopeWithDeps(context.Background(), root, "refactor pkg/hub.go", true, deps)
+		if calls != 0 || envelope.Project.GraphEvidence.Source != graphEvidenceWatchCache {
+			t.Fatalf("calls = %d, evidence = %#v", calls, envelope.Project.GraphEvidence)
+		}
+		if envelope.Project.HubCount == nil || *envelope.Project.HubCount != 1 || envelope.Intent.RiskLevel != "medium" {
+			t.Fatalf("envelope = %#v", envelope)
+		}
+	})
+
+	t.Run("invalid cache falls back to fresh graph", func(t *testing.T) {
+		invalid := *state
+		invalidGraph := *state.Graph
+		invalidGraph.BuilderRevision = "old"
+		invalid.Graph = &invalidGraph
+		fresh := &scanner.FileGraph{Imports: map[string][]string{"a.go": {"pkg/hub.go"}}, Importers: map[string][]string{"pkg/hub.go": {"a.go"}}}
+		deps := testContextEnvelopeDeps(files, fresh)
+		deps.readState = func(string) *watch.State { return &invalid }
+		calls := 0
+		original := deps.buildFileGraph
+		deps.buildFileGraph = func(ctx context.Context, root string) (*scanner.FileGraph, error) {
+			calls++
+			return original(ctx, root)
+		}
+		envelope := buildContextEnvelopeWithDeps(context.Background(), root, "refactor pkg/hub.go", true, deps)
+		if calls != 1 || envelope.Project.GraphEvidence.Source != graphEvidenceFreshScan {
+			t.Fatalf("calls = %d, evidence = %#v", calls, envelope.Project.GraphEvidence)
+		}
+	})
+
+	for _, tt := range []struct {
+		name  string
+		files []scanner.FileInfo
+	}{
+		{name: "changed count", files: append(append([]scanner.FileInfo(nil), files...), scanner.FileInfo{Path: "d.go"})},
+		{name: "same count replacement", files: []scanner.FileInfo{{Path: "pkg/replacement.go"}, {Path: "a.go"}, {Path: "b.go"}, {Path: "c.go"}}},
+	} {
+		t.Run(tt.name+" falls back to fresh graph", func(t *testing.T) {
+			fresh := &scanner.FileGraph{Imports: map[string][]string{"a.go": {tt.files[0].Path}}, Importers: map[string][]string{tt.files[0].Path: {"a.go"}}}
+			deps := testContextEnvelopeDeps(tt.files, fresh)
+			deps.readState = func(string) *watch.State { return state }
+			calls := 0
+			original := deps.buildFileGraph
+			deps.buildFileGraph = func(ctx context.Context, root string) (*scanner.FileGraph, error) {
+				calls++
+				return original(ctx, root)
+			}
+			envelope := buildContextEnvelopeWithDeps(context.Background(), root, "inspect "+tt.files[0].Path, true, deps)
+			if calls != 1 || envelope.Project.GraphEvidence.Source != graphEvidenceFreshScan {
+				t.Fatalf("calls = %d, evidence = %#v", calls, envelope.Project.GraphEvidence)
+			}
+		})
+	}
+
+	t.Run("large invalid cache stays unavailable", func(t *testing.T) {
+		invalid := *state
+		invalidGraph := *state.Graph
+		invalidGraph.ProjectRoot = t.TempDir()
+		invalid.Graph = &invalidGraph
+		large := make([]scanner.FileInfo, 5001)
+		deps := testContextEnvelopeDeps(large, nil)
+		deps.readState = func(string) *watch.State { return &invalid }
+		calls := 0
+		deps.buildFileGraph = func(context.Context, string) (*scanner.FileGraph, error) { calls++; return nil, nil }
+		envelope := buildContextEnvelopeWithDeps(context.Background(), root, "inspect", true, deps)
+		if calls != 0 || envelope.Project.GraphEvidence.Reason != graphEvidenceLargeRepository {
+			t.Fatalf("calls = %d, evidence = %#v", calls, envelope.Project.GraphEvidence)
+		}
+	})
+}
+
+func TestPromptHookValidatedGraphCache(t *testing.T) {
+	root := t.TempDir()
+	cfg := config.ProjectConfig{Only: []string{"go"}}
+	writeProjectConfig(t, root, cfg)
+	mustWriteFile(t, filepath.Join(root, "pkg", "types.go"), "package pkg\n")
+	mustWriteFile(t, filepath.Join(root, "generated", ".gitignore"), "*.go\n")
+	mustWriteFile(t, filepath.Join(root, "generated", "deeper", "ignored.go"), "package generated\n")
+	graphState := watch.NewGraphState(root, cfg, watch.GraphLifecycleAvailable, time.Now(), []string{"pkg/types.go"})
+	state := watch.State{
+		UpdatedAt: time.Now(),
+		Graph:     &graphState,
+		Importers: map[string][]string{"pkg/types.go": {"a.go", "b.go", "c.go"}},
+		Imports:   map[string][]string{"a.go": {"pkg/types.go"}},
+	}
+	configuredCount := 1
+	state.ConfiguredFileCount = &configuredCount
+
+	checkRisk := func(prompt, want string) {
+		writeWatchState(t, root, state)
+		withStdinInput(t, mustJSONInput(t, map[string]string{"prompt": prompt}), func() {
+			out := captureOutput(func() {
+				if err := hookPromptSubmit(root); err != nil {
+					t.Fatal(err)
+				}
+			})
+			if !strings.Contains(out, `"risk":"`+want+`"`) {
+				t.Fatalf("missing %s risk:\n%s", want, out)
+			}
+		})
+	}
+
+	checkRisk("refactor pkg/types.go", "medium")
+	checkRisk("refactor pkg/missing.go", "unknown")
+	checkRisk("refactor generated/deeper/ignored.go", "unknown")
+	state.Graph.BuilderRevision = "old"
+	checkRisk("refactor pkg/types.go", "unknown")
 }
 
 func testContextEnvelopeDeps(files []scanner.FileInfo, graph *scanner.FileGraph) contextEnvelopeDeps {

--- a/cmd/hooks.go
+++ b/cmd/hooks.go
@@ -114,6 +114,52 @@ func getHubInfoNoFallback(root string) *hubInfo {
 	return getHubInfoWithFallback(root, false)
 }
 
+func getValidatedHubInfo(root string) *hubInfo {
+	state := watch.ReadState(root)
+	graph, _ := watch.ValidateCachedGraph(state, root, config.Load(root))
+	if graph == nil {
+		return nil
+	}
+	return &hubInfo{
+		Hubs:      graph.HubFiles(),
+		Importers: graph.Importers,
+		Imports:   graph.Imports,
+		Coverage:  graph.Coverage,
+	}
+}
+
+func resolveValidatedHookFiles(root string, mentions []string, cfg config.ProjectConfig) []string {
+	files := make([]string, 0, len(mentions))
+	seen := make(map[string]struct{})
+	gitCache := scanner.NewGitIgnoreCache(root)
+	for _, mention := range mentions {
+		normalized := normalizeContextPath(mention)
+		if normalized == "" || !scanner.MatchesFilters(normalized, filepath.Ext(normalized), cfg.Only, cfg.Exclude) {
+			continue
+		}
+		candidate := filepath.Join(root, filepath.FromSlash(normalized))
+		info, err := os.Lstat(candidate)
+		if err != nil || !info.Mode().IsRegular() {
+			continue
+		}
+		for dir := filepath.Dir(candidate); ; dir = filepath.Dir(dir) {
+			gitCache.EnsureDir(dir)
+			if dir == filepath.Clean(root) || dir == filepath.Dir(dir) {
+				break
+			}
+		}
+		if gitCache.ShouldIgnore(candidate) {
+			continue
+		}
+		if _, duplicate := seen[normalized]; duplicate {
+			continue
+		}
+		seen[normalized] = struct{}{}
+		files = append(files, normalized)
+	}
+	return files
+}
+
 func getHubInfoWithFallback(root string, allowFallback bool) *hubInfo {
 	if state := watch.ReadState(root); state != nil {
 		// State may contain file/event info only (no dependency graph) on very
@@ -843,11 +889,14 @@ func hookPromptSubmit(root string) error {
 
 	projCfg := config.Load(root)
 	topK := projCfg.RoutingTopKOrDefault()
-	info := getHubInfoNoFallback(root)
+	info := getValidatedHubInfo(root)
 
 	// Extract mentioned files and classify intent
 	filesMentioned := extractMentionedFiles(prompt, topK)
-	intent := classifyIntent(prompt, filesMentioned, nil, projCfg)
+	if info != nil {
+		filesMentioned = resolveValidatedHookFiles(root, filesMentioned, projCfg)
+	}
+	intent := classifyIntent(prompt, filesMentioned, info, projCfg)
 
 	// Emit structured intent marker (machine-readable for tools) only when the
 	// classification is trustworthy — a zero/low-confidence category is a

--- a/cmd/hooks.go
+++ b/cmd/hooks.go
@@ -896,7 +896,9 @@ func hookPromptSubmit(root string) error {
 	if info != nil {
 		filesMentioned = resolveValidatedHookFiles(root, filesMentioned, projCfg)
 	}
-	intent := classifyIntent(prompt, filesMentioned, info, projCfg)
+	// The cached graph has no content fingerprint, so it cannot support a
+	// risk verdict after an in-place source edit.
+	intent := classifyIntent(prompt, filesMentioned, nil, projCfg)
 
 	// Emit structured intent marker (machine-readable for tools) only when the
 	// classification is trustworthy — a zero/low-confidence category is a

--- a/cmd/hooks_more_test.go
+++ b/cmd/hooks_more_test.go
@@ -483,7 +483,7 @@ func TestCheckFileImportersAndRouteSuggestions(t *testing.T) {
 
 func TestHookPromptSubmitShowsContextAndProgress(t *testing.T) {
 	root := t.TempDir()
-	writeProjectConfig(t, root, config.ProjectConfig{
+	cfg := config.ProjectConfig{
 		Routing: config.RoutingConfig{
 			Retrieval: config.RetrievalConfig{Strategy: "keyword", TopK: 2},
 			Subsystems: []config.Subsystem{
@@ -494,10 +494,16 @@ func TestHookPromptSubmitShowsContextAndProgress(t *testing.T) {
 				},
 			},
 		},
-	})
+	}
+	writeProjectConfig(t, root, cfg)
+	mustWriteFile(t, filepath.Join(root, "pkg", "types.go"), "package pkg\n")
+	graphState := watch.NewGraphState(root, cfg, watch.GraphLifecycleAvailable, time.Now(), []string{"pkg/types.go"})
+	configuredCount := 1
 	writeWatchState(t, root, watch.State{
-		UpdatedAt: time.Now(),
-		FileCount: 5,
+		UpdatedAt:           time.Now(),
+		FileCount:           5,
+		Graph:               &graphState,
+		ConfiguredFileCount: &configuredCount,
 		Importers: map[string][]string{
 			"pkg/types.go": {"a.go", "b.go", "c.go"},
 		},

--- a/watch/daemon.go
+++ b/watch/daemon.go
@@ -23,6 +23,7 @@ import (
 var (
 	buildTopologyGraph = topology.BuildGraph
 	writeTopologyCache = topology.WriteCacheAt
+	buildFileGraph     = scanner.BuildFileGraph
 )
 
 // Daemon is the watch daemon that keeps the graph updated
@@ -323,8 +324,6 @@ func (d *Daemon) isConfiguredFile(path string) bool {
 	return scanner.MatchesFilters(path, filepath.Ext(path), cfg.Only, cfg.Exclude)
 }
 
-// daemonRefreshConfiguredFiles is the seam the event loop calls, so tests can
-// observe how often control events trigger a refresh.
 var daemonRefreshConfiguredFiles = (*Daemon).refreshConfiguredFiles
 
 func (d *Daemon) refreshConfiguredFiles(resetIgnoreCache bool) error {
@@ -361,10 +360,26 @@ func (d *Daemon) refreshConfiguredFiles(resetIgnoreCache bool) error {
 	return nil
 }
 
+var daemonRefreshDependencies = (*Daemon).refreshDependencies
+
+func (d *Daemon) refreshDependencies() {
+	d.graph.mu.RLock()
+	stale := d.graph.GraphState.Status == graphLifecycleStale
+	configuredCount := len(d.graph.ConfiguredFiles)
+	d.graph.mu.RUnlock()
+	if !stale || !shouldComputeDependencyGraph(configuredCount) {
+		return
+	}
+	d.computeDeps()
+	if d.publisher != nil {
+		d.reportPublicationError(d.writeState())
+	}
+}
+
 // computeDeps builds the file-to-file dependency graph
 func (d *Daemon) computeDeps() {
 	d.computeDepsWith(func(ctx context.Context, root string) (*scanner.FileGraph, error) {
-		return scanner.BuildFileGraph(ctx, root, scanner.ConfiguredFilters(root))
+		return buildFileGraph(ctx, root, scanner.ConfiguredFilters(root))
 	})
 }
 

--- a/watch/daemon.go
+++ b/watch/daemon.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"codemap/analysis"
 	"codemap/config"
 	"codemap/internal/projectpath"
 	"codemap/limits"
@@ -177,6 +178,7 @@ func (d *Daemon) Start() error {
 
 func (d *Daemon) computeInitialGraphs(fileCount int) {
 	if fileCount > limits.LargeRepoFileCount {
+		d.markGraphLifecycle(graphLifecycleSkippedSize)
 		if d.verbose {
 			fmt.Printf("[watch] Skipping dependency and topology graphs for large repo (%d files)\n", fileCount)
 		}
@@ -361,19 +363,54 @@ func (d *Daemon) refreshConfiguredFiles(resetIgnoreCache bool) error {
 
 // computeDeps builds the file-to-file dependency graph
 func (d *Daemon) computeDeps() {
-	start := time.Now()
+	d.computeDepsWith(func(ctx context.Context, root string) (*scanner.FileGraph, error) {
+		return scanner.BuildFileGraph(ctx, root, scanner.ConfiguredFilters(root))
+	})
+}
 
-	// Build file graph (internal file-to-file dependencies)
-	fg, err := scanner.BuildFileGraph(context.Background(), d.root, scanner.ConfiguredFilters(d.root))
-	if err != nil {
+func (d *Daemon) computeDepsWith(build func(context.Context, string) (*scanner.FileGraph, error)) {
+	d.computeDepsWithBeforePublish(build, nil)
+}
+
+func (d *Daemon) computeDepsWithBeforePublish(build func(context.Context, string) (*scanner.FileGraph, error), beforePublish func()) {
+	start := time.Now()
+	buildConfig := config.Load(d.root)
+	d.graph.mu.RLock()
+	configuredBefore := make([]string, 0, len(d.graph.ConfiguredFiles))
+	for file := range d.graph.ConfiguredFiles {
+		configuredBefore = append(configuredBefore, file)
+	}
+	generationBefore := d.graph.graphGeneration
+	d.graph.mu.RUnlock()
+
+	// Build the file graph. Unavailable coverage provides no usable dependency
+	// evidence, so do not publish an authoritative empty graph.
+	fg, err := build(context.Background(), d.root)
+	if err != nil || fg == nil || (len(configuredBefore) > 0 && fg.Coverage.Status == analysis.CoverageUnavailable) {
+		d.markGraphLifecycle(graphLifecycleFailed)
 		if d.verbose {
 			fmt.Printf("[watch] File graph unavailable: %v\n", err)
 		}
 		return
 	}
+	if beforePublish != nil {
+		beforePublish()
+	}
 
 	d.graph.mu.Lock()
 	defer d.graph.mu.Unlock()
+	configuredAfter := make([]string, 0, len(d.graph.ConfiguredFiles))
+	for file := range d.graph.ConfiguredFiles {
+		configuredAfter = append(configuredAfter, file)
+	}
+	currentConfig := config.Load(d.root)
+	if d.graph.graphGeneration != generationBefore ||
+		ConfiguredInventoryFingerprint(configuredBefore) != ConfiguredInventoryFingerprint(configuredAfter) ||
+		graphFilterFingerprint(buildConfig) != graphFilterFingerprint(currentConfig) {
+		d.markGraphLifecycleLocked(newGraphState(d.root, currentConfig, graphLifecycleStale, time.Time{}, nil))
+		return
+	}
+	state := newGraphState(d.root, buildConfig, graphLifecycleAvailable, time.Now(), configuredBefore)
 
 	// Convert FileGraph to DepContext map
 	d.graph.DepCtx = make(map[string]*DepContext)
@@ -388,11 +425,27 @@ func (d *Daemon) computeDeps() {
 	}
 
 	d.graph.HasDeps = true
+	d.graph.GraphState = state
 
 	hubCount := len(fg.HubFiles())
 	if d.verbose {
 		fmt.Printf("[watch] File graph: %d files, %d hubs in %v\n", len(d.graph.Files), hubCount, time.Since(start))
 	}
+}
+
+func (d *Daemon) markGraphLifecycle(status GraphLifecycle) {
+	state := newGraphState(d.root, config.Load(d.root), status, time.Time{}, nil)
+	d.graph.mu.Lock()
+	defer d.graph.mu.Unlock()
+	d.markGraphLifecycleLocked(state)
+}
+
+func (d *Daemon) markGraphLifecycleLocked(state GraphState) {
+	d.graph.graphGeneration++
+	d.graph.GraphState = state
+	d.graph.HasDeps = false
+	d.graph.FileGraph = nil
+	d.graph.DepCtx = make(map[string]*DepContext)
 }
 
 // addWatchDirs recursively adds directories to the watcher

--- a/watch/events.go
+++ b/watch/events.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"codemap/config"
 	"codemap/internal/projectpath"
 	"codemap/internal/runtimefile"
 	"codemap/limits"
@@ -340,8 +341,12 @@ func (d *Daemon) handleConfiguredMembershipEvent(event fsnotify.Event) {
 	} else {
 		delete(d.graph.ConfiguredFiles, relPath)
 	}
+	changed := present != existed
+	if changed {
+		d.markGraphLifecycleLocked(newGraphState(d.root, config.Load(d.root), graphLifecycleStale, time.Time{}, nil))
+	}
 	d.graph.mu.Unlock()
-	if present != existed {
+	if changed {
 		d.reportPublicationError(d.writeState())
 	}
 }
@@ -532,8 +537,13 @@ func (d *Daemon) handleEvent(fsEvent fsnotify.Event) {
 				delete(d.graph.Files, relPath)
 				delete(d.graph.ConfiguredFiles, relPath)
 				delete(d.graph.State, relPath)
+				if wasConfigured {
+					state := newGraphState(d.root, config.Load(d.root), graphLifecycleStale, time.Time{}, nil)
+					d.markGraphLifecycleLocked(state)
+				}
 			}
 			d.graph.mu.Unlock()
+			d.reportPublicationError(d.writeState())
 			return
 		}
 
@@ -602,6 +612,10 @@ func (d *Daemon) handleEvent(fsEvent fsnotify.Event) {
 		delete(d.graph.Files, relPath)
 		delete(d.graph.ConfiguredFiles, relPath)
 		delete(d.graph.State, relPath)
+	}
+	if wasConfigured || isConfigured {
+		state := newGraphState(d.root, config.Load(d.root), graphLifecycleStale, time.Time{}, nil)
+		d.markGraphLifecycleLocked(state)
 	}
 
 	// Check if file is dirty (uncommitted) - only if git repo
@@ -690,35 +704,42 @@ func (d *Daemon) findRelatedHot(path string, window time.Duration) []string {
 		return nil
 	}
 
-	// Get connected files from the file graph
-	connected := d.graph.FileGraph.ConnectedFiles(path)
-	if len(connected) == 0 {
+	fileGraph := d.graph.FileGraph
+	imports := fileGraph.Imports[path]
+	importers := fileGraph.Importers[path]
+	if len(imports) == 0 && len(importers) == 0 {
 		return nil
 	}
 
-	connectedSet := make(map[string]bool)
-	for _, f := range connected {
-		connectedSet[f] = true
+	connected := make(map[string]struct{}, len(imports)+len(importers))
+	for _, related := range imports {
+		if related != path {
+			connected[related] = struct{}{}
+		}
+	}
+	for _, related := range importers {
+		if related != path {
+			connected[related] = struct{}{}
+		}
 	}
 
-	// Look at recent events and find matches
+	// Process newest events first and keep only the latest event for each path.
 	cutoff := time.Now().Add(-window)
-	recentlyEdited := make(map[string]bool)
+	var hot []string
 	for i := len(d.graph.Events) - 1; i >= 0; i-- {
 		e := d.graph.Events[i]
 		if e.Time.Before(cutoff) {
 			break
 		}
-		if e.Path != path && (e.Op == "CREATE" || e.Op == "WRITE") {
-			recentlyEdited[e.Path] = true
+		if e.Op != "CREATE" && e.Op != "WRITE" {
+			continue
 		}
-	}
-
-	// Find intersection
-	var hot []string
-	for file := range connectedSet {
-		if recentlyEdited[file] {
-			hot = append(hot, file)
+		if _, found := connected[e.Path]; found {
+			hot = append(hot, e.Path)
+			delete(connected, e.Path)
+			if len(connected) == 0 {
+				break
+			}
 		}
 	}
 

--- a/watch/events.go
+++ b/watch/events.go
@@ -160,6 +160,11 @@ func (d *Daemon) eventLoop() {
 	defer timer.Stop()
 
 	var timerC <-chan time.Time
+	handleEvent := func(event fsnotify.Event) {
+		if d.handleEvent(event) {
+			daemonRefreshDependencies(d)
+		}
+	}
 	armTimer := func(now time.Time) {
 		if !timer.Stop() {
 			select {
@@ -180,7 +185,7 @@ func (d *Daemon) eventLoop() {
 	}
 	flushDue := func(now time.Time) {
 		for _, event := range debouncer.takeDue(now) {
-			d.handleEvent(event)
+			handleEvent(event)
 		}
 		if d.publisher.due(now) {
 			d.reportPublicationError(d.publisher.publish())
@@ -254,7 +259,7 @@ func (d *Daemon) eventLoop() {
 				continue
 			}
 			for _, pending := range debouncer.takeDueBeforeEvent(event, now) {
-				d.handleEvent(pending)
+				handleEvent(pending)
 			}
 			if d.handleTopologyControlEvent(event) {
 				continue
@@ -269,11 +274,15 @@ func (d *Daemon) eventLoop() {
 					if info, err := os.Stat(event.Name); err == nil && info.IsDir() {
 						// Directory create - let it through to handleEvent
 					} else {
-						d.handleConfiguredMembershipEvent(event)
+						if d.handleConfiguredMembershipEvent(event) {
+							daemonRefreshDependencies(d)
+						}
 						continue
 					}
 				} else {
-					d.handleConfiguredMembershipEvent(event)
+					if d.handleConfiguredMembershipEvent(event) {
+						daemonRefreshDependencies(d)
+					}
 					continue
 				}
 			}
@@ -291,7 +300,7 @@ func (d *Daemon) eventLoop() {
 			case debounceDefer:
 				debouncer.deferEvent(event, now)
 			case debounceProcess:
-				d.handleEvent(event)
+				handleEvent(event)
 			}
 			armTimer(time.Now())
 
@@ -318,14 +327,14 @@ func (d *Daemon) filterControlEvent(path string) (resetIgnoreCache, control bool
 	return false, false
 }
 
-func (d *Daemon) handleConfiguredMembershipEvent(event fsnotify.Event) {
+func (d *Daemon) handleConfiguredMembershipEvent(event fsnotify.Event) bool {
 	event.Name = projectpath.CanonicalPath(event.Name)
 	relPath, err := filepath.Rel(projectpath.CanonicalPath(d.root), event.Name)
 	if err != nil {
-		return
+		return false
 	}
 	if path := filepath.ToSlash(relPath); path == ".codemap" || strings.HasPrefix(path, ".codemap/") {
-		return
+		return false
 	}
 	present := event.Op&(fsnotify.Remove|fsnotify.Rename) == 0
 	if present {
@@ -349,6 +358,7 @@ func (d *Daemon) handleConfiguredMembershipEvent(event fsnotify.Event) {
 	if changed {
 		d.reportPublicationError(d.writeState())
 	}
+	return changed
 }
 
 func (d *Daemon) processQueuedEvent(debouncer *eventDebouncer, event fsnotify.Event, now time.Time) {
@@ -430,7 +440,15 @@ func (d *Daemon) handleTopologyControlEvent(event fsnotify.Event) bool {
 
 func (d *Daemon) debounceAction(debouncer *eventDebouncer, event fsnotify.Event, now time.Time) debounceAction {
 	event.Name = projectpath.CanonicalPath(event.Name)
-	if !debouncer.shouldSkip(event, now) {
+	if event.Op&fsnotify.Write == 0 || event.Op&(fsnotify.Create|fsnotify.Remove|fsnotify.Rename) != 0 || event.Op&^(fsnotify.Write|fsnotify.Chmod) != 0 {
+		return debounceProcess
+	}
+	last, seen := debouncer.lastSeen[event.Name]
+	if seen && now.Sub(last) >= debouncer.pruneAfter {
+		seen = false
+	}
+	rapid := debouncer.shouldSkip(event, now)
+	if !rapid && !seen {
 		return debounceProcess
 	}
 	relPath, err := filepath.Rel(projectpath.CanonicalPath(d.root), event.Name)
@@ -454,10 +472,12 @@ func (d *Daemon) debounceAction(debouncer *eventDebouncer, event fsnotify.Event,
 	if err != nil {
 		return debounceProcess
 	}
-	// An identical write carries no new information and is skipped for every
-	// file; changed writes use the same quiet-window defer for every file.
-	if cachedModTime != 0 && cachedSize == info.Size() && cachedModTime == info.ModTime().UnixNano() {
+	// An unchanged repeat can arrive after a rebuild delayed the event loop.
+	if seen && cachedModTime != 0 && cachedSize == info.Size() && cachedModTime == info.ModTime().UnixNano() {
 		return debounceSkip
+	}
+	if !rapid {
+		return debounceProcess
 	}
 	return debounceDefer
 }
@@ -484,13 +504,13 @@ func isTransientFile(path string) bool {
 }
 
 // handleEvent processes a single file event
-func (d *Daemon) handleEvent(fsEvent fsnotify.Event) {
+func (d *Daemon) handleEvent(fsEvent fsnotify.Event) bool {
 	fsEvent.Name = projectpath.CanonicalPath(fsEvent.Name)
 	absPath := fsEvent.Name
 	if d.gitCache != nil {
 		// Ignore gitignored paths entirely so watcher churn cannot come from excluded trees.
 		if d.gitCache.ShouldIgnore(absPath) {
-			return
+			return false
 		}
 	}
 
@@ -511,7 +531,7 @@ func (d *Daemon) handleEvent(fsEvent fsnotify.Event) {
 	case fsEvent.Op&fsnotify.Rename != 0:
 		op = "RENAME"
 	default:
-		return
+		return false
 	}
 
 	event := Event{
@@ -543,8 +563,10 @@ func (d *Daemon) handleEvent(fsEvent fsnotify.Event) {
 				}
 			}
 			d.graph.mu.Unlock()
-			d.reportPublicationError(d.writeState())
-			return
+			if wasConfigured {
+				d.reportPublicationError(d.writeState())
+			}
+			return wasConfigured
 		}
 
 		// If a new directory was created, add it to the watcher
@@ -555,7 +577,7 @@ func (d *Daemon) handleEvent(fsEvent fsnotify.Event) {
 				d.gitCache.EnsureDir(dirPath)
 				if d.gitCache.ShouldIgnore(dirPath) {
 					d.graph.mu.Unlock()
-					return
+					return false
 				}
 			}
 			// Skip hidden directories and common ignores
@@ -563,7 +585,7 @@ func (d *Daemon) handleEvent(fsEvent fsnotify.Event) {
 				d.watcher.Add(fsEvent.Name)
 			}
 			d.graph.mu.Unlock()
-			return
+			return false
 		}
 
 		// Count new lines
@@ -613,7 +635,8 @@ func (d *Daemon) handleEvent(fsEvent fsnotify.Event) {
 		delete(d.graph.ConfiguredFiles, relPath)
 		delete(d.graph.State, relPath)
 	}
-	if wasConfigured || isConfigured {
+	graphInvalidated := wasConfigured || isConfigured
+	if graphInvalidated {
 		state := newGraphState(d.root, config.Load(d.root), graphLifecycleStale, time.Time{}, nil)
 		d.markGraphLifecycleLocked(state)
 	}
@@ -685,6 +708,7 @@ func (d *Daemon) handleEvent(fsEvent fsnotify.Event) {
 		}
 		fmt.Printf("[watch] %s %s %s%s%s%s%s\n", event.Time.Format("15:04:05"), op, relPath, deltaStr, dirtyStr, hubStr, hotStr)
 	}
+	return graphInvalidated
 }
 
 func countTopologyDependents(graph *topology.Graph, id topology.ID) int {

--- a/watch/events_debounce_test.go
+++ b/watch/events_debounce_test.go
@@ -1,13 +1,16 @@
 package watch
 
 import (
+	"context"
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"codemap/config"
+	"codemap/scanner"
 
 	"github.com/fsnotify/fsnotify"
 )
@@ -60,6 +63,12 @@ func TestDaemonDebounceActionUsesSizeAndModTime(t *testing.T) {
 	d.graph.State["main.go"].ModTime = info.ModTime().UnixNano()
 	if got := d.debounceAction(debouncer, event, base.Add(20*time.Millisecond)); got != debounceSkip {
 		t.Fatalf("duplicate write action = %v, want skip", got)
+	}
+	if got := d.debounceAction(debouncer, event, base.Add(200*time.Millisecond)); got != debounceSkip {
+		t.Fatalf("delayed duplicate write action = %v, want skip", got)
+	}
+	if got := d.debounceAction(debouncer, fsnotify.Event{Name: path, Op: fsnotify.Create}, base.Add(210*time.Millisecond)); got != debounceProcess {
+		t.Fatalf("create after write action = %v, want process", got)
 	}
 }
 
@@ -215,6 +224,66 @@ func TestStopClosesWatcherAfterEventLoopDrain(t *testing.T) {
 		return closeWatcher()
 	}
 	d.Stop()
+}
+
+func TestEventLoopRefreshesDependenciesAfterConfiguredEvent(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".codemap"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(root, "main.go")
+	if err := os.WriteFile(path, []byte("package main\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	d, err := NewDaemon(root, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { d.Stop() })
+	if err := d.watcher.Close(); err != nil {
+		t.Fatal(err)
+	}
+	d.watcher.Events = make(chan fsnotify.Event, 1)
+	d.watcher.Errors = make(chan error)
+	if err := os.MkdirAll(d.runtimeDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	d.graph.Files["main.go"] = &scanner.FileInfo{Path: "main.go", Ext: ".go"}
+	d.graph.State["main.go"] = &FileState{Lines: 1}
+	d.graph.ConfiguredFiles["main.go"] = struct{}{}
+	d.graph.GraphState = newGraphState(root, config.ProjectConfig{}, graphLifecycleAvailable, time.Now(), []string{"main.go"})
+	d.graph.FileGraph = &scanner.FileGraph{Imports: map[string][]string{"main.go": {"dep.go"}}}
+	d.graph.HasDeps = true
+
+	originalBuild := buildFileGraph
+	originalRefresh := daemonRefreshDependencies
+	t.Cleanup(func() {
+		buildFileGraph = originalBuild
+		daemonRefreshDependencies = originalRefresh
+	})
+	var refreshes atomic.Int32
+	buildFileGraph = func(context.Context, string, scanner.Filters) (*scanner.FileGraph, error) {
+		return &scanner.FileGraph{
+			Imports:   map[string][]string{"main.go": {"dep.go"}},
+			Importers: map[string][]string{"dep.go": {"main.go"}},
+		}, nil
+	}
+	daemonRefreshDependencies = func(d *Daemon) {
+		refreshes.Add(1)
+		originalRefresh(d)
+	}
+
+	d.eventLoopWG.Add(1)
+	go func() {
+		defer d.eventLoopWG.Done()
+		d.eventLoop()
+	}()
+	d.watcher.Events <- fsnotify.Event{Name: path, Op: fsnotify.Write}
+	waitForWatchCondition(t, time.Second, func() bool {
+		d.graph.mu.RLock()
+		defer d.graph.mu.RUnlock()
+		return refreshes.Load() > 0 && d.graph.GraphState.Status == graphLifecycleAvailable && d.graph.HasDeps
+	})
 }
 
 func TestEventDebouncerDoesNotSkipNonWriteOps(t *testing.T) {

--- a/watch/events_debounce_test.go
+++ b/watch/events_debounce_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 
+	"codemap/config"
+
 	"github.com/fsnotify/fsnotify"
 )
 
@@ -90,6 +92,40 @@ func TestDaemonDebounceActionProcessesMissingTrackedFile(t *testing.T) {
 	}
 	if got := d.debounceAction(debouncer, event, base.Add(10*time.Millisecond)); got != debounceProcess {
 		t.Fatalf("rapid missing-file action = %v, want process", got)
+	}
+}
+
+func TestDaemonDebouncesConfiguredWriteAfterFirstEvent(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "main.go")
+	content := []byte("package main\n")
+	if err := os.WriteFile(path, content, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, status := range []GraphLifecycle{graphLifecycleAvailable, graphLifecycleStale} {
+		t.Run(string(status), func(t *testing.T) {
+			d := &Daemon{
+				root: root,
+				graph: &Graph{
+					State:           map[string]*FileState{"main.go": {Size: info.Size(), ModTime: info.ModTime().UnixNano()}},
+					ConfiguredFiles: map[string]struct{}{"main.go": {}},
+					GraphState:      newGraphState(root, config.ProjectConfig{}, status, time.Now(), []string{"main.go"}),
+				},
+			}
+			debouncer := newEventDebouncer(100 * time.Millisecond)
+			event := fsnotify.Event{Name: path, Op: fsnotify.Write}
+			base := time.Unix(0, 0)
+			if got := d.debounceAction(debouncer, event, base); got != debounceProcess {
+				t.Fatal("first configured write should not be skipped")
+			}
+			if got := d.debounceAction(debouncer, event, base.Add(10*time.Millisecond)); got != debounceSkip {
+				t.Fatalf("duplicate configured write while graph is %s = %v, want skip", status, got)
+			}
+		})
 	}
 }
 

--- a/watch/events_handle_test.go
+++ b/watch/events_handle_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"codemap/config"
 	"codemap/scanner"
 
 	"github.com/fsnotify/fsnotify"
@@ -27,6 +28,9 @@ func TestHandleEventMissingWriteClearsStaleTrackedFile(t *testing.T) {
 			State: map[string]*FileState{
 				rel: {Lines: 3, Size: 32},
 			},
+			ConfiguredFiles: map[string]struct{}{rel: {}},
+			GraphState:      newGraphState(root, config.ProjectConfig{}, graphLifecycleAvailable, time.Now(), []string{rel}),
+			HasDeps:         true,
 		},
 	}
 
@@ -40,6 +44,39 @@ func TestHandleEventMissingWriteClearsStaleTrackedFile(t *testing.T) {
 	}
 	if _, exists := d.graph.State[rel]; exists {
 		t.Fatalf("expected stale file %q to be removed from graph.State", rel)
+	}
+	if d.graph.GraphState.Status != graphLifecycleStale || d.graph.HasDeps {
+		t.Fatalf("missing write left graph usable: %#v, has deps %t", d.graph.GraphState, d.graph.HasDeps)
+	}
+}
+
+func TestHandleConfiguredMembershipRemovalInvalidatesGraph(t *testing.T) {
+	root := t.TempDir()
+	if err := os.Mkdir(filepath.Join(root, ".codemap"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	const rel = "notes.md"
+	d := &Daemon{
+		root: root,
+		graph: &Graph{
+			ConfiguredFiles: map[string]struct{}{rel: {}},
+			State:           map[string]*FileState{rel: {Lines: 1}},
+			FileGraph:       &scanner.FileGraph{},
+			DepCtx:          map[string]*DepContext{rel: {}},
+			HasDeps:         true,
+			GraphState:      newGraphState(root, config.ProjectConfig{}, graphLifecycleAvailable, time.Now(), []string{rel}),
+		},
+	}
+
+	d.handleConfiguredMembershipEvent(fsnotify.Event{Name: filepath.Join(root, rel), Op: fsnotify.Remove})
+
+	d.graph.mu.RLock()
+	defer d.graph.mu.RUnlock()
+	if _, exists := d.graph.ConfiguredFiles[rel]; exists {
+		t.Fatalf("removed configured file %q remains in membership", rel)
+	}
+	if d.graph.GraphState.Status != graphLifecycleStale || d.graph.HasDeps || d.graph.FileGraph != nil {
+		t.Fatalf("configured removal left graph usable: state=%#v hasDeps=%t fileGraph=%#v", d.graph.GraphState, d.graph.HasDeps, d.graph.FileGraph)
 	}
 }
 
@@ -215,15 +252,11 @@ func TestHandleEventWriteUpdatesTrackedStateAndContext(t *testing.T) {
 	if last.Delta != 2 {
 		t.Fatalf("event delta = %d, want 2", last.Delta)
 	}
-	if last.Importers != 3 || last.Imports != 1 {
-		t.Fatalf("dependency context = imports:%d importers:%d", last.Imports, last.Importers)
+	if last.Importers != 0 || last.Imports != 0 || last.IsHub || len(last.RelatedHot) != 0 {
+		t.Fatalf("event retained stale dependency context: %#v", last)
 	}
-	if !last.IsHub {
-		t.Fatal("expected event to be marked as hub")
-	}
-	sort.Strings(last.RelatedHot)
-	if len(last.RelatedHot) != 1 || last.RelatedHot[0] != "dep.go" {
-		t.Fatalf("related hot files = %v, want [dep.go]", last.RelatedHot)
+	if d.graph.GraphState.Status != graphLifecycleStale || d.graph.HasDeps {
+		t.Fatalf("graph state = %#v, has deps %t", d.graph.GraphState, d.graph.HasDeps)
 	}
 }
 

--- a/watch/graph_state.go
+++ b/watch/graph_state.go
@@ -1,0 +1,167 @@
+package watch
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	pathpkg "path"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"codemap/config"
+	"codemap/scanner"
+)
+
+// GraphLifecycle describes whether persisted dependency maps are reusable.
+type GraphLifecycle string
+
+const (
+	GraphLifecycleAvailable   GraphLifecycle = "available"
+	GraphLifecycleStale       GraphLifecycle = "stale"
+	GraphLifecycleSkippedSize GraphLifecycle = "skipped_size"
+	GraphLifecycleFailed      GraphLifecycle = "failed"
+
+	graphLifecycleAvailable   = GraphLifecycleAvailable
+	graphLifecycleStale       = GraphLifecycleStale
+	graphLifecycleSkippedSize = GraphLifecycleSkippedSize
+	graphLifecycleFailed      = GraphLifecycleFailed
+
+	graphBuilderRevision        = "filegraph-v1"
+	graphCacheLegacy            = "legacy"
+	graphCacheRootMismatch      = "root_mismatch"
+	graphCacheFilterMismatch    = "filter_mismatch"
+	graphCacheRevisionMismatch  = "revision_mismatch"
+	graphCacheInventoryMismatch = "inventory_mismatch"
+	graphCacheIncomplete        = "incomplete"
+)
+
+// GraphState identifies the project and policies that produced a graph.
+type GraphState struct {
+	Status               GraphLifecycle `json:"status"`
+	ProjectRoot          string         `json:"project_root"`
+	FilterFingerprint    string         `json:"filter_fingerprint"`
+	InventoryFingerprint string         `json:"inventory_fingerprint"`
+	BuilderRevision      string         `json:"builder_revision"`
+	CompletedAt          time.Time      `json:"completed_at,omitempty"`
+}
+
+// NewGraphState records the provenance of a graph outcome.
+func NewGraphState(root string, cfg config.ProjectConfig, status GraphLifecycle, completedAt time.Time, configuredPaths []string) GraphState {
+	state := GraphState{
+		Status:            status,
+		ProjectRoot:       canonicalGraphRoot(root),
+		FilterFingerprint: graphFilterFingerprint(cfg),
+		BuilderRevision:   graphBuilderRevision,
+	}
+	if status == graphLifecycleAvailable {
+		state.CompletedAt = completedAt
+		state.InventoryFingerprint = ConfiguredInventoryFingerprint(configuredPaths)
+	}
+	return state
+}
+
+func newGraphState(root string, cfg config.ProjectConfig, status GraphLifecycle, completedAt time.Time, configuredPaths []string) GraphState {
+	return NewGraphState(root, cfg, status, completedAt, configuredPaths)
+}
+
+func canonicalGraphRoot(root string) string {
+	abs, err := filepath.Abs(root)
+	if err != nil {
+		return filepath.Clean(root)
+	}
+	if canonical, err := filepath.EvalSymlinks(abs); err == nil {
+		return filepath.Clean(canonical)
+	}
+	return filepath.Clean(abs)
+}
+
+func graphFilterFingerprint(cfg config.ProjectConfig) string {
+	only := append([]string(nil), cfg.Only...)
+	exclude := append([]string(nil), cfg.Exclude...)
+	sort.Strings(only)
+	sort.Strings(exclude)
+	payload, _ := json.Marshal(struct {
+		Only    []string `json:"only"`
+		Exclude []string `json:"exclude"`
+	}{Only: only, Exclude: exclude})
+	sum := sha256.Sum256(payload)
+	return hex.EncodeToString(sum[:])
+}
+
+// ConfiguredInventoryFingerprint identifies an exact configured path set.
+func ConfiguredInventoryFingerprint(paths []string) string {
+	normalized := normalizedConfiguredInventory(paths)
+	payload, _ := json.Marshal(normalized)
+	sum := sha256.Sum256(payload)
+	return hex.EncodeToString(sum[:])
+}
+
+func normalizedConfiguredInventory(paths []string) []string {
+	set := make(map[string]struct{}, len(paths))
+	for _, file := range paths {
+		file = strings.TrimSpace(strings.ReplaceAll(file, `\`, "/"))
+		file = strings.TrimPrefix(pathpkg.Clean(file), "./")
+		if file != "" && file != "." {
+			set[file] = struct{}{}
+		}
+	}
+	normalized := make([]string, 0, len(set))
+	for file := range set {
+		normalized = append(normalized, file)
+	}
+	sort.Strings(normalized)
+	return normalized
+}
+
+// ValidateCachedGraph returns a graph only when all producing invariants still
+// match the current project.
+func ValidateCachedGraph(state *State, root string, cfg config.ProjectConfig) (*scanner.FileGraph, string) {
+	if state == nil || state.Graph == nil {
+		return nil, graphCacheLegacy
+	}
+	graphState := state.Graph
+	if graphState.Status != graphLifecycleAvailable {
+		return nil, string(graphState.Status)
+	}
+	if graphState.ProjectRoot != canonicalGraphRoot(root) {
+		return nil, graphCacheRootMismatch
+	}
+	if graphState.FilterFingerprint != graphFilterFingerprint(cfg) {
+		return nil, graphCacheFilterMismatch
+	}
+	if graphState.BuilderRevision != graphBuilderRevision {
+		return nil, graphCacheRevisionMismatch
+	}
+	if graphState.InventoryFingerprint == "" {
+		return nil, graphCacheIncomplete
+	}
+	configuredCount, known := state.ConfiguredCount()
+	if !known || (configuredCount > 0 && len(state.Imports) == 0 && len(state.Importers) == 0) {
+		return nil, graphCacheIncomplete
+	}
+	return &scanner.FileGraph{
+		Imports:   state.Imports,
+		Importers: state.Importers,
+		Coverage:  state.Coverage,
+	}, ""
+}
+
+// ValidateCachedGraphForInventory also checks that current configured paths
+// match the cached graph.
+func ValidateCachedGraphForInventory(state *State, root string, cfg config.ProjectConfig, configuredPaths []string) (*scanner.FileGraph, string) {
+	graph, reason := ValidateCachedGraph(state, root, cfg)
+	if graph == nil {
+		return nil, reason
+	}
+	configuredCount, _ := state.ConfiguredCount()
+	if configuredCount != len(normalizedConfiguredInventory(configuredPaths)) || state.Graph.InventoryFingerprint != ConfiguredInventoryFingerprint(configuredPaths) {
+		return nil, graphCacheInventoryMismatch
+	}
+	return graph, ""
+}
+
+func validateCachedGraph(state *State, root string, cfg config.ProjectConfig) (*scanner.FileGraph, string) {
+	return ValidateCachedGraph(state, root, cfg)
+}

--- a/watch/graph_state.go
+++ b/watch/graph_state.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"codemap/analysis"
 	"codemap/config"
 	"codemap/scanner"
 )
@@ -137,8 +138,17 @@ func ValidateCachedGraph(state *State, root string, cfg config.ProjectConfig) (*
 	if graphState.InventoryFingerprint == "" {
 		return nil, graphCacheIncomplete
 	}
+	coverageStatus := state.Coverage.Status
+	coverageUnavailable := coverageStatus == analysis.CoverageUnavailable
+	if coverageStatus == "" && len(state.Coverage.Sources) > 0 {
+		coverageStatus = scanner.CoverageFromSources(state.Coverage.Sources).Status
+		coverageUnavailable = coverageStatus == analysis.CoverageUnavailable
+	}
+	if coverageUnavailable {
+		return nil, graphCacheIncomplete
+	}
 	configuredCount, known := state.ConfiguredCount()
-	if !known || (configuredCount > 0 && len(state.Imports) == 0 && len(state.Importers) == 0) {
+	if !known || (configuredCount > 0 && coverageStatus != analysis.CoverageComplete && len(state.Imports) == 0 && len(state.Importers) == 0) {
 		return nil, graphCacheIncomplete
 	}
 	return &scanner.FileGraph{

--- a/watch/graph_state_test.go
+++ b/watch/graph_state_test.go
@@ -34,6 +34,13 @@ func TestGraphProvenanceValidation(t *testing.T) {
 	if graph, reason := ValidateCachedGraphForInventory(&base, root, cfg, []string{"main.go", "dep.go"}); graph == nil || reason != "" {
 		t.Fatalf("matching inventory = %#v, %q", graph, reason)
 	}
+	edgeFree := base
+	edgeFree.Coverage.Status = analysis.CoverageComplete
+	edgeFree.Imports = map[string][]string{}
+	edgeFree.Importers = map[string][]string{}
+	if graph, reason := ValidateCachedGraph(&edgeFree, root, cfg); graph == nil || reason != "" {
+		t.Fatalf("complete edge-free cache = %#v, %q", graph, reason)
+	}
 	if graph, reason := ValidateCachedGraphForInventory(&base, root, cfg, []string{"main.go", "new.go"}); graph != nil || reason != graphCacheInventoryMismatch {
 		t.Fatalf("replacement inventory = %#v, %q; want nil, %q", graph, reason, graphCacheInventoryMismatch)
 	}
@@ -63,6 +70,10 @@ func TestGraphProvenanceValidation(t *testing.T) {
 			state.Graph.InventoryFingerprint = ""
 			return root, cfg
 		}, want: graphCacheIncomplete},
+		{name: "unavailable coverage", mutate: func(state *State) (string, config.ProjectConfig) {
+			state.Coverage.Status = analysis.CoverageUnavailable
+			return root, cfg
+		}, want: graphCacheIncomplete},
 		{name: "incomplete maps", mutate: func(state *State) (string, config.ProjectConfig) {
 			state.Imports = map[string][]string{}
 			state.Importers = map[string][]string{}
@@ -79,6 +90,41 @@ func TestGraphProvenanceValidation(t *testing.T) {
 				t.Fatalf("validateCachedGraph() = %#v, %q; want nil, %q", graph, reason, tt.want)
 			}
 		})
+	}
+}
+
+func TestConfiguredEventRefreshesDependencyGraph(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "main.go")
+	if err := os.WriteFile(path, []byte("package main\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	d := testGraphStateDaemon(root)
+
+	original := buildFileGraph
+	t.Cleanup(func() { buildFileGraph = original })
+	calls := 0
+	buildFileGraph = func(context.Context, string, scanner.Filters) (*scanner.FileGraph, error) {
+		calls++
+		return &scanner.FileGraph{
+			Imports:   map[string][]string{"main.go": {"dep.go"}},
+			Importers: map[string][]string{"dep.go": {"main.go"}},
+		}, nil
+	}
+
+	if !d.handleEvent(fsnotify.Event{Name: path, Op: fsnotify.Write}) {
+		t.Fatal("configured write did not invalidate the graph")
+	}
+	if d.graph.GraphState.Status != graphLifecycleStale {
+		t.Fatalf("after write graph state = %#v, want stale", d.graph.GraphState)
+	}
+	d.refreshDependencies()
+
+	if calls != 1 {
+		t.Fatalf("dependency builds = %d, want 1", calls)
+	}
+	if d.graph.GraphState.Status != graphLifecycleAvailable || !d.graph.HasDeps {
+		t.Fatalf("after refresh graph state = %#v, has deps %t", d.graph.GraphState, d.graph.HasDeps)
 	}
 }
 

--- a/watch/graph_state_test.go
+++ b/watch/graph_state_test.go
@@ -1,0 +1,247 @@
+package watch
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"codemap/analysis"
+	"codemap/config"
+	"codemap/scanner"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+func TestGraphProvenanceValidation(t *testing.T) {
+	root := t.TempDir()
+	cfg := config.ProjectConfig{Only: []string{"go", "rust"}, Exclude: []string{"vendor", "generated"}}
+	available := newGraphState(root, cfg, graphLifecycleAvailable, time.Unix(10, 0), []string{"dep.go", "main.go"})
+	base := State{
+		Graph:     &available,
+		Imports:   map[string][]string{"main.go": {"dep.go"}},
+		Importers: map[string][]string{"dep.go": {"main.go"}},
+	}
+	configuredCount := 2
+	base.ConfiguredFileCount = &configuredCount
+
+	graph, reason := validateCachedGraph(&base, root, cfg)
+	if graph == nil || reason != "" || len(graph.Importers["dep.go"]) != 1 {
+		t.Fatalf("valid cache = %#v, %q", graph, reason)
+	}
+	if graph, reason := ValidateCachedGraphForInventory(&base, root, cfg, []string{"main.go", "dep.go"}); graph == nil || reason != "" {
+		t.Fatalf("matching inventory = %#v, %q", graph, reason)
+	}
+	if graph, reason := ValidateCachedGraphForInventory(&base, root, cfg, []string{"main.go", "new.go"}); graph != nil || reason != graphCacheInventoryMismatch {
+		t.Fatalf("replacement inventory = %#v, %q; want nil, %q", graph, reason, graphCacheInventoryMismatch)
+	}
+	inconsistentCount := base
+	count := 3
+	inconsistentCount.ConfiguredFileCount = &count
+	if graph, reason := ValidateCachedGraphForInventory(&inconsistentCount, root, cfg, []string{"main.go", "dep.go"}); graph != nil || reason != graphCacheInventoryMismatch {
+		t.Fatalf("inconsistent count = %#v, %q; want nil, %q", graph, reason, graphCacheInventoryMismatch)
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(*State) (string, config.ProjectConfig)
+		want   string
+	}{
+		{name: "legacy", mutate: func(state *State) (string, config.ProjectConfig) { state.Graph = nil; return root, cfg }, want: graphCacheLegacy},
+		{name: "stale", mutate: graphStatusMutation(root, cfg, graphLifecycleStale), want: string(graphLifecycleStale)},
+		{name: "skipped size", mutate: graphStatusMutation(root, cfg, graphLifecycleSkippedSize), want: string(graphLifecycleSkippedSize)},
+		{name: "failed", mutate: graphStatusMutation(root, cfg, graphLifecycleFailed), want: string(graphLifecycleFailed)},
+		{name: "root mismatch", mutate: func(*State) (string, config.ProjectConfig) { return t.TempDir(), cfg }, want: graphCacheRootMismatch},
+		{name: "filter mismatch", mutate: func(*State) (string, config.ProjectConfig) { return root, config.ProjectConfig{Only: []string{"go"}} }, want: graphCacheFilterMismatch},
+		{name: "revision mismatch", mutate: func(state *State) (string, config.ProjectConfig) {
+			state.Graph.BuilderRevision = "old"
+			return root, cfg
+		}, want: graphCacheRevisionMismatch},
+		{name: "missing inventory fingerprint", mutate: func(state *State) (string, config.ProjectConfig) {
+			state.Graph.InventoryFingerprint = ""
+			return root, cfg
+		}, want: graphCacheIncomplete},
+		{name: "incomplete maps", mutate: func(state *State) (string, config.ProjectConfig) {
+			state.Imports = map[string][]string{}
+			state.Importers = map[string][]string{}
+			return root, cfg
+		}, want: "incomplete"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			state := base
+			copyGraph := *base.Graph
+			state.Graph = &copyGraph
+			requestRoot, requestCfg := tt.mutate(&state)
+			if graph, reason := validateCachedGraph(&state, requestRoot, requestCfg); graph != nil || reason != tt.want {
+				t.Fatalf("validateCachedGraph() = %#v, %q; want nil, %q", graph, reason, tt.want)
+			}
+		})
+	}
+}
+
+func TestGraphFilterFingerprintIsDeterministic(t *testing.T) {
+	left := config.ProjectConfig{Only: []string{"rust", "go"}, Exclude: []string{"vendor", "generated"}}
+	right := config.ProjectConfig{Only: []string{"go", "rust"}, Exclude: []string{"generated", "vendor"}}
+	if graphFilterFingerprint(left) != graphFilterFingerprint(right) {
+		t.Fatal("filter order changed fingerprint")
+	}
+	if graphFilterFingerprint(left) == graphFilterFingerprint(config.ProjectConfig{Only: []string{"go"}}) {
+		t.Fatal("filter change did not change fingerprint")
+	}
+}
+
+func TestConfiguredInventoryFingerprintIsDeterministic(t *testing.T) {
+	left := []string{"src/main.go", `pkg\types.go`, "src/main.go"}
+	right := []string{"pkg/types.go", "src/main.go"}
+	if ConfiguredInventoryFingerprint(left) != ConfiguredInventoryFingerprint(right) {
+		t.Fatal("inventory order, separators, or duplicates changed fingerprint")
+	}
+	if ConfiguredInventoryFingerprint(left) == ConfiguredInventoryFingerprint([]string{"src/main.go", "pkg/new.go"}) {
+		t.Fatal("same-count replacement did not change fingerprint")
+	}
+}
+
+func TestGraphStateBuildTransitions(t *testing.T) {
+	root := t.TempDir()
+	d := testGraphStateDaemon(root)
+
+	d.computeDepsWith(func(context.Context, string) (*scanner.FileGraph, error) { return nil, errors.New("scanner failed") })
+	if d.graph.GraphState.Status != graphLifecycleFailed || d.graph.HasDeps {
+		t.Fatalf("failed state = %#v, has deps %t", d.graph.GraphState, d.graph.HasDeps)
+	}
+	d.computeDepsWith(func(context.Context, string) (*scanner.FileGraph, error) {
+		return &scanner.FileGraph{Coverage: scanner.GraphCoverage{Status: analysis.CoverageUnavailable}}, nil
+	})
+	if d.graph.GraphState.Status != graphLifecycleFailed || d.graph.HasDeps {
+		t.Fatalf("empty graph state = %#v, has deps %t", d.graph.GraphState, d.graph.HasDeps)
+	}
+
+	d.computeDepsWith(func(context.Context, string) (*scanner.FileGraph, error) {
+		return &scanner.FileGraph{Imports: map[string][]string{"main.go": {"dep.go"}}, Importers: map[string][]string{"dep.go": {"main.go"}}}, nil
+	})
+	if d.graph.GraphState.Status != graphLifecycleAvailable || !d.graph.HasDeps || d.graph.GraphState.CompletedAt.IsZero() {
+		t.Fatalf("retry state = %#v, has deps %t", d.graph.GraphState, d.graph.HasDeps)
+	}
+
+	d.markGraphLifecycle(graphLifecycleSkippedSize)
+	if d.graph.GraphState.Status != graphLifecycleSkippedSize || d.graph.HasDeps {
+		t.Fatalf("skipped state = %#v, has deps %t", d.graph.GraphState, d.graph.HasDeps)
+	}
+
+	d.graph.mu.Lock()
+	d.graph.ConfiguredFiles = map[string]struct{}{"main.go": {}, "dep.go": {}}
+	d.graph.mu.Unlock()
+	d.computeDepsWith(func(context.Context, string) (*scanner.FileGraph, error) {
+		d.graph.mu.Lock()
+		delete(d.graph.ConfiguredFiles, "dep.go")
+		d.graph.ConfiguredFiles["replacement.go"] = struct{}{}
+		d.graph.mu.Unlock()
+		return &scanner.FileGraph{Imports: map[string][]string{"main.go": {"dep.go"}}, Importers: map[string][]string{"dep.go": {"main.go"}}}, nil
+	})
+	if d.graph.GraphState.Status != graphLifecycleStale || d.graph.HasDeps {
+		t.Fatalf("inventory changed during build = %#v, has deps %t", d.graph.GraphState, d.graph.HasDeps)
+	}
+}
+
+func TestGraphPublicationRejectsInterleavedInvalidators(t *testing.T) {
+	graph := func(context.Context, string) (*scanner.FileGraph, error) {
+		return &scanner.FileGraph{Imports: map[string][]string{"main.go": {"dep.go"}}, Importers: map[string][]string{"dep.go": {"main.go"}}}, nil
+	}
+
+	t.Run("same-path write generation", func(t *testing.T) {
+		root := t.TempDir()
+		d := testGraphStateDaemon(root)
+		d.computeDepsWithBeforePublish(graph, func() {
+			d.markGraphLifecycle(graphLifecycleStale)
+		})
+		if d.graph.GraphState.Status != graphLifecycleStale || d.graph.HasDeps {
+			t.Fatalf("interleaved write = %#v, has deps %t", d.graph.GraphState, d.graph.HasDeps)
+		}
+	})
+
+	t.Run("filter edit", func(t *testing.T) {
+		root := t.TempDir()
+		if err := os.MkdirAll(filepath.Join(root, ".codemap"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		configPath := filepath.Join(root, ".codemap", "config.json")
+		if err := os.WriteFile(configPath, []byte(`{"only":["go"]}`), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		d := testGraphStateDaemon(root)
+		d.computeDepsWithBeforePublish(graph, func() {
+			if err := os.WriteFile(configPath, []byte(`{"only":["rust"]}`), 0o644); err != nil {
+				t.Fatal(err)
+			}
+		})
+		if d.graph.GraphState.Status != graphLifecycleStale || d.graph.HasDeps {
+			t.Fatalf("interleaved filter edit = %#v, has deps %t", d.graph.GraphState, d.graph.HasDeps)
+		}
+	})
+}
+
+func TestConfiguredEventInvalidatesGraph(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		op   fsnotify.Op
+	}{
+		{name: "create", op: fsnotify.Create},
+		{name: "write", op: fsnotify.Write},
+		{name: "remove", op: fsnotify.Remove},
+		{name: "rename", op: fsnotify.Rename},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			if err := os.MkdirAll(filepath.Join(root, ".codemap"), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			path := filepath.Join(root, "main.go")
+			if tt.op == fsnotify.Create || tt.op == fsnotify.Write {
+				if err := os.WriteFile(path, []byte("package main\n"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			}
+			d := testGraphStateDaemon(root)
+			d.eventLog = filepath.Join(root, ".codemap", "events.log")
+			d.graph.ConfiguredFiles["main.go"] = struct{}{}
+
+			d.handleEvent(fsnotify.Event{Name: path, Op: tt.op})
+
+			if d.graph.GraphState.Status != graphLifecycleStale || d.graph.HasDeps {
+				t.Fatalf("event left graph usable: %#v, has deps %t", d.graph.GraphState, d.graph.HasDeps)
+			}
+			state := ReadState(root)
+			if state == nil || state.Graph == nil || state.Graph.Status != graphLifecycleStale {
+				t.Fatalf("persisted state = %#v", state)
+			}
+		})
+	}
+}
+
+func graphStatusMutation(root string, cfg config.ProjectConfig, status GraphLifecycle) func(*State) (string, config.ProjectConfig) {
+	return func(state *State) (string, config.ProjectConfig) {
+		state.Graph.Status = status
+		return root, cfg
+	}
+}
+
+func testGraphStateDaemon(root string) *Daemon {
+	state := newGraphState(root, config.ProjectConfig{}, graphLifecycleAvailable, time.Now(), []string{"main.go"})
+	return &Daemon{
+		root: root,
+		graph: &Graph{
+			Root:            root,
+			Files:           map[string]*scanner.FileInfo{"main.go": {Path: "main.go", Ext: ".go"}},
+			ConfiguredFiles: map[string]struct{}{"main.go": {}},
+			FileGraph:       &scanner.FileGraph{Imports: map[string][]string{"main.go": {"dep.go"}}},
+			DepCtx:          map[string]*DepContext{},
+			State:           map[string]*FileState{"main.go": {Lines: 1}},
+			WorkingSet:      NewWorkingSet(),
+			HasDeps:         true,
+			GraphState:      state,
+		},
+	}
+}

--- a/watch/more_test.go
+++ b/watch/more_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"codemap/config"
 	"codemap/internal/projectpath"
 	"codemap/limits"
 	"codemap/scanner"
@@ -48,6 +49,7 @@ func TestGetGraphWriteInitialStateAndFindRelatedHot(t *testing.T) {
 	d := &Daemon{
 		root: root,
 		graph: &Graph{
+			GraphState: newGraphState(root, config.ProjectConfig{}, graphLifecycleAvailable, time.Now(), []string{"pkg/types.go", "main.go", "other.go"}),
 			Files: map[string]*scanner.FileInfo{
 				"pkg/types.go": {Path: "pkg/types.go"},
 				"main.go":      {Path: "main.go"},

--- a/watch/publication.go
+++ b/watch/publication.go
@@ -77,7 +77,8 @@ func (p *statePublisher) snapshot(generation uint64) State {
 		configuredFileCount = len(d.graph.Files)
 	}
 	root := canonicalRoot(d.root)
-	s := State{Root: root, CanonicalRoot: root, DaemonInstance: p.instance, Generation: generation, UpdatedAt: time.Now(), FileCount: len(d.graph.Files), ConfiguredFileCount: &configuredFileCount, Hubs: []string{}, Importers: map[string][]string{}, Imports: map[string][]string{}, RecentEvents: append([]Event(nil), events...), WorkingSet: d.graph.WorkingSet.Snapshot(50)}
+	graphState := d.graph.GraphState
+	s := State{Root: root, CanonicalRoot: root, DaemonInstance: p.instance, Generation: generation, UpdatedAt: time.Now(), FileCount: len(d.graph.Files), ConfiguredFileCount: &configuredFileCount, Hubs: []string{}, Importers: map[string][]string{}, Imports: map[string][]string{}, RecentEvents: append([]Event(nil), events...), WorkingSet: d.graph.WorkingSet.Snapshot(50), Graph: &graphState}
 	if d.graph.FileGraph != nil {
 		s.Hubs = d.graph.FileGraph.HubFiles()
 		s.Importers = d.graph.FileGraph.Importers

--- a/watch/types.go
+++ b/watch/types.go
@@ -56,8 +56,8 @@ type Graph struct {
 	LastScan         time.Time
 	IsGitRepo        bool
 	HasDeps          bool // whether deps were successfully computed
-	GraphState      GraphState
-	graphGeneration uint64
+	GraphState       GraphState
+	graphGeneration  uint64
 }
 
 // State represents the daemon state that hooks can read

--- a/watch/types.go
+++ b/watch/types.go
@@ -56,6 +56,8 @@ type Graph struct {
 	LastScan         time.Time
 	IsGitRepo        bool
 	HasDeps          bool // whether deps were successfully computed
+	GraphState      GraphState
+	graphGeneration uint64
 }
 
 // State represents the daemon state that hooks can read
@@ -73,6 +75,7 @@ type State struct {
 	RecentEvents        []Event               `json:"recent_events"` // last 50 events for timeline
 	WorkingSet          *WorkingSet           `json:"working_set,omitempty"`
 	Coverage            scanner.GraphCoverage `json:"coverage,omitempty"`
+	Graph               *GraphState           `json:"graph,omitempty"`
 }
 
 // ConfiguredCount returns the persisted count for the active project filters.

--- a/watch/watch_test.go
+++ b/watch/watch_test.go
@@ -254,13 +254,18 @@ func TestFileRemoval(t *testing.T) {
 	}
 }
 
-// TestDebounce tests that rapid events are debounced
 func TestDebounce(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "codemap-watch-test")
 	if err != nil {
 		t.Fatalf("Failed to create temp dir: %v", err)
 	}
 	defer os.RemoveAll(tmpDir)
+	if err := os.MkdirAll(filepath.Join(tmpDir, ".codemap"), 0o755); err != nil {
+		t.Fatalf("Failed to create config dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpDir, ".codemap", "config.json"), []byte(`{"exclude":["rapid.go"]}`), 0o644); err != nil {
+		t.Fatalf("Failed to exclude debounce fixture: %v", err)
+	}
 
 	testFile := filepath.Join(tmpDir, "rapid.go")
 	if err := os.WriteFile(testFile, []byte("package rapid\n"), 0644); err != nil {


### PR DESCRIPTION
## What does this PR do?

- Persists graph lifecycle, project, filter, builder, and exact inventory provenance.
- Coalesces duplicate writes, persists configured membership changes, and publishes rebuilt graphs atomically.
- Reuses cached evidence only when fresh context inventory proves an exact match.

This prevents agentic coding workflows from relying on stale dependency data after edits, filter changes, or membership changes.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] New language support
- [ ] Documentation
- [ ] Other

## Checklist

- [x] Tested locally with Go 1.27.0: `go test ./...`
- [x] Race-tested watch publication and event paths: `go test -race ./...`
- [x] Verified with `go vet ./...`

## Additional notes

Hooks remain scan-free; context performs the exact current-inventory proof before cache reuse.
