### PR TITLE
fix(watch): Treat an unparseable readiness file as not-ready-yet

### DIFF
--- a/main.go
+++ b/main.go
@@ -1153,22 +1153,31 @@ func publishWatchReadiness(path string, readinessErr error) error {
 
 func waitWatchReadiness(path string, timeout time.Duration) error {
 	deadline := time.Now().Add(timeout)
+	// A readiness file that does not parse is a file still being written, not
+	// a daemon that failed: publishWatchReadiness renames its payload into
+	// place atomically, but nothing guarantees every writer does, and treating
+	// the first unparseable read as fatal reported a startup failure for a
+	// daemon that was starting fine. Keep the last parse error so a file that
+	// never becomes valid says why, rather than only that it timed out.
+	var lastParseErr error
 	for {
 		data, err := os.ReadFile(path)
 		if err == nil {
 			var status watchReadiness
-			if err := json.Unmarshal(data, &status); err != nil {
-				return fmt.Errorf("reading daemon readiness: %w", err)
-			}
-			if status.Error != "" {
+			if parseErr := json.Unmarshal(data, &status); parseErr != nil {
+				lastParseErr = parseErr
+			} else if status.Error != "" {
 				return errors.New(status.Error)
+			} else {
+				return nil
 			}
-			return nil
-		}
-		if !errors.Is(err, os.ErrNotExist) {
+		} else if !errors.Is(err, os.ErrNotExist) {
 			return fmt.Errorf("reading daemon readiness: %w", err)
 		}
 		if time.Now().After(deadline) {
+			if lastParseErr != nil {
+				return fmt.Errorf("reading daemon readiness: %w", lastParseErr)
+			}
 			return fmt.Errorf("daemon readiness timed out after %s", timeout)
 		}
 		time.Sleep(10 * time.Millisecond)

--- a/watch_readiness_test.go
+++ b/watch_readiness_test.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// A readiness file caught mid-write reads as zero or partial bytes. Treating
+// that as fatal reported a startup failure for a daemon that was starting
+// fine, and made TestRunWatchStartWaitsForChildReadinessFailure fail whenever
+// the machine was loaded enough to land in the window.
+func TestWaitWatchReadinessWaitsThroughPartialWrite(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "ready.json")
+	if err := os.WriteFile(path, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		_ = os.WriteFile(path, []byte(`{"error":"claim rejected"}`), 0o644)
+	}()
+
+	err := waitWatchReadiness(path, 5*time.Second)
+	if err == nil || !strings.Contains(err.Error(), "claim rejected") {
+		t.Fatalf("waitWatchReadiness() = %v, want the daemon's own error once the file is complete", err)
+	}
+}
+
+func TestWaitWatchReadinessSucceedsAfterPartialWrite(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "ready.json")
+	if err := os.WriteFile(path, []byte(`{"err`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		_ = os.WriteFile(path, []byte(`{}`), 0o644)
+	}()
+
+	if err := waitWatchReadiness(path, 5*time.Second); err != nil {
+		t.Fatalf("waitWatchReadiness() = %v, want success once the file is complete", err)
+	}
+}
+
+// A file that never becomes valid still has to say why, rather than reporting
+// only that it timed out.
+func TestWaitWatchReadinessReportsPersistentGarbage(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "ready.json")
+	if err := os.WriteFile(path, []byte("not json at all"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	err := waitWatchReadiness(path, 200*time.Millisecond)
+	if err == nil || !strings.Contains(err.Error(), "reading daemon readiness") {
+		t.Fatalf("waitWatchReadiness() = %v, want the parse failure surfaced", err)
+	}
+}
+
+// A missing file must still time out rather than hang.
+func TestWaitWatchReadinessTimesOutWhenAbsent(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "never-written.json")
+	err := waitWatchReadiness(path, 100*time.Millisecond)
+	if err == nil || !strings.Contains(err.Error(), "timed out") {
+		t.Fatalf("waitWatchReadiness() = %v, want a timeout", err)
+	}
+}


### PR DESCRIPTION
Found while investigating a CI failure on #175. Small, standalone — deliberately not folded into that PR, which touches only `scanner/`.

## What's wrong

`waitWatchReadiness` (`main.go:1154`) returns on the first successful read:

```go
data, err := os.ReadFile(path)
if err == nil {
    var status watchReadiness
    if err := json.Unmarshal(data, &status); err != nil {
        return fmt.Errorf("reading daemon readiness: %w", err)   // gives up
    }
```

A readiness file that exists but is empty or half-written reads successfully with zero or partial bytes, so the unmarshal fails and the wait aborts. Only `os.ErrNotExist` counts as "not ready yet".

Measured against the real function:

```
empty readiness file   -> reading daemon readiness: unexpected end of JSON input   after 0s
partial readiness file -> reading daemon readiness: unexpected end of JSON input
```

The **0s** is the point: it doesn't wait out any part of the 30s timeout, it fails on the first poll.

An unparseable file is a file still being written, not a daemon that failed. Now the poll continues to the deadline, and the last parse error is surfaced if the deadline passes — so a file that never becomes valid still says *why*, rather than only that it timed out.

## Scope, honestly

`publishWatchReadiness` already writes via temp-file + `os.Rename`, so **codemap's own daemon does not open this window**. This is the reader being brittle to any writer that isn't atomic — defence in depth plus test robustness, not a user-facing startup bug. I said otherwise in an earlier comment on #175 and have corrected it there.

## What I could and could not verify

- **Verified:** the mechanism, directly against `waitWatchReadiness` (above), and that the fix makes it wait through a partial write and then honour the real content. Four tests cover: partial → real error, partial → success, persistent garbage → parse error surfaced, absent file → still times out.
- **Not verified:** that this resolves the CI failure that led me here (`TestRunWatchStartWaitsForChildReadinessFailure` on `Test (ubuntu-latest, 1.24)`, #175). **I could not reproduce that failure locally** — 15/15 pass unloaded and 10/10 under CPU contention, on both `main` and the PR branch.

An earlier attempt of mine appeared to reproduce it at 20/20 on both branches. That measurement was wrong: I was running relocated test binaries from outside the repo, where they exit without running the test at all, so I was measuring my own harness rather than the test. Retracted rather than left standing.

What I do know: the CI error string is produced by exactly one code path, this one; the test's child is `sh -c 'printf … > "$CODEMAP_WATCH_READINESS_FILE"'`, and `>` truncates the file into existence before `printf` writes it, which is precisely the window; and `codemap/scanner` passed in that same run while #175's diff touches nothing else. So this is the plausible cause and the fix is right on its own terms — but I'm not claiming it as proven.

## Verification

`go vet ./...` clean, `gofmt` clean, `go test ./...` at the main baseline (only the three known root-environment permission failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PEUvjGsJemDFSV8nbxvxBo

---
_Generated by [Claude Code](https://claude.ai/code/session_01PEUvjGsJemDFSV8nbxvxBo)_